### PR TITLE
feat(bike): integrate ride synchronization into foreground service

### DIFF
--- a/applications/ashbike/apps/mobile/src/main/java/com/zoewave/probase/ashbike/mobile/di/MobileTrackingModule.kt
+++ b/applications/ashbike/apps/mobile/src/main/java/com/zoewave/probase/ashbike/mobile/di/MobileTrackingModule.kt
@@ -1,9 +1,12 @@
 package com.zoewave.probase.ashbike.mobile.di
+import com.zoewave.ashbike.data.services.RideSyncEngine
 import com.zoewave.ashbike.data.services.RideTrackingEngine
 import com.zoewave.probase.ashbike.mobile.data.sensor.MobileLocationBleEngine
+import com.zoewave.probase.ashbike.mobile.data.sync.MobileRideSyncEngine
 
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
@@ -17,4 +20,10 @@ abstract class MobileTrackingModule {
     abstract fun bindTrackingEngine(
         impl: MobileLocationBleEngine
     ): RideTrackingEngine
+
+    @Provides
+    @Singleton
+    fun provideRideSyncEngine(): RideSyncEngine {
+        return MobileRideSyncEngine()
+    }
 }

--- a/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/health/di/WearTrackingModule.kt
+++ b/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/health/di/WearTrackingModule.kt
@@ -7,9 +7,11 @@ import androidx.health.services.client.ExerciseClient
 import androidx.health.services.client.HealthServices
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.zoewave.ashbike.data.services.RideSyncEngine
 import com.zoewave.ashbike.data.services.RideTrackingEngine
 import com.zoewave.probase.ashbike.wear.data.health.sensor.WearEmulatorTrackingEngine
 import com.zoewave.probase.ashbike.wear.data.health.sensor.WearExerciseClientEngine
+import com.zoewave.probase.ashbike.wear.data.sync.WearRideSyncEngine
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -53,5 +55,11 @@ object WearTrackingModule {
             // Inject the pure, battery-optimized production engine
             WearExerciseClientEngine(exerciseClient)
         }
+    }
+
+    @Provides
+    @Singleton
+    fun provideRideSyncEngine(@ApplicationContext context: Context): RideSyncEngine {
+        return WearRideSyncEngine(context)
     }
 }

--- a/applications/ashbike/features/main/src/main/java/com/zoewave/probase/ashbike/features/main/service/BikeForegroundService.kt
+++ b/applications/ashbike/features/main/src/main/java/com/zoewave/probase/ashbike/features/main/service/BikeForegroundService.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.maps.model.LatLng
 import com.zoewave.ashbike.data.repository.bike.BikeRepository
+import com.zoewave.ashbike.data.services.RideSyncEngine
 import com.zoewave.ashbike.data.services.RideTrackingEngine
 import com.zoewave.ashbike.model.bike.BikeRideInfo
 import com.zoewave.ashbike.model.bike.LocationEnergyLevel
@@ -54,6 +55,7 @@ class BikeForegroundService : LifecycleService() {
     @Inject lateinit var appSettingsRepository: AppSettingsRepository
     @Inject lateinit var bikeRepository: BikeRepository
     @Inject lateinit var heartRateRepository: HeartRateRepository
+    @Inject lateinit var syncEngine: RideSyncEngine
 
     // --- System & Hardware ---
     @Inject lateinit var trackingEngine: RideTrackingEngine
@@ -426,6 +428,11 @@ class BikeForegroundService : LifecycleService() {
             // 2. Save DB
             withContext(Dispatchers.IO) {
                 repo.insertRideWithLocations(rideEntity, locEntities)
+            }
+            // 2. Beam it!
+            // (On the watch, this fires over Bluetooth. On the phone, it does nothing).
+            withContext(Dispatchers.IO) {
+                syncEngine.syncCompletedRide(rideEntity, locEntities)
             }
             // 3. ✅ IMMEDIATE RESET (Stop + Zero)
             resetDashboardData()


### PR DESCRIPTION
This commit introduces a `RideSyncEngine` to the ride tracking pipeline, enabling cross-device data synchronization when a ride is completed. The implementation ensures that completed rides are transmitted from the source device (e.g., Wear OS) to the companion device.

- **`BikeForegroundService.kt`**:
    - Injected `RideSyncEngine`.
    - Updated the ride completion logic to trigger `syncCompletedRide` after persisting the ride to the local database, enabling data transfer between devices.

- **`WearTrackingModule.kt`**:
    - Added a Hilt provider for `RideSyncEngine` using the `WearRideSyncEngine` implementation.

- **`MobileTrackingModule.kt`**:
    - Added a Hilt provider for `RideSyncEngine` using the `MobileRideSyncEngine` implementation.