### PR TITLE
refactor(wear): force production tracking engine and add emulator log…

### DIFF
--- a/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/health/di/WearTrackingModule.kt
+++ b/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/health/di/WearTrackingModule.kt
@@ -9,7 +9,6 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.zoewave.ashbike.data.services.RideSyncEngine
 import com.zoewave.ashbike.data.services.RideTrackingEngine
-import com.zoewave.probase.ashbike.wear.data.health.sensor.WearEmulatorTrackingEngine
 import com.zoewave.probase.ashbike.wear.data.health.sensor.WearExerciseClientEngine
 import com.zoewave.probase.ashbike.wear.data.sync.WearRideSyncEngine
 import dagger.Module
@@ -40,7 +39,7 @@ object WearTrackingModule {
     @Singleton
     fun provideRideTrackingEngine(
         exerciseClient: ExerciseClient,
-        fusedLocationClient: FusedLocationProviderClient
+        // fusedLocationClient: FusedLocationProviderClient
     ): RideTrackingEngine {
 
         // Check if we are running on an Android Studio Emulator
@@ -48,13 +47,15 @@ object WearTrackingModule {
                 Build.MODEL.contains("Emulator") ||
                 Build.MODEL.contains("sdk_gwear")
 
-        return if (isEmulator) {
+        return WearExerciseClientEngine(exerciseClient)
+
+        /*if (isEmulator) {
             // Inject the hacky hybrid engine so your mock routes work
             WearEmulatorTrackingEngine(exerciseClient, fusedLocationClient)
         } else {
             // Inject the pure, battery-optimized production engine
             WearExerciseClientEngine(exerciseClient)
-        }
+        }*/
     }
 
     @Provides

--- a/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/health/sensor/WearEmulatorTrackingEngine.kt
+++ b/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/health/sensor/WearEmulatorTrackingEngine.kt
@@ -3,6 +3,7 @@ package com.zoewave.probase.ashbike.wear.data.health.sensor
 import android.annotation.SuppressLint
 import android.os.Build
 import android.os.Looper
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.health.services.client.ExerciseClient
 import androidx.health.services.client.ExerciseUpdateCallback
@@ -22,10 +23,10 @@ import com.zoewave.ashbike.model.bike.LocationPoint
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import javax.inject.Inject
 
 @RequiresApi(Build.VERSION_CODES.BAKLAVA)
-class WearEmulatorTrackingEngine @Inject constructor(
+//class WearEmulatorTrackingEngine @Inject constructor(
+class WearEmulatorTrackingEngine constructor( // removeDI
     private val exerciseClient: ExerciseClient,
     private val fusedLocationClient: FusedLocationProviderClient
 ) : RideTrackingEngine {
@@ -54,6 +55,13 @@ class WearEmulatorTrackingEngine @Inject constructor(
     private val locationCallback = object : LocationCallback() {
         override fun onLocationResult(result: LocationResult) {
             result.lastLocation?.let { loc ->
+                // Calculate km/h for the log just so we can read it easily
+                val rawSpeedMs = if (loc.hasSpeed()) loc.speed else -1f
+                val speedKmh = if (loc.hasSpeed()) loc.speed * 3.6f else -1f
+
+                Log.d("AshBikeDebug", "📍 SENSOR TICK | Time: ${loc.time} | Lat/Lng: ${loc.latitude}, ${loc.longitude}")
+                Log.d("AshBikeDebug", "📍 SENSOR SPEED | HasSpeed: ${loc.hasSpeed()} | m/s: $rawSpeedMs | km/h: $speedKmh")
+
                 _currentLocation.value = LocationPoint(
                     latitude = loc.latitude,
                     longitude = loc.longitude,
@@ -68,6 +76,12 @@ class WearEmulatorTrackingEngine @Inject constructor(
 
     @SuppressLint("MissingPermission")
     override fun startRide(intervalMs: Long, minIntervalMs: Long) {
+
+        // 1. Intercept and override the service's request for testing
+        val emulatorIntervalMs = 1000L
+
+        Log.d("AshBikeDebug", "🚀 EMULATOR OVERRIDE | Service asked for $intervalMs but forcing $emulatorIntervalMs")
+
         // Start Health Services (Heart Rate ONLY, GPS disabled)
         val config = ExerciseConfig(
             exerciseType = ExerciseType.BIKING,
@@ -78,9 +92,9 @@ class WearEmulatorTrackingEngine @Inject constructor(
         exerciseClient.setUpdateCallback(exerciseUpdateCallback)
         exerciseClient.startExerciseAsync(config)
 
-        // Start Fused Location (Sees the Emulator Route perfectly)
-        val locationRequest = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, intervalMs)
-            .setMinUpdateIntervalMillis(minIntervalMs)
+        // 2. Pass the forced 1-second interval to FusedLocation
+        val locationRequest = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, emulatorIntervalMs)
+            .setMinUpdateIntervalMillis(emulatorIntervalMs)
             .build()
 
         fusedLocationClient.requestLocationUpdates(


### PR DESCRIPTION
…ging

This commit temporarily bypasses the hybrid emulator tracking logic in favor of the production `WearExerciseClientEngine` and adds detailed debug logging to the `WearEmulatorTrackingEngine` for troubleshooting location and speed data.

- **`WearTrackingModule.kt`**:
    - Updated `provideRideTrackingEngine` to unconditionally return `WearExerciseClientEngine`.
    - Commented out the emulator check and `FusedLocationProviderClient` injection logic.

- **`WearEmulatorTrackingEngine.kt`**:
    - Added `Log.d` statements to capture sensor ticks, latitude/longitude, and speed (converted to km/h) from the location callback.
    - Updated `startRide` to override the requested update interval, forcing a 1-second (1000ms) interval for Fused Location updates.
    - Removed `@Inject` annotation to effectively disable DI for this class.