### PR TITLE
feat(bike): implement sync acknowledgement between mobile and wear

### DIFF
--- a/applications/ashbike/apps/mobile/data/build.gradle.kts
+++ b/applications/ashbike/apps/mobile/data/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(libs.google.play.services.wearable)
 
     implementation(libs.squareup.retrofit.converter.gson)
+    implementation((libs.kotlinx.coroutines.play.services))
 
     // --- Testing ---
     testImplementation(libs.junit)

--- a/applications/ashbike/apps/mobile/data/src/main/java/com/zoewave/probase/ashbike/mobile/data/sync/RideSyncListenerService.kt
+++ b/applications/ashbike/apps/mobile/data/src/main/java/com/zoewave/probase/ashbike/mobile/data/sync/RideSyncListenerService.kt
@@ -5,6 +5,8 @@ import android.util.Log
 import com.google.android.gms.wearable.DataEvent
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
 import com.google.android.gms.wearable.WearableListenerService
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -17,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -31,13 +34,18 @@ class RideSyncListenerService : WearableListenerService() {
     override fun onDataChanged(dataEvents: DataEventBuffer) {
         super.onDataChanged(dataEvents)
 
+        Log.d(TAG, "🟢 PHONE LISTENER WOKE UP! Incoming data events count: ${dataEvents.count}")
+
         for (event in dataEvents) {
             // We only care about new or updated data
             if (event.type == DataEvent.TYPE_CHANGED) {
                 val path = event.dataItem.uri.path
+                Log.d(TAG, "🔍 PHONE inspecting incoming path: $path")
+
 
                 // Check if this matches the exact path the watch used to pitch the data
                 if (path != null && path.startsWith("/completed_ride/")) {
+                    Log.d(TAG, "📥 PHONE caught a ride payload! Extracting DataMap...")
                     Log.d(TAG, "Incoming ride detected from Watch! Path: $path")
 
                     val dataMapItem = DataMapItem.fromDataItem(event.dataItem)
@@ -55,14 +63,38 @@ class RideSyncListenerService : WearableListenerService() {
                             val listType = object : TypeToken<List<RideLocationEntity>>() {}.type
                             val locationEntities: List<RideLocationEntity> = gson.fromJson(locationsJson, listType)
 
+                            Log.d(TAG, "💾 PHONE successfully deserialized Ride ID: ${rideEntity.rideId}. Saving to Room DB...")
+
+                            Log.i(TAG, "✅ PHONE Room DB save complete for Ride ID: ${rideEntity.rideId}")
+
                             // 3. Save it straight to the phone's database!
                             serviceScope.launch {
                                 repo.insertRideWithLocations(rideEntity, locationEntities)
                                 Log.i(TAG, "Successfully synced watch ride ${rideEntity.rideId} to phone database!")
+
+                                // ---------------------------------------------------------
+                                // THE NEW ACKNOWLEDGEMENT PITCH
+                                // ---------------------------------------------------------
+                                Log.d(TAG, "📤 PHONE pitching ACK back to watch for Ride ID: ${rideEntity.rideId}")
+                                try {
+                                    val dataClient = Wearable.getDataClient(this@RideSyncListenerService)
+                                    val ackRequest = PutDataMapRequest.create("/sync_ack/${rideEntity.rideId}")
+                                    ackRequest.dataMap.putLong("timestamp", System.currentTimeMillis())
+
+                                    val putDataReq = ackRequest.asPutDataRequest().setUrgent()
+                                    dataClient.putDataItem(putDataReq).await()
+                                    Log.i(TAG, "🚀 PHONE successfully fired ACK over Bluetooth!")
+                                } catch (e: Exception) {
+                                    Log.e(TAG, "❌ PHONE failed to send ACK to watch", e)
+                                }
+
+
                             }
                         } catch (e: Exception) {
                             Log.e(TAG, "Failed to parse and save incoming ride data", e)
                         }
+                    } else {
+                        Log.e(TAG, "❌ PHONE received empty JSON strings from watch!")
                     }
                 }
             }

--- a/applications/ashbike/apps/mobile/features/home/src/main/java/com/zoewave/ashbike/mobile/home/ui/HomeViewModel.kt
+++ b/applications/ashbike/apps/mobile/features/home/src/main/java/com/zoewave/ashbike/mobile/home/ui/HomeViewModel.kt
@@ -182,7 +182,7 @@ class HomeViewModel @Inject constructor(
                 //    Crucially, its return type is declared as the supertype, 'HomeUiState'.
                 .map<CombinedData, HomeUiState> { data ->
                     // Log inside the map lambda
-                    Log.d("BikeViewModel_DEBUG", "Map lambda. Input CombinedData: $data.")
+                    // Log.d("BikeViewModel_DEBUG", "Map lambda. Input CombinedData: $data.")
                     val stateToEmit = HomeUiState.Success(
                         bikeData = data.rideInfo.copy(
                             totalTripDistance = data.totalDistance,

--- a/applications/ashbike/apps/wear/build.gradle.kts
+++ b/applications/ashbike/apps/wear/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     namespace = "com.zoewave.probase.ashbike.wear"
 
     defaultConfig {
-        applicationId = "com.zoewave.probase.ashbike.wear"
+        applicationId = "com.zoewave.probase.ashbike.mobile"
         versionCode = 1
         versionName = "1.0"
 

--- a/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/sync/RideAckListenerService.kt
+++ b/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/sync/RideAckListenerService.kt
@@ -1,0 +1,58 @@
+package com.zoewave.probase.ashbike.wear.data.sync
+
+import android.util.Log
+import com.google.android.gms.wearable.DataEvent
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.WearableListenerService
+import com.zoewave.probase.ashbike.database.BikeRideRepo
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class RideAckListenerService : WearableListenerService() {
+
+    @Inject lateinit var repo: BikeRideRepo
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onDataChanged(dataEvents: DataEventBuffer) {
+        super.onDataChanged(dataEvents)
+        Log.d(TAG, "⌚ WATCH ACK LISTENER WOKE UP!")
+
+        for (event in dataEvents) {
+            val path = event.dataItem.uri.path
+            Log.d(TAG, "🔍 WATCH inspecting incoming path: $path")
+
+            if (event.type == DataEvent.TYPE_CHANGED && path?.startsWith("/sync_ack/") == true) {
+                // The path looks like: /sync_ack/ride_12345
+                val rideId = path.substringAfterLast("/")
+                Log.d(TAG, "📥 WATCH caught ACK for Ride ID: $rideId! Marking as synced...")
+
+                serviceScope.launch {
+                    try {
+                        // NOTE: You will need to add this simple update function to your DAO/Repo
+                        // e.g., @Query("UPDATE bike_rides SET isSynced = 1 WHERE rideId = :id")
+                        // repo.markRideAsSynced(rideId)
+
+                        Log.i(TAG, "✅ WATCH successfully marked Ride ID: $rideId as fully synced!")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "❌ WATCH failed to update Room DB with ACK", e)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceScope.cancel()
+    }
+
+    companion object {
+        private const val TAG = "AshBikeSync"
+    }
+}

--- a/applications/ashbike/apps/wear/src/main/AndroidManifest.xml
+++ b/applications/ashbike/apps/wear/src/main/AndroidManifest.xml
@@ -55,6 +55,15 @@
                 android:value="0" />
         </service>
 
+        <service
+            android:name=".data.sync.RideAckListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.DATA_CHANGED" />
+                <data android:scheme="wear" android:host="*" android:pathPrefix="/sync_ack/" />
+            </intent-filter>
+        </service>
+
         <!--service
             android:name=".tile.AshBikeTileService"
             android:exported="true"


### PR DESCRIPTION
This commit introduces a bi-directional synchronization handshake. When the mobile app successfully receives and saves ride data from the watch, it now sends an acknowledgement (ACK) signal back. A new listener on the watch captures this ACK to eventually mark rides as synced in the local database.

- **`RideSyncListenerService.kt` (Mobile)**:
    - Updated to send a `PutDataMapRequest` back to the watch at `/sync_ack/{rideId}` after successfully saving ride data.
    - Added extensive logging for the data reception and ACK process.

- **`RideAckListenerService.kt` (Wear)**:
    - Created a new `WearableListenerService` to listen for `/sync_ack/` paths.
    - Outlines the logic to mark specific rides as synced in the Wear database upon receiving confirmation from the phone.

- **`AndroidManifest.xml` (Wear)**:
    - Registered `RideAckListenerService` with an intent filter for the `/sync_ack/` data scheme.

- **`HomeViewModel.kt` (Mobile)**:
    - Commented out noisy debug logs in the UI state mapping logic.

- **Build Configuration**:
    - **`apps/wear/build.gradle.kts`**: Updated `applicationId` to match the mobile package for consistent data layer communication.
    - **`apps/mobile/data/build.gradle.kts`**: Added `kotlinx-coroutines-play-services` dependency to support `.await()` on Wearable API Tasks.