### PR TITLE
refactor(bike): use Wearable Assets for large location data sync

### DIFF
--- a/applications/ashbike/apps/mobile/data/src/main/java/com/zoewave/probase/ashbike/mobile/data/sync/RideSyncListenerService.kt
+++ b/applications/ashbike/apps/mobile/data/src/main/java/com/zoewave/probase/ashbike/mobile/data/sync/RideSyncListenerService.kt
@@ -1,6 +1,5 @@
 package com.zoewave.probase.ashbike.mobile.data.sync
 
-
 import android.util.Log
 import com.google.android.gms.wearable.DataEvent
 import com.google.android.gms.wearable.DataEventBuffer
@@ -44,41 +43,50 @@ class RideSyncListenerService : WearableListenerService() {
                 val path = event.dataItem.uri.path
                 Log.d(TAG, "🔍 PHONE inspecting incoming path: $path")
 
-
                 // Check if this matches the exact path the watch used to pitch the data
                 if (path != null && path.startsWith("/completed_ride/")) {
                     Log.d(TAG, "📥 PHONE caught a ride payload! Extracting DataMap...")
-                    Log.d(TAG, "Incoming ride detected from Watch! Path: $path")
 
                     val dataMapItem = DataMapItem.fromDataItem(event.dataItem)
                     val dataMap = dataMapItem.dataMap
 
-                    // 1. Extract the JSON payloads we packed on the watch
+                    // 1. Extract the String (Ride Info) and the Asset (Massive Location Array)
                     val rideJson = dataMap.getString("ride_data")
-                    val locationsJson = dataMap.getString("location_data")
+                    val locationAsset = dataMap.getAsset("location_data") // 🚀 NOW FETCHED AS AN ASSET
 
-                    if (rideJson != null && locationsJson != null) {
-                        try {
-                            // 2. Deserialize the data back into your Room Entities
-                            val rideEntity = gson.fromJson(rideJson, BikeRideEntity::class.java)
+                    if (rideJson != null && locationAsset != null) {
 
-                            val listType = object : TypeToken<List<RideLocationEntity>>() {}.type
-                            val locationEntities: List<RideLocationEntity> = gson.fromJson(locationsJson, listType)
+                        // 2. Move into the Coroutine to download and parse the Asset safely
+                        serviceScope.launch {
+                            try {
+                                Log.d(TAG, "📦 PHONE downloading Asset bytes from Play Services...")
 
-                            Log.d(TAG, "💾 PHONE successfully deserialized Ride ID: ${rideEntity.rideId}. Saving to Room DB...")
+                                // Request the raw file stream from Play Services
+                                val assetInputStream = Wearable.getDataClient(this@RideSyncListenerService)
+                                    .getFdForAsset(locationAsset)
+                                    .await()
+                                    .inputStream
 
-                            Log.i(TAG, "✅ PHONE Room DB save complete for Ride ID: ${rideEntity.rideId}")
+                                // Convert the byte stream back into our massive JSON String
+                                val locationsJson = assetInputStream?.bufferedReader(Charsets.UTF_8)?.use { it.readText() }
 
-                            // 3. Save it straight to the phone's database!
-                            serviceScope.launch {
-                                repo.insertRideWithLocations(rideEntity, locationEntities)
-                                Log.i(TAG, "Successfully synced watch ride ${rideEntity.rideId} to phone database!")
+                                if (locationsJson != null) {
+                                    // 3. Deserialize the data back into your Room Entities
+                                    val rideEntity = gson.fromJson(rideJson, BikeRideEntity::class.java)
 
-                                // ---------------------------------------------------------
-                                // THE NEW ACKNOWLEDGEMENT PITCH
-                                // ---------------------------------------------------------
-                                Log.d(TAG, "📤 PHONE pitching ACK back to watch for Ride ID: ${rideEntity.rideId}")
-                                try {
+                                    val listType = object : TypeToken<List<RideLocationEntity>>() {}.type
+                                    val locationEntities: List<RideLocationEntity> = gson.fromJson(locationsJson, listType)
+
+                                    Log.d(TAG, "💾 PHONE successfully deserialized Ride ID: ${rideEntity.rideId}. Saving to Room DB...")
+
+                                    // 4. Save it straight to the phone's database!
+                                    repo.insertRideWithLocations(rideEntity, locationEntities)
+                                    Log.i(TAG, "✅ PHONE Room DB save complete for Ride ID: ${rideEntity.rideId}")
+
+                                    // ---------------------------------------------------------
+                                    // THE NEW ACKNOWLEDGEMENT PITCH
+                                    // ---------------------------------------------------------
+                                    Log.d(TAG, "📤 PHONE pitching ACK back to watch for Ride ID: ${rideEntity.rideId}")
                                     val dataClient = Wearable.getDataClient(this@RideSyncListenerService)
                                     val ackRequest = PutDataMapRequest.create("/sync_ack/${rideEntity.rideId}")
                                     ackRequest.dataMap.putLong("timestamp", System.currentTimeMillis())
@@ -86,17 +94,16 @@ class RideSyncListenerService : WearableListenerService() {
                                     val putDataReq = ackRequest.asPutDataRequest().setUrgent()
                                     dataClient.putDataItem(putDataReq).await()
                                     Log.i(TAG, "🚀 PHONE successfully fired ACK over Bluetooth!")
-                                } catch (e: Exception) {
-                                    Log.e(TAG, "❌ PHONE failed to send ACK to watch", e)
+
+                                } else {
+                                    Log.e(TAG, "❌ PHONE failed to read bytes from the location Asset!")
                                 }
-
-
+                            } catch (e: Exception) {
+                                Log.e(TAG, "❌ PHONE failed to parse, save, or ACK incoming ride data", e)
                             }
-                        } catch (e: Exception) {
-                            Log.e(TAG, "Failed to parse and save incoming ride data", e)
                         }
                     } else {
-                        Log.e(TAG, "❌ PHONE received empty JSON strings from watch!")
+                        Log.e(TAG, "❌ PHONE received missing ride JSON or location Asset from watch!")
                     }
                 }
             }

--- a/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/sync/WearRideSyncEngine.kt
+++ b/applications/ashbike/apps/wear/data/src/main/java/com/zoewave/probase/ashbike/wear/data/sync/WearRideSyncEngine.kt
@@ -2,6 +2,7 @@ package com.zoewave.probase.ashbike.wear.data.sync
 
 import android.content.Context
 import android.util.Log
+import com.google.android.gms.wearable.Asset
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 import com.google.gson.GsonBuilder
@@ -32,9 +33,13 @@ class WearRideSyncEngine @Inject constructor(
             val rideJson = gson.toJson(ride)
             val locationsJson = gson.toJson(locations)
 
+            // 🚀 THE FIX: Convert the massive locations JSON into a byte array and wrap it in an Asset
+            val locationBytes = locationsJson.toByteArray(Charsets.UTF_8)
+            val locationAsset = Asset.createFromBytes(locationBytes)
+
             // 3. Pack the DataMap
-            request.dataMap.putString("ride_data", rideJson)
-            request.dataMap.putString("location_data", locationsJson)
+            request.dataMap.putString("ride_data", rideJson) // Ride summary is small, String is fine
+            request.dataMap.putAsset("location_data", locationAsset) // Locations list is massive, MUST be an Asset
 
             // Adding a timestamp forces the DataClient to treat this as a "new"
             // event, even if the payload looks identical to a previous one.
@@ -44,7 +49,7 @@ class WearRideSyncEngine @Inject constructor(
             val putDataReq = request.asPutDataRequest().setUrgent()
             dataClient.putDataItem(putDataReq).await()
 
-            Log.d("AshBikeSync", "Ride successfully beamed to Phone!")
+            Log.d("AshBikeSync", "Ride successfully beamed to Phone as an Asset!")
 
         } catch (e: Exception) {
             Log.e("AshBikeSync", "Failed to sync ride to phone", e)


### PR DESCRIPTION
This commit optimizes the data synchronization between Wear OS and mobile by migrating large location datasets from standard Strings to Wearable `Asset` objects. This avoids potential payload size limitations in the `DataClient` when syncing long bike rides.

- **`WearRideSyncEngine.kt`**:
    - Converted the `locations` JSON string into a byte array and wrapped it in a `com.google.android.gms.wearable.Asset`.
    - Updated `DataMap` packing to use `putAsset` for location data while maintaining `putString` for the smaller ride summary.

- **`RideSyncListenerService.kt`**:
    - Updated the receiver logic to extract the location data as an `Asset`.
    - Refactored the processing flow into a coroutine to asynchronously download the asset byte stream using `getFdForAsset`.
    - Improved error handling and logging around the asset extraction and database insertion process.