### PR TITLE
feat(ashbike): implement MobileRideSyncEngine and update dependencies

### DIFF
--- a/applications/ashbike/apps/mobile/data/build.gradle.kts
+++ b/applications/ashbike/apps/mobile/data/build.gradle.kts
@@ -13,9 +13,11 @@ dependencies {
     // --- Shared Projects ---
     // Contains the RideTrackingEngine interface
     implementation(project(":applications:ashbike:data"))
+    implementation(project(":applications:ashbike:database"))
 
     // Contains the LocationPoint domain model
     implementation(project(":applications:ashbike:model"))
+
 
     // Contains your HeartRateRepository for the BLE chest strap
     implementation(project(":core:data"))

--- a/applications/ashbike/apps/mobile/data/src/main/java/com/zoewave/probase/ashbike/mobile/data/sync/MobileRideSyncEngine.kt
+++ b/applications/ashbike/apps/mobile/data/src/main/java/com/zoewave/probase/ashbike/mobile/data/sync/MobileRideSyncEngine.kt
@@ -1,0 +1,17 @@
+package com.zoewave.probase.ashbike.mobile.data.sync
+
+import android.util.Log
+import com.zoewave.ashbike.data.services.RideSyncEngine
+import com.zoewave.probase.ashbike.database.BikeRideEntity
+import com.zoewave.probase.ashbike.database.RideLocationEntity
+
+import javax.inject.Inject
+
+class MobileRideSyncEngine @Inject constructor() : RideSyncEngine {
+
+    override suspend fun syncCompletedRide(ride: BikeRideEntity, locations: List<RideLocationEntity>) {
+        // Do absolutely nothing!
+        // The phone is the final destination, so it doesn't need to transmit rides.
+        Log.d("AshBikeSync", "Mobile app formal ride saved. No outgoing sync required.")
+    }
+}


### PR DESCRIPTION
This commit introduces the `MobileRideSyncEngine` to the mobile data module and updates the build configuration to include the database project. Since the mobile app is the final destination for ride data, the sync engine implementation is intentionally a no-op.

- **`MobileRideSyncEngine.kt`**:
    - Implemented `RideSyncEngine` with a no-op `syncCompletedRide` method, as the phone does not need to transmit rides further.

- **`applications/ashbike/apps/mobile/data/build.gradle.kts`**:
    - Added a dependency on the `:applications:ashbike:database` project.