### PR TITLE
feat(health): Add weekly distance and calorie charts

### DIFF
--- a/core/data/src/main/java/com/zoewave/probase/core/data/service/health/HealthSessionManager.kt
+++ b/core/data/src/main/java/com/zoewave/probase/core/data/service/health/HealthSessionManager.kt
@@ -111,6 +111,28 @@ class HealthSessionManager(private val context: Context) {
     }
 
     /**
+     * Reads distance records for a specific time range.
+     */
+    suspend fun readDistance(start: Instant, end: Instant): List<DistanceRecord> =
+        healthConnectClient.readRecords(
+            ReadRecordsRequest(
+                recordType = DistanceRecord::class,
+                timeRangeFilter = TimeRangeFilter.between(start, end)
+            )
+        ).records
+
+    /**
+     * Reads total calories burned records for a specific time range.
+     */
+    suspend fun readTotalCalories(start: Instant, end: Instant): List<TotalCaloriesBurnedRecord> =
+        healthConnectClient.readRecords(
+            ReadRecordsRequest(
+                recordType = TotalCaloriesBurnedRecord::class,
+                timeRangeFilter = TimeRangeFilter.between(start, end)
+            )
+        ).records
+
+    /**
      * Reads in existing [StepsRecord]s for a specific time range.
      */
     suspend fun readSteps(start: Instant, end: Instant): List<StepsRecord> =

--- a/features/health/src/main/java/com/zoewave/probase/features/health/ui/HealthUiState.kt
+++ b/features/health/src/main/java/com/zoewave/probase/features/health/ui/HealthUiState.kt
@@ -7,18 +7,14 @@ sealed interface HealthUiState {
     object Uninitialized : HealthUiState
     object Loading : HealthUiState
     object Disabled : HealthUiState
-
     data class PermissionsRequired(val message: String) : HealthUiState
+    data class Error(val message: String, val uuid: UUID = UUID.randomUUID()) : HealthUiState
 
     data class Success(
-        // Renamed 'healthData' to 'sessions' to match the ViewModel and be more specific
         val sessions: List<ExerciseSessionRecord>,
-        // Added this field to hold the data for your weekly graph
-        val weeklySteps: Map<String, Long> = emptyMap()
-    ) : HealthUiState
-
-    data class Error(
-        val message: String,
-        val uuid: UUID = UUID.randomUUID()
+        val weeklySteps: Map<String, Long> = emptyMap(),
+        // Add these two new fields:
+        val weeklyDistance: Map<String, Double> = emptyMap(), // Meters
+        val weeklyCalories: Map<String, Double> = emptyMap()  // Kcal
     ) : HealthUiState
 }


### PR DESCRIPTION
This commit expands the health feature to display weekly activity charts for distance and calories, in addition to the existing steps chart.

- **`HealthViewModel.kt`**:
    - The `loadHealthData` function is updated to fetch the last 7 days of distance and total calories burned from `HealthConnect`.
    - It now processes this data, along with steps, into daily totals and passes them to the `HealthUiState`.

- **`HealthUiState.kt`**:
    - The `Success` state now includes `weeklyDistance` (Map<String, Double>) and `weeklyCalories` (Map<String, Double>) to hold the new aggregated data.

- **`HealthRoute.kt`**:
    - The `HealthDataScreen` is updated to be vertically scrollable to accommodate the new charts.
    - `WeeklyStepsChart` has been replaced by a reusable `GenericWeeklyChart` composable.
    - Three instances of `GenericWeeklyChart` are now used to display weekly steps, calories burned (kcal), and distance traveled (km), each with a distinct color and value formatting.

- **`HealthSessionManager.kt`**:
    - New public functions `readDistance()` and `readTotalCalories()` have been added to fetch `DistanceRecord` and `TotalCaloriesBurnedRecord` from the Health Connect client within a specified time range.