### PR TITLE
refactor(rides): Restructure Ride History screen into modular components

### DIFF
--- a/applications/ashbike/apps/wear/features/rides/src/main/java/com/zoewave/probase/ashbike/wear/features/rides/RideHistoryCard.kt
+++ b/applications/ashbike/apps/wear/features/rides/src/main/java/com/zoewave/probase/ashbike/wear/features/rides/RideHistoryCard.kt
@@ -1,0 +1,105 @@
+package com.zoewave.probase.ashbike.wear.features.rides
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.Card
+import androidx.wear.compose.material3.Icon
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import com.zoewave.ashbike.model.bike.BikeRide
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun RideHistoryCard(
+    ride: BikeRide,
+    onRideClick: () -> Unit,
+    onDeleteClick: (BikeRide) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Helper to format the timestamp (e.g., "Feb 21, 02:12")
+    val formatter = SimpleDateFormat("MMM dd, HH:mm", Locale.getDefault())
+    val dateString = formatter.format(Date(ride.startTime))
+
+    // Helper to calculate duration in seconds (for the top right corner)
+    val durationSeconds = ((ride.endTime - ride.startTime) / 1000).coerceAtLeast(0)
+
+    Card(
+        onClick = onRideClick,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+
+            // Header Row: Date + (Duration & Delete)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = dateString,
+                    style = MaterialTheme.typography.titleMedium,//title3,
+                    color = Color.White
+                )
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "${durationSeconds}s",
+                        style = MaterialTheme.typography.bodyExtraSmall,//.arcSmall,//.caption2,
+                        color = Color.LightGray
+                    )
+
+                    Spacer(modifier = Modifier.width(6.dp))
+
+                    // Small Delete Button
+                    Button(
+                        onClick = { onDeleteClick(ride) },
+                        // colors = ButtonDefaults.buttonColors(backgroundColor = Color.Transparent),
+                        modifier = Modifier.size(24.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete Ride",
+                            tint = Color.Gray, // Keeping it subtle to match the UI
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            // Stats Body
+            Text(
+                text = "Distance: ${ride.totalDistance} km",
+                style = MaterialTheme.typography.bodySmall,//.body2,
+                color = Color.LightGray
+            )
+            Text(
+                text = "Avg: ${ride.averageSpeed} km/h",
+                style = MaterialTheme.typography.bodySmall,//.body2,
+                color = Color.LightGray
+            )
+            Text(
+                text = "Max: ${ride.maxSpeed} km/h",
+                style = MaterialTheme.typography.bodySmall,//.body2,
+                color = Color.LightGray
+            )
+        }
+    }
+}

