### PR TITLE
refactor(navigation): Refine back button visibility in `AshBikeMainSc…

### DIFF
--- a/applications/ashbike/apps/mobile/src/main/java/com/zoewave/probase/ashbike/mobile/ui/components/AshBikeMainScreen.kt
+++ b/applications/ashbike/apps/mobile/src/main/java/com/zoewave/probase/ashbike/mobile/ui/components/AshBikeMainScreen.kt
@@ -169,7 +169,7 @@ fun AshBikeMainScreen(
                     navigationIcon = {
 
                         // Stat
-                        if (!isRootScreen) {
+                        if (currentDestination is AshBikeDestination.RideDetail) {
                             IconButton(onClick = {
                                 // Pop the specific detail screen off the stack
                                 if (backStack.size > 1) {
@@ -181,7 +181,7 @@ fun AshBikeMainScreen(
                                     contentDescription = "Back"
                                 )
                             }
-                        }
+                       }
 
                         // End
 


### PR DESCRIPTION
…reen`

This commit refactors the logic for displaying the back arrow in the main screen's `TopAppBar`.

Previously, the back button's visibility was determined by a generic `!isRootScreen` check. This has been updated to a more specific condition, `currentDestination is AshBikeDestination.RideDetail`, ensuring the back button now only appears on the ride detail screen. This change improves navigational clarity and correctness.

- **`AshBikeMainScreen.kt`**:
    - Changed the `if` condition for rendering the navigation `IconButton` from `!isRootScreen` to `currentDestination is AshBikeDestination.RideDetail`.