### PR TITLE
refactor(settings): Introduce state for expandable sections and type-…

### DIFF
--- a/applications/ashbike/apps/mobile/features/settings/build.gradle.kts
+++ b/applications/ashbike/apps/mobile/features/settings/build.gradle.kts
@@ -26,9 +26,12 @@ dependencies {
     implementation(project(":features:nfc"))
     implementation(project(":features:qrscanner"))
 
+
+
     // Database (If Home needs direct DB access, otherwise access via :core:data)
     implementation(project(":applications:ashbike:database"))
     implementation(project(":applications:ashbike:model"))
+    implementation(project(":applications:ashbike:features:main"))
 
     // --- Serialization (The backbone of Nav3) ---
     implementation(libs.kotlinx.serialization.json)

--- a/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/SettingsEvents.kt
+++ b/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/SettingsEvents.kt
@@ -14,4 +14,5 @@ sealed class SettingsEvent {
     data class UpdateEnergyLevel(val level: LocationEnergyLevel) : SettingsEvent()
     data class UpdateLongRideEnabled(val enabled: Boolean) : SettingsEvent() // New event for short ride
     // data class OnShowGpsCountdownChanged(val show: Boolean) : SettingsEvent() // New event
+    data class OnSetExpandedSection(val sectionId: String?) : SettingsEvent()
 }

--- a/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/SettingsScreenExpand.kt
+++ b/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/SettingsScreenExpand.kt
@@ -42,6 +42,7 @@ import com.zoewave.ashbike.mobile.settings.ui.components.QrExpandableEx
 import com.zoewave.ashbike.mobile.settings.ui.components.SectionHeader
 import com.zoewave.ashbike.mobile.settings.ui.components.ThemeSettingsCard
 import com.zoewave.ashbike.mobile.settings.ui.components.health.HealthExpandableEx
+import com.zoewave.probase.ashbike.features.main.navigation.AshBikeDestination
 import com.zoewave.probase.features.ble.ui.BluetoothLeEvent
 import com.zoewave.probase.features.ble.ui.BluetoothLeUiState
 import com.zoewave.probase.features.nfc.ui.NfcRwEvent
@@ -78,7 +79,7 @@ fun SettingsScreenEx(
     nfcEvent: (NfcRwEvent) -> Unit,
     bleUiState: BluetoothLeUiState,
     bleEvent: (BluetoothLeEvent) -> Unit,
-    navTo: (String) -> Unit,
+    navTo: (AshBikeDestination) -> Unit,
     initialCardKeyToExpand: String? = null // Added parameter
 ) {
     val expandedSections = remember { mutableStateSetOf<SectionKey>() }
@@ -87,9 +88,23 @@ fun SettingsScreenEx(
 
     // Effect to expand the card specified by the navigation argument
     LaunchedEffect(initialCardKeyToExpand) {
-        if (initialCardKeyToExpand == CardKey.AppPrefs.name) {
-            expandedSections.add(SectionKey.App) // Expand the parent section
-            expandedCards.add(CardKey.AppPrefs)  // Expand the AppPrefs card
+        if (initialCardKeyToExpand != null) {
+            // Normalize to lowercase for safer comparison
+            when (initialCardKeyToExpand.lowercase()) {
+                "app_prefs", "appprefs" -> {
+                    expandedSections.add(SectionKey.App)       // Open Parent
+                    expandedCards.add(CardKey.AppPrefs)        // Open Card
+                }
+                "bike_config", "bikeconfig" -> {
+                    expandedSections.add(SectionKey.Bike)      // Open Parent
+                    expandedCards.add(CardKey.BikeConfig)      // Open Card
+                }
+                "theme" -> {
+                    expandedSections.add(SectionKey.App)
+                    expandedCards.add(CardKey.Theme)
+                }
+                // Add other deep links here...
+            }
         }
     }
 
@@ -174,7 +189,6 @@ fun SettingsScreenEx(
                 HealthExpandableEx(
                     expanded = expandedCards.contains(CardKey.Health),
                     onExpandToggle = { toggle(expandedCards, CardKey.Health) },
-                    navTo = navTo
                 )
             }
             item {
@@ -183,7 +197,6 @@ fun SettingsScreenEx(
                     nfcEvent = nfcEvent,
                     expanded = expandedCards.contains(CardKey.Nfc),
                     onExpandToggle = { toggle(expandedCards, CardKey.Nfc) },
-                    navTo = navTo
                 )
             }
             item {

--- a/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/SettingsUiRoute.kt
+++ b/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/SettingsUiRoute.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.zoewave.probase.ashbike.features.main.navigation.AshBikeDestination
 import com.zoewave.probase.core.ui.components.status.ErrorScreen
 import com.zoewave.probase.core.ui.components.status.LoadingScreen
 import com.zoewave.probase.features.ble.ui.BluetoothLeViewModel
@@ -16,7 +17,7 @@ internal const val ARG_CARD_TO_EXPAND = "cardToExpandArg" // Added argument name
 @Composable
 fun SettingsUiRoute(
     modifier: Modifier = Modifier,
-    navTo: (String) -> Unit,
+    navTo: (AshBikeDestination) -> Unit,
     //nfcUiState : NfcUiState,
     //nfcEvent : (NfcRwEvent) -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),

--- a/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/SettingsUiState.kt
+++ b/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/SettingsUiState.kt
@@ -15,7 +15,8 @@ sealed interface SettingsUiState {
         val profile: ProfileData? = null, // Make nullable and provide default
         val isProfileIncomplete: Boolean = true, // Add this field
         val currentEnergyLevel: LocationEnergyLevel = LocationEnergyLevel.BALANCED, // Added field
-        val isLongRideEnabled: Boolean = false // Added for short ride feature
+        val isLongRideEnabled: Boolean = false, // Added for short ride feature
+        val expandedSectionId: String? = null
     ) : SettingsUiState
 
     data class Error(val message: String) : SettingsUiState

--- a/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/components/BikeConfigurationEx.kt
+++ b/applications/ashbike/apps/mobile/features/settings/src/main/java/com/zoewave/ashbike/mobile/settings/ui/components/BikeConfigurationEx.kt
@@ -31,12 +31,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.zoewave.ashbike.mobile.settings.R
+import com.zoewave.probase.ashbike.features.main.navigation.AshBikeDestination
 
 @Composable
 fun BikeConfigurationEx(
     expanded: Boolean,
     onExpandToggle: () -> Unit,
-    navTo: (String) -> Unit
+    navTo: (AshBikeDestination) -> Unit
 ) {
     Card(
         modifier = Modifier
@@ -98,7 +99,7 @@ fun BikeConfigurationEx(
                     Spacer(modifier = Modifier.height(16.dp))
                     Button(
                         enabled = false,
-                        onClick = { navTo("settings_bike_advanced") }
+                        onClick = { navTo(AshBikeDestination.AdvancedBikeSettings) }
                     ) {
                         Text(stringResource(R.string.settings_advanced_bike_settings_button))
                     }


### PR DESCRIPTION
…safe navigation

This commit refactors the settings screen to manage the state of expandable sections within the `SettingsViewModel` and improves navigation by using a type-safe `AshBikeDestination` enum instead of raw strings.

- **State Management for Expandable Sections**:
    - `SettingsViewModel`, `SettingsUiState`, and `SettingsEvents` have been updated to track which settings section is currently expanded (e.g., "app_prefs"). This allows for programmatic control over the UI, such as expanding a specific card via a deep link.
    - A new `OnSetExpandedSection` event and a corresponding `_expandedSection` state flow were added to the ViewModel.

- **Type-Safe Navigation**:
    - Navigation logic throughout the settings feature (`SettingsUiRoute`, `BikeConfigurationEx`, `SettingsScreenExpand`) has been updated to use the `AshBikeDestination` enum. This replaces string-based routes, making navigation more robust and less error-prone.
    - A dependency on the `:applications:ashbike:features:main` module was added to `build.gradle.kts` to access the `AshBikeDestination` definition.

- **Enhanced Deep Linking**:
    - The `SettingsScreenExpand` composable now includes logic in a `LaunchedEffect` to parse an incoming `initialCardKeyToExpand` argument and correctly expand the corresponding parent section and specific settings card (e.g., "app_prefs", "bike_config"). This improves the user experience when navigating directly to a setting.