--- a/applications/ashbike/apps/wear/features/rides/src/main/java/com/zoewave/probase/ashbike/wear/features/rides/RideHistoryPage.kt
+++ b/applications/ashbike/apps/wear/features/rides/src/main/java/com/zoewave/probase/ashbike/wear/features/rides/RideHistoryPage.kt
@@ -1,215 +1,49 @@
 package com.zoewave.probase.ashbike.wear.features.rides
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
-import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
-import androidx.wear.compose.material3.ListHeader
-import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
-import androidx.wear.compose.material3.TitleCard
-import androidx.wear.tooling.preview.devices.WearDevices
 import com.zoewave.ashbike.model.bike.BikeRide
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
-// ==========================================
-// 2. The UI Page (Stateless & Previewable)
-// ==========================================
 @Composable
 fun RideHistoryPage(
-    rides: List<BikeRide>, // ✅ Changed to expect BikeRide domain models
-    onRideClick: (String) -> Unit
+    rides: List<BikeRide>, // The list of data from your Room DB
+    onRideClick: (BikeRide) -> Unit, // What happens when a user taps a card
+    onDeleteClick: (BikeRide) -> Unit, // What happens when a user taps the trash can
+    modifier: Modifier = Modifier
 ) {
-    val listState = rememberScalingLazyListState()
-
+    // ScalingLazyColumn is the standard scrolling list for Wear OS
     ScalingLazyColumn(
-        state = listState,
-        modifier = Modifier.fillMaxSize(),
-        // Crucial: Padding pushes the first/last items safely past the round screen curves
-        contentPadding = PaddingValues(top = 32.dp, bottom = 32.dp, start = 12.dp, end = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-
-        // --- Header ---
-        item {
-            ListHeader {
-                Text(
-                    text = "Ride History",
-                    color = Color.White,
-                    style = MaterialTheme.typography.titleMedium// title3
-                )
-            }
-        }
-
-        // --- Empty State ---
-        if (rides.isEmpty()) {
-            item {
-                Spacer(modifier = Modifier.height(24.dp))
-                Text(
-                    text = "No recorded rides yet.",
-                    color = Color.LightGray,
-                    fontSize = 14.sp,
-                    textAlign = TextAlign.Center
-                )
-            }
-        }
-
-        // --- Ride Cards ---
-        items(rides, key = { it.rideId }) { ride ->
-            TitleCard(
-                onClick = { onRideClick(ride.rideId) },
-                title = {
-                    Text(
-                        text = formatStartDate(ride.startTime),
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 14.sp,
-                        color = Color.White
-                    )
-                },
-                // The "time" slot is natively top-right aligned in Wear OS TitleCards
-                time = {
-                    Text(
-                        text = formatDuration(ride.startTime, ride.endTime),
-                        color = MaterialTheme.colorScheme.primary,//.colors.primary,
-                        fontSize = 12.sp
-                    )
-                },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                // Card Body matching your phone's history feed
-                Column(
-                    modifier = Modifier.padding(top = 4.dp),
-                    verticalArrangement = Arrangement.spacedBy(2.dp)
-                ) {
-                    Text(
-                        text = "Distance: ${String.format(Locale.US, "%.1f", ride.totalDistance)} km",
-                        fontSize = 13.sp,
-                        color = Color.LightGray
-                    )
-                    Text(
-                        text = "Avg: ${String.format(Locale.US, "%.1f", ride.averageSpeed)} km/h",
-                        fontSize = 12.sp,
-                        color = Color.LightGray
-                    )
-                    Text(
-                        text = "Max: ${String.format(Locale.US, "%.1f", ride.maxSpeed)} km/h",
-                        fontSize = 12.sp,
-                        color = Color.LightGray
-                    )
-                }
-            }
-        }
-    }
-}
-
-// ==========================================
-// 3. Formatting Helpers
-// ==========================================
-private fun formatStartDate(timeInMillis: Long): String {
-    val formatter = SimpleDateFormat("MMM dd, HH:mm", Locale.getDefault())
-    return formatter.format(Date(timeInMillis))
-}
-
-private fun formatDuration(start: Long, end: Long): String {
-    if (end <= start) return "0s"
-    val diffSeconds = (end - start) / 1000
-    val minutes = diffSeconds / 60
-    val seconds = diffSeconds % 60
-    return if (minutes > 0) "${minutes}m ${seconds}s" else "${seconds}s"
-}
-
-// ==========================================
-// 4. Previews (Test your scaling behavior!)
-// ==========================================
-@Preview(
-    device = WearDevices.SMALL_ROUND,
-    showSystemUi = true,
-    backgroundColor = 0xFF000000,
-    showBackground = true,
-    name = "History List - Populated"
-)
-
-
-// ==========================================
-// Previews (Test your scaling behavior!)
-// ==========================================
-@Preview(
-    device = WearDevices.SMALL_ROUND,
-    showSystemUi = true,
-    backgroundColor = 0xFF000000,
-    showBackground = true,
-    name = "History List - Populated"
-)
-@Composable
-fun RideHistoryPagePreview() {
-    val dummyRides = listOf(
-        BikeRide(
-            rideId = "1",
-            startTime = System.currentTimeMillis() - 14000,
-            endTime = System.currentTimeMillis(),
-            totalDistance = 0.3f,
-            averageSpeed = 64.1f, // 2. Added 'f' to convert Double to Float
-            maxSpeed = 37.1f,     // Added 'f'
-            startLat = 0.0, startLng = 0.0, endLat = 0.0, endLng = 0.0,
-            elevationGain = 0.0f, // Added 'f'
-            elevationLoss = 0.0f, // Added 'f'
-            caloriesBurned = 0,
-            isHealthDataSynced = false,
-            // 3. Added all missing required parameters
-            avgHeartRate = null, maxHeartRate = null, healthConnectRecordId = null,
-            weatherCondition = null, rideType = null, notes = null, rating = null,
-            bikeId = null, batteryStart = null, batteryEnd = null,
-            locations = emptyList()
-        ),
-        BikeRide(
-            rideId = "2",
-            startTime = System.currentTimeMillis() - 86400000 - 3600000,
-            endTime = System.currentTimeMillis() - 86400000,
-            totalDistance = 24.5f,
-            averageSpeed = 24.5f, // Added 'f'
-            maxSpeed = 41.2f,     // Added 'f'
-            startLat = 0.0, startLng = 0.0, endLat = 0.0, endLng = 0.0,
-            elevationGain = 120.0f, // Added 'f'
-            elevationLoss = 110.0f, // Added 'f'
-            caloriesBurned = 540,
-            isHealthDataSynced = true,
-            // 3. Added all missing required parameters
-            avgHeartRate = 145, maxHeartRate = 165, healthConnectRecordId = "hc_123",
-            weatherCondition = "Sunny", rideType = "Gravel", notes = "Morning spin", rating = 5,
-            bikeId = "bike_01", batteryStart = 100, batteryEnd = 82,
-            locations = emptyList()
+        modifier = modifier.fillMaxSize(),
+        // Adds padding so the top/bottom items don't get cut off by the round screen
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+            top = 32.dp,
+            bottom = 32.dp,
+            start = 8.dp,
+            end = 8.dp
         )
-    )
+    ) {
+        // Optional: A title at the top of the list
+        item {
+            Text(
+                text = "Recent Rides",
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
 
-    MaterialTheme {
-        Box(
-            modifier = Modifier.fillMaxSize().background(Color.Black),
-            contentAlignment = Alignment.Center
-        ) {
-            RideHistoryPage(
-                rides = dummyRides,
-                onRideClick = {}
+        // Loop through your list of rides and create a card for each one
+        items(rides) { ride ->
+            RideHistoryCard(
+                ride = ride,
+                // Pass the clicks up to the parent screen/ViewModel
+                onRideClick = { onRideClick(ride) },
+                onDeleteClick = { onDeleteClick(ride) },
+                modifier = Modifier.padding(bottom = 4.dp) // Spacing between cards
             )
         }
     }

--- a/applications/ashbike/apps/wear/features/rides/src/main/java/com/zoewave/probase/ashbike/wear/features/rides/RideHistoryPageFull.kt
+++ b/applications/ashbike/apps/wear/features/rides/src/main/java/com/zoewave/probase/ashbike/wear/features/rides/RideHistoryPageFull.kt
@@ -1,0 +1,216 @@
+package com.zoewave.probase.ashbike.wear.features.rides
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.TitleCard
+import androidx.wear.tooling.preview.devices.WearDevices
+import com.zoewave.ashbike.model.bike.BikeRide
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// ==========================================
+// 2. The UI Page (Stateless & Previewable)
+// ==========================================
+@Composable
+fun RideHistoryPageFull(
+    rides: List<BikeRide>, // ✅ Changed to expect BikeRide domain models
+    onRideClick: (String) -> Unit
+) {
+    val listState = rememberScalingLazyListState()
+
+    ScalingLazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxSize(),
+        // Crucial: Padding pushes the first/last items safely past the round screen curves
+        contentPadding = PaddingValues(top = 32.dp, bottom = 32.dp, start = 12.dp, end = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        // --- Header ---
+        item {
+            ListHeader {
+                Text(
+                    text = "Ride History",
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium// title3
+                )
+            }
+        }
+
+        // --- Empty State ---
+        if (rides.isEmpty()) {
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+                Text(
+                    text = "No recorded rides yet.",
+                    color = Color.LightGray,
+                    fontSize = 14.sp,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+
+        // --- Ride Cards ---
+        items(rides, key = { it.rideId }) { ride ->
+            TitleCard(
+                onClick = { onRideClick(ride.rideId) },
+                title = {
+                    Text(
+                        text = formatStartDate(ride.startTime),
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 14.sp,
+                        color = Color.White
+                    )
+                },
+                // The "time" slot is natively top-right aligned in Wear OS TitleCards
+                time = {
+                    Text(
+                        text = formatDuration(ride.startTime, ride.endTime),
+                        color = MaterialTheme.colorScheme.primary,//.colors.primary,
+                        fontSize = 12.sp
+                    )
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                // Card Body matching your phone's history feed
+                Column(
+                    modifier = Modifier.padding(top = 4.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Text(
+                        text = "Distance: ${String.format(Locale.US, "%.1f", ride.totalDistance)} km",
+                        fontSize = 13.sp,
+                        color = Color.LightGray
+                    )
+                    Text(
+                        text = "Avg: ${String.format(Locale.US, "%.1f", ride.averageSpeed)} km/h",
+                        fontSize = 12.sp,
+                        color = Color.LightGray
+                    )
+                    Text(
+                        text = "Max: ${String.format(Locale.US, "%.1f", ride.maxSpeed)} km/h",
+                        fontSize = 12.sp,
+                        color = Color.LightGray
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ==========================================
+// 3. Formatting Helpers
+// ==========================================
+private fun formatStartDate(timeInMillis: Long): String {
+    val formatter = SimpleDateFormat("MMM dd, HH:mm", Locale.getDefault())
+    return formatter.format(Date(timeInMillis))
+}
+
+private fun formatDuration(start: Long, end: Long): String {
+    if (end <= start) return "0s"
+    val diffSeconds = (end - start) / 1000
+    val minutes = diffSeconds / 60
+    val seconds = diffSeconds % 60
+    return if (minutes > 0) "${minutes}m ${seconds}s" else "${seconds}s"
+}
+
+// ==========================================
+// 4. Previews (Test your scaling behavior!)
+// ==========================================
+@Preview(
+    device = WearDevices.SMALL_ROUND,
+    showSystemUi = true,
+    backgroundColor = 0xFF000000,
+    showBackground = true,
+    name = "History List - Populated"
+)
+
+
+// ==========================================
+// Previews (Test your scaling behavior!)
+// ==========================================
+@Preview(
+    device = WearDevices.SMALL_ROUND,
+    showSystemUi = true,
+    backgroundColor = 0xFF000000,
+    showBackground = true,
+    name = "History List - Populated"
+)
+@Composable
+fun RideHistoryPagePreview() {
+    val dummyRides = listOf(
+        BikeRide(
+            rideId = "1",
+            startTime = System.currentTimeMillis() - 14000,
+            endTime = System.currentTimeMillis(),
+            totalDistance = 0.3f,
+            averageSpeed = 64.1f, // 2. Added 'f' to convert Double to Float
+            maxSpeed = 37.1f,     // Added 'f'
+            startLat = 0.0, startLng = 0.0, endLat = 0.0, endLng = 0.0,
+            elevationGain = 0.0f, // Added 'f'
+            elevationLoss = 0.0f, // Added 'f'
+            caloriesBurned = 0,
+            isHealthDataSynced = false,
+            // 3. Added all missing required parameters
+            avgHeartRate = null, maxHeartRate = null, healthConnectRecordId = null,
+            weatherCondition = null, rideType = null, notes = null, rating = null,
+            bikeId = null, batteryStart = null, batteryEnd = null,
+            locations = emptyList()
+        ),
+        BikeRide(
+            rideId = "2",
+            startTime = System.currentTimeMillis() - 86400000 - 3600000,
+            endTime = System.currentTimeMillis() - 86400000,
+            totalDistance = 24.5f,
+            averageSpeed = 24.5f, // Added 'f'
+            maxSpeed = 41.2f,     // Added 'f'
+            startLat = 0.0, startLng = 0.0, endLat = 0.0, endLng = 0.0,
+            elevationGain = 120.0f, // Added 'f'
+            elevationLoss = 110.0f, // Added 'f'
+            caloriesBurned = 540,
+            isHealthDataSynced = true,
+            // 3. Added all missing required parameters
+            avgHeartRate = 145, maxHeartRate = 165, healthConnectRecordId = "hc_123",
+            weatherCondition = "Sunny", rideType = "Gravel", notes = "Morning spin", rating = 5,
+            bikeId = "bike_01", batteryStart = 100, batteryEnd = 82,
+            locations = emptyList()
+        )
+    )
+
+    MaterialTheme {
+        Box(
+            modifier = Modifier.fillMaxSize().background(Color.Black),
+            contentAlignment = Alignment.Center
+        ) {
+            RideHistoryPageFull(
+                rides = dummyRides,
+                onRideClick = {}
+            )
+        }
+    }
+}

--- a/applications/ashbike/apps/wear/features/rides/src/main/java/com/zoewave/probase/ashbike/wear/features/rides/RideHistoryRoute.kt
+++ b/applications/ashbike/apps/wear/features/rides/src/main/java/com/zoewave/probase/ashbike/wear/features/rides/RideHistoryRoute.kt
@@ -9,16 +9,25 @@ import com.zoewave.ashbike.model.bike.BikeRide
 // ==========================================
 // 1. The Route (Handles State & Module Isolation)
 // ==========================================
+
 @Composable
 fun RideHistoryRoute(
     viewModel: RidesViewModel = hiltViewModel(),
     onNavigateToDetail: (String) -> Unit
 ) {
-    // Now safely collecting domain models
+    // Safely collecting domain models from the ViewModel
     val rides: List<BikeRide> by viewModel.ridesState.collectAsState()
 
     RideHistoryPage(
         rides = rides,
-        onRideClick = onNavigateToDetail
+        onRideClick = { ride ->
+            // Map the full BikeRide object to just its ID for the navigation graph
+            onNavigateToDetail(ride.rideId)
+        },
+        onDeleteClick = { ride ->
+            // Assuming your ViewModel takes the full object to delete it.
+            // (If your ViewModel expects a String instead, use ride.rideId here too).
+            viewModel.deleteRide(ride.rideId)
+        }
     )
 }


### PR DESCRIPTION
This commit refactors the Wear OS ride history feature to improve code structure and maintainability. The monolithic `RideHistoryPage` has been broken down into smaller, more focused composables: `RideHistoryPageFull`, `RideHistoryCard`, and a simplified `RideHistoryPage`.

This new structure separates concerns, making each component easier to understand, test, and reuse.

- **`RideHistoryPageFull.kt` (New)**:
    - This new file contains the main UI for the ride history screen, a `ScalingLazyColumn` that displays a list of rides.
    - It includes a header, an empty state message, and uses `TitleCard` to display ride details (date, duration, distance, and speed).
    - It also contains a full `@Preview` with mock `BikeRide` data.

- **`RideHistoryCard.kt` (New)**:
    - A new `Card` composable responsible for displaying a single ride entry.
    - It includes the ride date, duration, key stats (distance, average/max speed), and adds a `Delete` button for each ride.

- **`RideHistoryPage.kt` (Refactored)**:
    - The original `RideHistoryPage` has been simplified to act as a container.
    - It now uses a `ScalingLazyColumn` to render a list of the new `RideHistoryCard` components.
    - The detailed UI implementation has been moved to `RideHistoryPageFull.kt` and `RideHistoryCard.kt`.

- **`RideHistoryRoute.kt` (Updated)**:
    - The route has been updated to handle the new `onDeleteClick` action from the `RideHistoryPage`.
    - It now passes the `deleteRide` function from the `RidesViewModel` to the UI layer.
    - The `onRideClick` lambda now correctly passes the `rideId` string for navigation.