### PR TITLE
feat(mobile): add Wear OS ride synchronization listener

### DIFF
--- a/applications/ashbike/apps/mobile/data/build.gradle.kts
+++ b/applications/ashbike/apps/mobile/data/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
 
     // --- Coroutines ---
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.google.play.services.wearable)
+
+    implementation(libs.squareup.retrofit.converter.gson)
 
     // --- Testing ---
     testImplementation(libs.junit)

--- a/applications/ashbike/apps/mobile/data/src/main/java/com/zoewave/probase/ashbike/mobile/data/sync/RideSyncListenerService.kt
+++ b/applications/ashbike/apps/mobile/data/src/main/java/com/zoewave/probase/ashbike/mobile/data/sync/RideSyncListenerService.kt
@@ -1,0 +1,81 @@
+package com.zoewave.probase.ashbike.mobile.data.sync
+
+
+import android.util.Log
+import com.google.android.gms.wearable.DataEvent
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.WearableListenerService
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.zoewave.probase.ashbike.database.BikeRideEntity
+import com.zoewave.probase.ashbike.database.BikeRideRepo
+import com.zoewave.probase.ashbike.database.RideLocationEntity
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class RideSyncListenerService : WearableListenerService() {
+
+    // Hilt perfectly injects your Room DB repository!
+    @Inject lateinit var repo: BikeRideRepo
+
+    private val gson = Gson()
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        super.onDataChanged(dataEvents)
+
+        for (event in dataEvents) {
+            // We only care about new or updated data
+            if (event.type == DataEvent.TYPE_CHANGED) {
+                val path = event.dataItem.uri.path
+
+                // Check if this matches the exact path the watch used to pitch the data
+                if (path != null && path.startsWith("/completed_ride/")) {
+                    Log.d(TAG, "Incoming ride detected from Watch! Path: $path")
+
+                    val dataMapItem = DataMapItem.fromDataItem(event.dataItem)
+                    val dataMap = dataMapItem.dataMap
+
+                    // 1. Extract the JSON payloads we packed on the watch
+                    val rideJson = dataMap.getString("ride_data")
+                    val locationsJson = dataMap.getString("location_data")
+
+                    if (rideJson != null && locationsJson != null) {
+                        try {
+                            // 2. Deserialize the data back into your Room Entities
+                            val rideEntity = gson.fromJson(rideJson, BikeRideEntity::class.java)
+
+                            val listType = object : TypeToken<List<RideLocationEntity>>() {}.type
+                            val locationEntities: List<RideLocationEntity> = gson.fromJson(locationsJson, listType)
+
+                            // 3. Save it straight to the phone's database!
+                            serviceScope.launch {
+                                repo.insertRideWithLocations(rideEntity, locationEntities)
+                                Log.i(TAG, "Successfully synced watch ride ${rideEntity.rideId} to phone database!")
+                            }
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Failed to parse and save incoming ride data", e)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Prevent memory leaks when the OS puts this service back to sleep
+        serviceScope.cancel()
+    }
+
+    companion object {
+        private const val TAG = "AshBikeSync"
+    }
+}

--- a/applications/ashbike/apps/mobile/src/main/AndroidManifest.xml
+++ b/applications/ashbike/apps/mobile/src/main/AndroidManifest.xml
@@ -74,6 +74,16 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:name="com.zoewave.probase.ashbike.mobile.data.sync.RideSyncListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+
+                <data android:scheme="wear" android:host="*" android:pathPrefix="/completed_ride/" />
+            </intent-filter>
+        </service>
+
         <!-- must match package name for GlassesMainActivity -->
         <activity
             android:name="com.zoewave.ashbike.mobile.glass.GlassesMainActivity"


### PR DESCRIPTION
This commit implements a `WearableListenerService` on the mobile app to automatically receive and persist completed ride data sent from a Wear OS device.

- **`AndroidManifest.xml`**:
    - Registered `RideSyncListenerService` with an intent filter for the `DATA_CHANGED` action and the `/completed_ride/` path prefix.

- **`RideSyncListenerService.kt`**:
    - Created a new service that listens for `wear` data events.
    - Implemented logic to deserialize JSON payloads for ride and location entities using Gson.
    - Integrated `BikeRideRepo` with Hilt to persist synced data directly into the mobile database within a background coroutine scope.

- **`build.gradle.kts`**:
    - Added dependencies for `google-play-services-wearable` and `gson` to support data layer communication and serialization.