### PR TITLE
feat(health): Add `StackedWeeklyChart` component

### DIFF
--- a/features/health/src/debug/kotlin/com/zoewave/probase/features/health/ui/components/charts/StackedWeeklyChartPreview.kt
+++ b/features/health/src/debug/kotlin/com/zoewave/probase/features/health/ui/components/charts/StackedWeeklyChartPreview.kt
@@ -1,0 +1,52 @@
+package com.zoewave.probase.features.health.ui.components.charts
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import java.time.LocalDate
+
+@Preview(showBackground = true)
+@Composable
+fun StackedWeeklyChartPreview() {
+    val today = LocalDate.now()
+    val mockData = mutableMapOf<String, List<ChartSegment>>()
+
+    // Define standard colors for activities
+    val colorBiking = Color(0xFF4CAF50) // Green
+    val colorWalking = Color(0xFF03A9F4) // Blue
+    val colorOther = Color(0xFF9E9E9E)   // Gray
+
+    for (i in 6 downTo 0) {
+        val dateStr = today.minusDays(i.toLong()).toString()
+
+        // Create mock segments for the day
+        val segments = mutableListOf<ChartSegment>()
+
+        // Randomly add walking distance (e.g., normal daily movement)
+        segments.add(ChartSegment((1000..3000).random().toDouble(), colorWalking, "Walking"))
+
+        // Randomly add biking distance to some days
+        if (i % 2 == 0) {
+            segments.add(ChartSegment((4000..10000).random().toDouble(), colorBiking, "Biking"))
+        }
+
+        // Add some random unclassified distance
+        segments.add(ChartSegment((500..1500).random().toDouble(), colorOther, "Other"))
+
+        mockData[dateStr] = segments
+    }
+
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            StackedWeeklyChart(
+                title = "Distance by Activity (km)",
+                data = mockData,
+                formatValue = { v -> String.format("%.1f", v / 1000) }
+            )
+        }
+    }
+}

--- a/features/health/src/main/java/com/zoewave/probase/features/health/ui/components/charts/ChartSegment.kt
+++ b/features/health/src/main/java/com/zoewave/probase/features/health/ui/components/charts/ChartSegment.kt
@@ -1,0 +1,119 @@
+package com.zoewave.probase.features.health.ui.components.charts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
+
+// 1. Define a data class for the segments
+data class ChartSegment(
+    val value: Double,
+    val color: Color,
+    val label: String // e.g., "Biking", "Walking"
+)
+
+@Composable
+fun StackedWeeklyChart(
+    title: String,
+    data: Map<String, List<ChartSegment>>, // Date -> List of activities
+    formatValue: (Double) -> String
+) {
+    // Find the maximum total value for a single day to scale the chart
+    val maxDailyTotal = data.values.maxOfOrNull { daySegments ->
+        daySegments.sumOf { it.value }
+    } ?: 1.0
+
+    val sortedData = data.toSortedMap()
+
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (maxDailyTotal == 0.0) {
+                Text("No data", style = MaterialTheme.typography.bodySmall)
+            } else {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(150.dp),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.Bottom
+                ) {
+                    sortedData.forEach { (dateStr, segments) ->
+                        val dayLabel = try {
+                            LocalDate.parse(dateStr).dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())
+                        } catch (e: Exception) {
+                            dateStr.takeLast(2)
+                        }
+
+                        val dailyTotal = segments.sumOf { it.value }
+                        val totalBarHeightFraction = (dailyTotal / maxDailyTotal).coerceAtLeast(0.02)
+
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.Bottom
+                        ) {
+                            // Total value label on top
+                            Text(
+                                text = formatValue(dailyTotal),
+                                style = MaterialTheme.typography.labelSmall,
+                                maxLines = 1,
+                                fontSize = 10.sp
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+
+                            // The Stacked Bar
+                            Column(
+                                modifier = Modifier
+                                    .width(12.dp)
+                                    .fillMaxHeight(totalBarHeightFraction.toFloat())
+                                    .clip(RoundedCornerShape(4.dp)),
+                                verticalArrangement = Arrangement.Bottom
+                            ) {
+                                // Draw each segment based on its percentage of the day's total
+                                segments.forEach { segment ->
+                                    if (segment.value > 0) {
+                                        val segmentWeight = (segment.value / dailyTotal).toFloat()
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .weight(segmentWeight)
+                                                .background(segment.color)
+                                        )
+                                    }
+                                }
+                            }
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = dayLabel,
+                                style = MaterialTheme.typography.labelSmall
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new `StackedWeeklyChart` composable for visualizing weekly data broken down by activity type.

The new chart is designed to display stacked bars for each day of the week, where each segment of a bar represents a different activity (e.g., "Walking," "Biking") with a distinct color.

- **`features/health/src/main/java/com/zoewave/probase/features/health/ui/components/charts/ChartSegment.kt` (New)**:
    - This new file contains the `StackedWeeklyChart` composable.
    - It accepts a map of data where keys are date strings and values are a list of `ChartSegment` objects.
    - A `ChartSegment` data class (`value`, `color`, `label`) has been added to define individual parts of a bar.
    - The chart automatically scales the bar heights based on the maximum daily total and displays the formatted total value above each bar.

- **`features/health/src/debug/kotlin/com/zoewave/probase/features/health/ui/components/charts/StackedWeeklyChartPreview.kt` (New)**:
    - A corresponding preview file has been added to demonstrate the `StackedWeeklyChart` with mock, multi-activity data.