### PR TITLE
feat(wear): implement WearRideSyncEngine for ride data transmission

### DIFF
--- a/applications/ashbike/apps/wear/data/build.gradle.kts
+++ b/applications/ashbike/apps/wear/data/build.gradle.kts
@@ -24,8 +24,6 @@ dependencies {
     implementation(project(":applications:ashbike:model"))
     implementation(project(":applications:ashbike:data"))
 
-
-
     // --- Health & Wear Sensors ---
     // Replaced Health Connect with Health Services for live hardware sensor reading
     implementation(libs.androidx.health.wear.services.client)
@@ -33,6 +31,10 @@ dependencies {
     // --- Android Base ---
     implementation(libs.androidx.core.ktx)
     implementation(libs.google.play.services.location)
+    implementation(libs.google.play.services.wearable)
+
+    implementation(libs.squareup.retrofit.converter.gson)
+    implementation((libs.kotlinx.coroutines.play.services))
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/sync/WearRideSyncEngine.kt
+++ b/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/sync/WearRideSyncEngine.kt
@@ -1,0 +1,52 @@
+package com.zoewave.probase.ashbike.wear.data.sync
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import com.google.gson.Gson
+import com.zoewave.ashbike.data.services.RideSyncEngine
+import com.zoewave.probase.ashbike.database.BikeRideEntity
+import com.zoewave.probase.ashbike.database.RideLocationEntity
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.tasks.await
+
+import javax.inject.Inject
+
+class WearRideSyncEngine @Inject constructor(
+    @ApplicationContext private val context: Context
+) : RideSyncEngine {
+
+    private val dataClient = Wearable.getDataClient(context)
+    private val gson = Gson()
+
+    override suspend fun syncCompletedRide(ride: BikeRideEntity, locations: List<RideLocationEntity>) {
+        try {
+            Log.d("AshBikeSync", "Packaging ride for transmission: ${ride.rideId}")
+
+            // 1. Create a unique path for the DataItem
+            val request = PutDataMapRequest.create("/completed_ride/${ride.rideId}")
+
+            // 2. Serialize the data to JSON strings
+            val rideJson = gson.toJson(ride)
+            val locationsJson = gson.toJson(locations)
+
+            // 3. Pack the DataMap
+            request.dataMap.putString("ride_data", rideJson)
+            request.dataMap.putString("location_data", locationsJson)
+
+            // Adding a timestamp forces the DataClient to treat this as a "new"
+            // event, even if the payload looks identical to a previous one.
+            request.dataMap.putLong("timestamp", System.currentTimeMillis())
+
+            // 4. Fire it over Bluetooth/Wi-Fi!
+            val putDataReq = request.asPutDataRequest().setUrgent()
+            dataClient.putDataItem(putDataReq).await()
+
+            Log.d("AshBikeSync", "Ride successfully beamed to Phone!")
+
+        } catch (e: Exception) {
+            Log.e("AshBikeSync", "Failed to sync ride to phone", e)
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the `WearRideSyncEngine` to handle the transmission of completed ride data from Wear OS devices to a paired phone using the Google Play Services Wearable `DataClient`.

- **`WearRideSyncEngine.kt`**:
    - Implements `RideSyncEngine` to serialize `BikeRideEntity` and `RideLocationEntity` objects into JSON using Gson.
    - Utilizes `PutDataMapRequest` to package ride and location data into a unique `/completed_ride/` path.
    - Ensures immediate delivery by setting the data request as urgent and appending a timestamp to force updates.

- **`applications/ashbike/apps/wear/data/build.gradle.kts`**:
    - Added dependencies for `google.play.services.wearable`, `retrofit.converter.gson`, and `kotlinx.coroutines.play.services` to support Wearable Data Layer APIs and asynchronous task handling.