### PR TITLE
feat(ui): Introduce reusable `FeatureScaffold` for consistent UI

### DIFF
--- a/app/src/main/java/com/zoewave/probase/ui/components/FeatureInventoryEntryProvider.kt
+++ b/app/src/main/java/com/zoewave/probase/ui/components/FeatureInventoryEntryProvider.kt
@@ -12,7 +12,8 @@ import com.zoewave.probase.features.nav3.ui.inventory.FeatureInventoryScreen
 
 fun featureInventoryEntryProvider(
     key: NavKey,
-    navigateTo: (NavKey) -> Unit
+    navigateTo: (NavKey) -> Unit,
+    navigateBack: () -> Unit // ✅ Receive the back action
 ): NavEntry<NavKey> {
 
     // We wrap the content in a NavEntry, casting the key back to our specific type
@@ -28,18 +29,23 @@ fun featureInventoryEntryProvider(
             }
 
             is FeatureInventory.Health -> {
-                HealthRoute()
+                FeatureScaffold(title = "Health", onBack = navigateBack) {
+                    HealthRoute()
+                }
             }
 
             is FeatureInventory.Rides -> {
+                FeatureScaffold(title = "Rides", onBack = navigateBack) {}
                 // RidesUIRoute(navTo = { /* Handle internal navigation */ })
             }
 
             is FeatureInventory.Settings -> {
+                FeatureScaffold(title = "Settings", onBack = navigateBack) {}
                 // SettingsUiRoute()
             }
 
             is FeatureInventory.Weather -> {
+                FeatureScaffold(title = "Weather", onBack = navigateBack) {}
                 // WeatherUiRoute()
             }
 

--- a/app/src/main/java/com/zoewave/probase/ui/components/FeatureInventoryNavHost.kt
+++ b/app/src/main/java/com/zoewave/probase/ui/components/FeatureInventoryNavHost.kt
@@ -21,6 +21,9 @@ fun FeatureInventoryNavHost(
         backStack.add(dest)
     }
 
+    // Define the Back Action
+    val navigateBack: () -> Unit = { backStack.removeLastOrNull() }
+
     // 3. Back Handler
     // NavBackStack usually implements List/Collection, so checking size works
     BackHandler(enabled = backStack.size > 1) {
@@ -37,7 +40,8 @@ fun FeatureInventoryNavHost(
             // ✅ DELEGATE: Call the provider function
             featureInventoryEntryProvider(
                 key = key,
-                navigateTo = navigateTo
+                navigateTo = navigateTo,
+                navigateBack = navigateBack
             )
         }
     )

--- a/app/src/main/java/com/zoewave/probase/ui/components/FeatureScaffold.kt
+++ b/app/src/main/java/com/zoewave/probase/ui/components/FeatureScaffold.kt
@@ -1,0 +1,34 @@
+package com.zoewave.probase.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeatureScaffold(
+    title: String,
+    onBack: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            content()
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a reusable `FeatureScaffold` composable to provide a consistent top app bar and back navigation for all feature screens. This refactor centralizes the screen layout logic, making it easier to maintain and ensuring a uniform user experience.

- **`FeatureScaffold.kt`**:
    - A new file has been created to house the `FeatureScaffold` composable.
    - This composable takes a `title`, an `onBack` lambda, and a `content` composable.
    - It renders a `Scaffold` with a `TopAppBar` that displays the given title and a back arrow `IconButton`.

- **`FeatureInventoryNavHost.kt`**:
    - A `navigateBack` lambda is now defined to handle back navigation by removing the last entry from the `backStack`.
    - This `navigateBack` action is passed down to the `featureInventoryEntryProvider`.

- **`FeatureInventoryEntryProvider.kt`**:
    - The provider now accepts the `navigateBack` function.
    - The `Health`, `Rides`, `Settings`, and `Weather` feature routes are now wrapped with the new `FeatureScaffold`, passing the appropriate title and the `navigateBack` action.