### PR TITLE
feat(home): Refine average speed calculation and display

### DIFF
--- a/applications/ashbike/apps/mobile/features/home/src/main/java/com/zoewave/ashbike/mobile/home/components/main/StatsRow.kt
+++ b/applications/ashbike/apps/mobile/features/home/src/main/java/com/zoewave/ashbike/mobile/home/components/main/StatsRow.kt
@@ -59,6 +59,12 @@ fun StatsRow(
     val avgSpeed = bikeData.averageSpeed
     val elevationValue: Double? = bikeData.elevation.takeIf { it > 0.0 }
 
+    val avgSpeedText = if (avgSpeed < 0) {
+        "--" // ✅ The Sentinel Value triggers this
+    } else {
+        stringResource(R.string.feature_main_stats_value_kmh_format, avgSpeed) // Normal formatting (e.g., "22.5")
+    }
+
     val stats = mutableListOf(
         StatItem(
             icon = Icons.Filled.Straight,
@@ -75,7 +81,7 @@ fun StatsRow(
         StatItem(
             icon = Icons.Filled.Speed,
             label = stringResource(R.string.feature_main_stats_label_avg_speed),
-            value = stringResource(R.string.feature_main_stats_value_kmh_format, avgSpeed),
+            value = avgSpeedText,
             activeColor = if (isBikeComputerOn) MaterialTheme.colorScheme.iconColorAvgSpeed else null
         )
     ).apply {

--- a/applications/ashbike/docs/actions/short/README.md
+++ b/applications/ashbike/docs/actions/short/README.md
@@ -4,6 +4,8 @@
 
 * **Total Distance:** ~2.32 km (approx. 1.44 miles)
 * **Total Time:** 3 minutes and 43 seconds
+* **Estimated Burn:** 45 – 65 calories
+* **Average Speed:** 37.21 km/h
 
 ---
 

--- a/applications/ashbike/features/main/src/main/java/com/zoewave/probase/ashbike/features/main/service/BikeForegroundService.kt
+++ b/applications/ashbike/features/main/src/main/java/com/zoewave/probase/ashbike/features/main/service/BikeForegroundService.kt
@@ -265,10 +265,10 @@ class BikeForegroundService : LifecycleService() {
             formalRideSegmentMaxSpeedKph = max(formalRideSegmentMaxSpeedKph, speedKph)
             displayMaxSpeed = formalRideSegmentMaxSpeedKph
 
-            displayAverageSpeed = if (segmentDurationSeconds > 0 && segmentDistMeters > 0) {
+            displayAverageSpeed = if (segmentDurationSeconds > MIN_TIME_FOR_AVG_SPEED_SECONDS && segmentDistMeters > 0) {
                 (segmentDistMeters / segmentDurationSeconds) * 3.6
             } else {
-                0.0
+                -1.0 // Code for "Show --"
             }
 
             // Map path for UI
@@ -285,10 +285,10 @@ class BikeForegroundService : LifecycleService() {
             displayDuration = formatDuration(sessionDurationMillis)
             displayMaxSpeed = continuousMaxSpeedKph
 
-            displayAverageSpeed = if (sessionDurationSeconds > 0 && continuousDistanceMeters > 0) {
+            displayAverageSpeed = if (sessionDurationSeconds > MIN_TIME_FOR_AVG_SPEED_SECONDS && continuousDistanceMeters > 0) {
                 (continuousDistanceMeters / sessionDurationSeconds) * 3.6
             } else {
-                0.0
+                -1.0 // Code for "Show --"
             }
         }
 
@@ -505,6 +505,8 @@ class BikeForegroundService : LifecycleService() {
         private const val MAX_ACCURACY_THRESHOLD_METERS = 30f
         private const val MIN_DISTANCE_THRESHOLD_METERS = 5f
         private const val MIN_ALLOWED_GPS_INTERVAL_MS = 1000L
+
+        private const val MIN_TIME_FOR_AVG_SPEED_SECONDS = 5
 
         fun getInitialRideInfo() = BikeRideInfo(
             location = null, currentSpeed = 0.0, averageSpeed = 0.0, maxSpeed = 0.0,


### PR DESCRIPTION
This commit improves the average speed calculation by introducing a minimum time threshold and updates the UI to handle the initial state more gracefully.

- **`BikeForegroundService.kt`**: The average speed calculation for both ride segments and the total session will now only begin after a minimum of 5 seconds (`MIN_TIME_FOR_AVG_SPEED_SECONDS`). Before this threshold is met, the service reports a sentinel value of `-1.0`. This prevents displaying potentially misleading or volatile averages at the very start of a ride.

- **`StatsRow.kt`**: The UI component for displaying ride statistics now checks for the `-1.0` sentinel value. If detected, it displays "--" for the average speed, providing a clearer "not yet available" state to the user. Once valid data is available, it formats the speed in km/h as before.

- **`docs/actions/short/README.md`**: The ride summary documentation has been updated to include example values for "Estimated Burn" and "Average Speed".