### PR TITLE
fix(rides): Update duration format in ride details

### DIFF
--- a/applications/ashbike/apps/mobile/features/rides/src/main/res/values/strings.xml
+++ b/applications/ashbike/apps/mobile/features/rides/src/main/res/values/strings.xml
@@ -82,7 +82,7 @@
     <string name="feature_trips_detail_label_elevation">Elevation</string>
     <string name="feature_trips_detail_value_elevation_format">%1$d↑/%2$d↓ m</string>
     <string name="feature_trips_detail_label_duration">Duration</string>
-    <string name="feature_trips_detail_value_duration_format">%02d:%02d</string>
+    <string name="feature_trips_detail_value_duration_format">%1$dh %2$02dm</string>
     <string name="feature_trips_detail_label_calories">Calories</string>
     <string name="feature_trips_detail_value_calories_format">%d kcal</string>
     <string name="feature_trips_detail_label_notes">Notes</string>


### PR DESCRIPTION
This commit changes the string format for displaying ride duration in the trip details screen.

- **`strings.xml`**: The format for `feature_trips_detail_value_duration_format` was updated from `%02d:%02d` to `%1$dh %2$02dm`. This changes the display from a `MM:SS` style to include explicit hour and minute units (e.g., `1h 05m`), improving clarity for the user.