### PR TITLE
refactor(ble): namespace string resources and remove hardcoded strings

### DIFF
--- a/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/BluetoothLeSuccessScreen.kt
+++ b/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/BluetoothLeSuccessScreen.kt
@@ -99,7 +99,7 @@ fun BluetoothLeSuccessScreen(
                         Text(
                             // Assuming device.name can be null
                             text = device.name
-                                ?: stringResource(id = R.string.ble_text_unnamed_device),
+                                ?: stringResource(id = R.string.features_ble_ble_text_unnamed_device),
                             style = MaterialTheme.typography.titleLarge,
                             fontWeight = FontWeight.Bold
                         )
@@ -121,13 +121,13 @@ fun BluetoothLeSuccessScreen(
                             }
                             if (gattConnectionState == GattConnectionState.Connected) {
                                 Button(onClick = { readCharacteristics() }) {
-                                    Text(stringResource(id = R.string.ble_action_read_values))
+                                    Text(stringResource(id = R.string.features_ble_ble_action_read_values))
                                 }
                             }
                         }
                         Text(
                             text = stringResource(
-                                id = R.string.ble_text_status_label,
+                                id = R.string.features_ble_ble_text_status_label,
                                 gattConnectionState.toString()
                             ),
                             style = MaterialTheme.typography.bodySmall
@@ -151,7 +151,7 @@ fun BluetoothLeSuccessScreen(
             ) {
                 Text(
                     text = stringResource(
-                        id = R.string.ble_title_discovered_devices,
+                        id = R.string.features_ble_ble_title_discovered_devices,
                         discoveredDevices.size
                     ),
                     style = MaterialTheme.typography.titleMedium,
@@ -188,8 +188,8 @@ fun BluetoothLeSuccessScreen(
             if (discoveredDevices.isEmpty()) {
                 item {
                     Text(
-                        text = if (scanState == ScanState.SCANNING) stringResource(id = R.string.ble_text_scanning_for_devices) else stringResource(
-                            id = R.string.ble_text_no_devices_found
+                        text = if (scanState == ScanState.SCANNING) stringResource(id = R.string.features_ble_ble_text_scanning_for_devices) else stringResource(
+                            id = R.string.features_ble_ble_text_no_devices_found
                         ),
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(16.dp)
@@ -199,7 +199,7 @@ fun BluetoothLeSuccessScreen(
                 item {
                     Text(
                         text = stringResource(
-                            id = R.string.ble_text_no_named_devices_found,
+                            id = R.string.features_ble_ble_text_no_named_devices_found,
                             discoveredDevices.size
                         ),
                         style = MaterialTheme.typography.bodyMedium,
@@ -221,7 +221,7 @@ fun BluetoothLeSuccessScreen(
             item { Spacer(modifier = Modifier.height(8.dp)) }
             item {
                 Text(
-                    stringResource(id = R.string.ble_title_gatt_services),
+                    stringResource(id = R.string.features_ble_ble_title_gatt_services),
                     style = MaterialTheme.typography.titleMedium,
                     modifier = Modifier.padding(bottom = 4.dp)
                 )
@@ -232,7 +232,7 @@ fun BluetoothLeSuccessScreen(
                         .fillMaxWidth()
                         .padding(bottom = 8.dp)) {
                         Text(
-                            stringResource(id = R.string.ble_text_service_uuid, service.uuid),
+                            stringResource(id = R.string.features_ble_ble_text_service_uuid, service.uuid),
                             style = MaterialTheme.typography.bodySmall
                         )
                         service.characteristics.forEach { characteristic ->
@@ -241,7 +241,7 @@ fun BluetoothLeSuccessScreen(
                                 characteristic.value ?: stringResource(id = CoreUiR.string.text_na)
                             Text(
                                 text = stringResource(
-                                    id = R.string.ble_text_characteristic_details,
+                                    id = R.string.features_ble_ble_text_characteristic_details,
                                     characteristic.uuid,
                                     valueDisplay
                                 ),
@@ -254,7 +254,7 @@ fun BluetoothLeSuccessScreen(
             } else if (activeDevice != null) { // Only show "no services" if an active device is connected but no services found
                 item {
                     Text(
-                        stringResource(id = R.string.ble_error_no_services_discovered),
+                        stringResource(id = R.string.features_ble_ble_error_no_services_discovered),
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(16.dp)
                     )
@@ -289,12 +289,12 @@ fun DiscoveredDeviceItem(
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-            text = stringResource(id = R.string.ble_text_device_address, device.address),
+            text = stringResource(id = R.string.features_ble_ble_text_device_address, device.address),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         Text(
-            text = stringResource(id = R.string.ble_text_device_rssi, device.rssi),
+            text = stringResource(id = R.string.features_ble_ble_text_device_rssi, device.rssi),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )

--- a/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/GattCharTable.kt
+++ b/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/GattCharTable.kt
@@ -40,7 +40,7 @@ fun GattServices(
         Button(
             onClick = readBat
         ) {
-            Text(stringResource(id = R.string.ble_action_read_battery_level)) // Updated
+            Text(stringResource(id = R.string.features_ble_ble_action_read_battery_level)) // Updated
         }
 
         LazyColumn(
@@ -50,7 +50,7 @@ fun GattServices(
         ) {
             item {
                 Text(
-                    text = stringResource(id = R.string.ble_title_gatt_services), // Updated
+                    text = stringResource(id = R.string.features_ble_ble_title_gatt_services), // Updated
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                 )
@@ -72,7 +72,7 @@ fun GattServices(
                                 Text(
                                     // Updated with new string R.string.ble_text_characteristic_name
                                     text = stringResource(
-                                        id = R.string.ble_text_characteristic_name,
+                                        id = R.string.features_ble_ble_text_characteristic_name,
                                         characteristic.name
                                     ),
                                     style = MaterialTheme.typography.bodySmall,
@@ -81,7 +81,7 @@ fun GattServices(
                                 IconButton(onClick = { /*onCharacteristicClick(entry, characteristic)*/ }) {
                                     Icon(
                                         Icons.Default.Info,
-                                        contentDescription = stringResource(id = R.string.ble_cd_read_characteristic) // Updated
+                                        contentDescription = stringResource(id = R.string.features_ble_ble_cd_read_characteristic) // Updated
                                     )
                                 }
                             }
@@ -107,7 +107,7 @@ fun Gattab(
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                text = stringResource(id = R.string.ble_title_sensor_tag_details), // Updated
+                text = stringResource(id = R.string.features_ble_ble_title_sensor_tag_details), // Updated
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(bottom = 8.dp)
@@ -116,7 +116,7 @@ fun Gattab(
             Text(
                 // Updated
                 text = stringResource(
-                    id = R.string.ble_label_battery_level_formatted,
+                    id = R.string.features_ble_ble_label_battery_level_formatted,
                     batteryLevel()
                 ),
                 style = MaterialTheme.typography.bodyMedium,
@@ -125,19 +125,19 @@ fun Gattab(
             Text(
                 // Updated - Assuming "22°C" is a placeholder for a dynamic value.
                 // For now, we format it with the existing placeholder.
-                text = stringResource(id = R.string.ble_label_temperature_formatted, "22°C"),
+                text = stringResource(id = R.string.features_ble_ble_label_temperature_formatted, "22°C"),
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
             Text(
                 // Updated - Assuming "45%" is a placeholder.
-                text = stringResource(id = R.string.ble_label_humidity_formatted, "45%"),
+                text = stringResource(id = R.string.features_ble_ble_label_humidity_formatted, "45%"),
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
             Text(
                 // Updated - Assuming "0" is a placeholder.
-                text = stringResource(id = R.string.ble_label_last_synced_formatted, "0"),
+                text = stringResource(id = R.string.features_ble_ble_label_last_synced_formatted, "0"),
                 style = MaterialTheme.typography.bodyMedium
             )
         }

--- a/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/GattServicesCarousel.kt
+++ b/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/GattServicesCarousel.kt
@@ -28,9 +28,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.core.model.ble.DeviceService
+import com.zoewave.probase.features.ble.R
 
 // Composable for GATT Services Carousel
 @OptIn(ExperimentalAnimationApi::class)
@@ -45,11 +47,11 @@ fun GattServicesCarousel(
             onClick = readBat,
             modifier = Modifier.padding(16.dp)
         ) {
-            Text("Read Battery Level")
+            Text(stringResource(R.string.features_ble_ble_action_read_battery_level))
         }
 
         Text(
-            text = "GATT Services",
+            text = stringResource(R.string.features_ble_ble_title_gatt_services),
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(16.dp)
@@ -107,7 +109,7 @@ fun FrontOfCard(service: DeviceService) {
             fontWeight = FontWeight.Bold
         )
         Text(
-            text = "UUID: ${service.uuid}",
+            text = stringResource(R.string.features_ble_ble_label_uuid) + " ${service.uuid}",
             style = MaterialTheme.typography.bodySmall,
             color = Color.Gray
         )
@@ -122,7 +124,7 @@ fun BackOfCard(service: DeviceService) {
             .fillMaxWidth()
     ) {
         Text(
-            text = "Characteristics:",
+            text = stringResource(R.string.features_ble_ble_title_characteristics),
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold
         )
@@ -137,7 +139,7 @@ fun BackOfCard(service: DeviceService) {
                     color = Color.Gray
                 )
                 Text(
-                    text = "Value: ${characteristic.value}",
+                    text = stringResource(R.string.features_ble_ble_text_characteristic_value_label, characteristic.value),
                     style = MaterialTheme.typography.bodySmall
                 )
             }

--- a/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/GattServicesList.kt
+++ b/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/GattServicesList.kt
@@ -84,7 +84,7 @@ fun ExpandableGattServiceCard(
                         fontWeight = FontWeight.Bold
                     )
                     Text(
-                        text = stringResource(id = R.string.ble_text_service_uuid, service.uuid),
+                        text = stringResource(id = R.string.features_ble_ble_text_service_uuid, service.uuid),
                         style = MaterialTheme.typography.bodySmall,
                         color = Color.Gray
                     )
@@ -101,7 +101,7 @@ fun ExpandableGattServiceCard(
             if (isExpanded) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = stringResource(id = R.string.ble_title_characteristics),
+                    text = stringResource(id = R.string.features_ble_ble_title_characteristics),
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold
                 )
@@ -125,7 +125,7 @@ fun ExpandableGattServiceCard(
                             )
                             Text(
                                 text = stringResource(
-                                    id = R.string.ble_text_characteristic_value_label,
+                                    id = R.string.features_ble_ble_text_characteristic_value_label,
                                     characteristic.value
                                         ?: stringResource(id = CoreUiR.string.text_na)
                                 ),
@@ -163,7 +163,7 @@ fun ExpandableGattServiceCardOrig(service: DeviceService) {
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = stringResource(id = R.string.ble_text_service_uuid, service.uuid),
+                text = stringResource(id = R.string.features_ble_ble_text_service_uuid, service.uuid),
                 style = MaterialTheme.typography.bodySmall,
                 color = Color.Gray
             )
@@ -171,7 +171,7 @@ fun ExpandableGattServiceCardOrig(service: DeviceService) {
             if (isExpanded) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = stringResource(id = R.string.ble_title_characteristics),
+                    text = stringResource(id = R.string.features_ble_ble_title_characteristics),
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold
                 )
@@ -189,7 +189,7 @@ fun ExpandableGattServiceCardOrig(service: DeviceService) {
                         )
                         Text(
                             text = stringResource(
-                                id = R.string.ble_text_characteristic_value_label,
+                                id = R.string.features_ble_ble_text_characteristic_value_label,
                                 characteristic.value ?: stringResource(id = CoreUiR.string.text_na)
                             ),
                             style = MaterialTheme.typography.bodySmall

--- a/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/PermissionsDenied.kt
+++ b/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/PermissionsDenied.kt
@@ -31,7 +31,7 @@ fun PermissionsDenied(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = stringResource(id = R.string.ble_message_permissions_denied), // Replaced hardcoded string
+            text = stringResource(id = R.string.features_ble_ble_message_permissions_denied), // Replaced hardcoded string
             style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center
         )

--- a/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/PermissionsRationale.kt
+++ b/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/PermissionsRationale.kt
@@ -32,7 +32,7 @@ fun PermissionsRationale(
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            text = stringResource(id = R.string.ble_message_permissions_rationale_scan), // Updated
+            text = stringResource(id = R.string.features_ble_ble_message_permissions_rationale_scan), // Updated
             style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center
         )

--- a/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/ScanControls.kt
+++ b/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/ScanControls.kt
@@ -43,26 +43,26 @@ fun ScanControls(
                 onClick = startScan,
                 enabled = isStartScanningEnabled && scanState != ScanState.SCANNING
             ) {
-                Text(stringResource(id = R.string.ble_scan_controls_start_scan_button))
+                Text(stringResource(id = R.string.features_ble_ble_scan_controls_start_scan_button))
             }
             Spacer(Modifier.width(8.dp))
             Button(
                 onClick = stopScan,
                 enabled = scanState == ScanState.SCANNING
             ) {
-                Text(stringResource(id = R.string.ble_scan_controls_stop_scan_button))
+                Text(stringResource(id = R.string.features_ble_ble_scan_controls_stop_scan_button))
             }
         }
 
         Spacer(Modifier.height(8.dp)) // Keep this spacer for visual separation
 
         val statusText = when (scanState) {
-            ScanState.NOT_SCANNING -> stringResource(id = R.string.ble_scan_controls_status_display_not_scanning) // Updated
-            ScanState.SCANNING -> stringResource(id = R.string.ble_scan_controls_status_display_scanning)       // Updated
-            ScanState.STOPPING -> stringResource(id = R.string.ble_scan_controls_status_display_stopping)     // Updated
+            ScanState.NOT_SCANNING -> stringResource(id = R.string.features_ble_ble_scan_controls_status_display_not_scanning) // Updated
+            ScanState.SCANNING -> stringResource(id = R.string.features_ble_ble_scan_controls_status_display_scanning)       // Updated
+            ScanState.STOPPING -> stringResource(id = R.string.features_ble_ble_scan_controls_status_display_stopping)     // Updated
         }
         Text(
-            text = stringResource(id = R.string.ble_scan_controls_status_label) + " " + statusText,
+            text = stringResource(id = R.string.features_ble_ble_scan_controls_status_label) + " " + statusText,
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )

--- a/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/StatusBar.kt
+++ b/features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/StatusBar.kt
@@ -71,7 +71,7 @@ fun StatusBar(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = stringResource(id = R.string.ble_status_bar_title), // Changed
+                    text = stringResource(id = R.string.features_ble_ble_status_bar_title), // Changed
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.primary
                 )
@@ -86,9 +86,9 @@ fun StatusBar(
                             ScanState.STOPPING -> Icons.Outlined.Clear
                         },
                         contentDescription = when (scanState) {
-                            ScanState.NOT_SCANNING -> stringResource(id = R.string.ble_cd_scan_state_not_scanning)
-                            ScanState.SCANNING -> stringResource(id = R.string.ble_cd_scan_state_scanning)
-                            ScanState.STOPPING -> stringResource(id = R.string.ble_cd_scan_state_stopping)
+                            ScanState.NOT_SCANNING -> stringResource(id = R.string.features_ble_ble_cd_scan_state_not_scanning)
+                            ScanState.SCANNING -> stringResource(id = R.string.features_ble_ble_cd_scan_state_scanning)
+                            ScanState.STOPPING -> stringResource(id = R.string.features_ble_ble_cd_scan_state_stopping)
                         },
                         tint = when (scanState) {
                             ScanState.NOT_SCANNING -> Color.Red //MaterialTheme.colorScheme.error
@@ -100,9 +100,9 @@ fun StatusBar(
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = when (scanState) {
-                            ScanState.NOT_SCANNING -> stringResource(id = R.string.ble_text_scan_state_not_scanning)
-                            ScanState.SCANNING -> stringResource(id = R.string.ble_text_scan_state_scanning)
-                            ScanState.STOPPING -> stringResource(id = R.string.ble_text_scan_state_stopping)
+                            ScanState.NOT_SCANNING -> stringResource(id = R.string.features_ble_ble_text_scan_state_not_scanning)
+                            ScanState.SCANNING -> stringResource(id = R.string.features_ble_ble_text_scan_state_scanning)
+                            ScanState.STOPPING -> stringResource(id = R.string.features_ble_ble_text_scan_state_stopping)
                         },
                         color = //MaterialTheme.colorScheme.onPrimary,
                             when (scanState) {
@@ -175,7 +175,7 @@ fun StatusBar(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Settings,
-                            contentDescription = stringResource(id = R.string.ble_status_bar_cd_manage_permissions), // Changed
+                            contentDescription = stringResource(id = R.string.features_ble_ble_status_bar_cd_manage_permissions), // Changed
                             tint = MaterialTheme.colorScheme.primary
                         )
                     }
@@ -194,7 +194,7 @@ fun Legend() {
 
     Column {
         Text(
-            text = stringResource(id = R.string.ble_status_bar_legend_title), // Changed
+            text = stringResource(id = R.string.features_ble_ble_status_bar_legend_title), // Changed
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier.padding(bottom = 4.dp)
@@ -208,7 +208,7 @@ fun Legend() {
             )
             Spacer(modifier = Modifier.width(4.dp))
             Text(
-                stringResource(id = R.string.ble_status_bar_legend_granted),
+                stringResource(id = R.string.features_ble_ble_status_bar_legend_granted),
                 style = MaterialTheme.typography.bodySmall
             ) // Changed
         }
@@ -221,7 +221,7 @@ fun Legend() {
             )
             Spacer(modifier = Modifier.width(4.dp))
             Text(
-                stringResource(id = R.string.ble_status_bar_legend_denied),
+                stringResource(id = R.string.features_ble_ble_status_bar_legend_denied),
                 style = MaterialTheme.typography.bodySmall
             ) // Changed
         }
@@ -234,7 +234,7 @@ fun Legend() {
             )
             Spacer(modifier = Modifier.width(4.dp))
             Text(
-                stringResource(id = R.string.ble_status_bar_legend_not_requested),
+                stringResource(id = R.string.features_ble_ble_status_bar_legend_not_requested),
                 style = MaterialTheme.typography.bodySmall
             ) // Changed
         }
@@ -244,12 +244,12 @@ fun Legend() {
 @Composable
 private fun getFriendlyName(permission: String): String {
     return when (permission) {
-        android.Manifest.permission.BLUETOOTH_SCAN -> stringResource(id = R.string.ble_status_bar_perm_scan_nearby) // Changed
+        android.Manifest.permission.BLUETOOTH_SCAN -> stringResource(id = R.string.features_ble_ble_status_bar_perm_scan_nearby) // Changed
         android.Manifest.permission.BLUETOOTH_CONNECT -> stringResource(id = CoreUiR.string.action_connect)
-        android.Manifest.permission.BLUETOOTH_ADVERTISE -> stringResource(id = R.string.ble_status_bar_perm_advertise) // Changed
-        android.Manifest.permission.ACCESS_COARSE_LOCATION -> stringResource(id = R.string.ble_status_bar_perm_coarse_location) // Changed
-        android.Manifest.permission.ACCESS_FINE_LOCATION -> stringResource(id = R.string.ble_status_bar_perm_fine_location) // Changed
-        else -> stringResource(id = R.string.ble_status_bar_perm_unknown) // Changed
+        android.Manifest.permission.BLUETOOTH_ADVERTISE -> stringResource(id = R.string.features_ble_ble_status_bar_perm_advertise) // Changed
+        android.Manifest.permission.ACCESS_COARSE_LOCATION -> stringResource(id = R.string.features_ble_ble_status_bar_perm_coarse_location) // Changed
+        android.Manifest.permission.ACCESS_FINE_LOCATION -> stringResource(id = R.string.features_ble_ble_status_bar_perm_fine_location) // Changed
+        else -> stringResource(id = R.string.features_ble_ble_status_bar_perm_unknown) // Changed
     }
 }
 

--- a/features/ble/src/main/res/values/strings.xml
+++ b/features/ble/src/main/res/values/strings.xml
@@ -1,91 +1,91 @@
 <resources>
     <!-- Strings for StatusBar.kt -->
-    <string name="ble_status_bar_title">BLE Status</string>
-    <string name="ble_text_scan_state_not_scanning">Not Scanning</string>
-    <string name="ble_text_scan_state_scanning">Scanning…</string>
-    <string name="ble_text_scan_state_stopping">Stopping…</string>
+    <string name="features_ble_ble_status_bar_title">BLE Status</string>
+    <string name="features_ble_ble_text_scan_state_not_scanning">Not Scanning</string>
+    <string name="features_ble_ble_text_scan_state_scanning">Scanning…</string>
+    <string name="features_ble_ble_text_scan_state_stopping">Stopping…</string>
     <!-- Assuming cd_scan_state can use the text_scan_state if appropriate, or keep separate if descriptions must differ -->
-    <string name="ble_cd_scan_state_not_scanning">Scan State: Not Scanning</string>
-    <string name="ble_cd_scan_state_scanning">Scan State: Scanning</string>
-    <string name="ble_cd_scan_state_stopping">Scan State: Stopping</string>
+    <string name="features_ble_ble_cd_scan_state_not_scanning">Scan State: Not Scanning</string>
+    <string name="features_ble_ble_cd_scan_state_scanning">Scan State: Scanning</string>
+    <string name="features_ble_ble_cd_scan_state_stopping">Scan State: Stopping</string>
 
-    <string name="ble_status_bar_cd_manage_permissions">Manage Permissions</string>
-    <string name="ble_status_bar_legend_title">Legend:</string>
-    <string name="ble_status_bar_legend_granted">Granted</string>
-    <string name="ble_status_bar_legend_denied">Permanently Denied</string>
-    <string name="ble_status_bar_legend_not_requested">Not Yet Requested</string>
-    <string name="ble_status_bar_perm_scan_nearby">Scan Nearby</string>
-    <string name="ble_status_bar_perm_advertise">Advertise</string>
-    <string name="ble_status_bar_perm_coarse_location">Coarse Location</string>
-    <string name="ble_status_bar_perm_fine_location">Fine Location</string>
-    <string name="ble_status_bar_perm_unknown">Unknown Permission</string>
+    <string name="features_ble_ble_status_bar_cd_manage_permissions">Manage Permissions</string>
+    <string name="features_ble_ble_status_bar_legend_title">Legend:</string>
+    <string name="features_ble_ble_status_bar_legend_granted">Granted</string>
+    <string name="features_ble_ble_status_bar_legend_denied">Permanently Denied</string>
+    <string name="features_ble_ble_status_bar_legend_not_requested">Not Yet Requested</string>
+    <string name="features_ble_ble_status_bar_perm_scan_nearby">Scan Nearby</string>
+    <string name="features_ble_ble_status_bar_perm_advertise">Advertise</string>
+    <string name="features_ble_ble_status_bar_perm_coarse_location">Coarse Location</string>
+    <string name="features_ble_ble_status_bar_perm_fine_location">Fine Location</string>
+    <string name="features_ble_ble_status_bar_perm_unknown">Unknown Permission</string>
 
     <!-- Strings for ScanControls.kt -->
-    <string name="ble_scan_controls_start_scan_button">Start Scan</string>
-    <string name="ble_scan_controls_stop_scan_button">Stop Scan</string>
-    <string name="ble_scan_controls_status_label">Scan Status:</string> <!-- More generic -->
-    <string name="ble_scan_controls_scan_status_error">Status: Error - %1$s</string>
-    <string name="ble_scan_controls_scan_status_unknown_error">Status: Unknown Error</string>
+    <string name="features_ble_ble_scan_controls_start_scan_button">Start Scan</string>
+    <string name="features_ble_ble_scan_controls_stop_scan_button">Stop Scan</string>
+    <string name="features_ble_ble_scan_controls_status_label">Scan Status:</string> <!-- More generic -->
+    <string name="features_ble_ble_scan_controls_scan_status_error">Status: Error - %1$s</string>
+    <string name="features_ble_ble_scan_controls_scan_status_unknown_error">Status: Unknown Error</string>
     <!-- The following might be redundant if the above `ble_text_scan_state_` are used with a prefix in code -->
     <!-- Keeping for now if specific casing/context is needed -->
-    <string name="ble_scan_controls_status_display_not_scanning">NOT SCANNING</string>
-    <string name="ble_scan_controls_status_display_scanning">SCANNING</string>
-    <string name="ble_scan_controls_status_display_stopping">STOPPING</string>
+    <string name="features_ble_ble_scan_controls_status_display_not_scanning">NOT SCANNING</string>
+    <string name="features_ble_ble_scan_controls_status_display_scanning">SCANNING</string>
+    <string name="features_ble_ble_scan_controls_status_display_stopping">STOPPING</string>
 
     <!-- Strings for BluetoothLeSuccessScreen.kt & DiscoveredDeviceItem -->
-    <string name="ble_text_unnamed_device">Unnamed Device</string>
-    <string name="ble_action_read_values">Read Values</string>
-    <string name="ble_text_status_label">Status: %1$s</string>
-    <string name="ble_title_discovered_devices">Discovered Devices (%1$d)</string>
-    <string name="ble_text_scanning_for_devices">Scanning for devices…</string>
-    <string name="ble_text_no_devices_found">No devices found.</string>
-    <string name="ble_text_no_named_devices_found">No usable named devices found. (Total scanned: %1$d)</string>
-    <string name="ble_title_gatt_services">GATT Services</string>
-    <string name="ble_text_service_uuid">Service: %1$s</string>
-    <string name="ble_text_characteristic_details">	Char: %1$s - Value: %2$s</string>
-    <string name="ble_error_no_services_discovered">No services discovered or available for this device.</string>
-    <string name="ble_text_device_address">Address: %1$s</string>
-    <string name="ble_text_device_rssi">RSSI: %1$d dBm</string>
+    <string name="features_ble_ble_text_unnamed_device">Unnamed Device</string>
+    <string name="features_ble_ble_action_read_values">Read Values</string>
+    <string name="features_ble_ble_text_status_label">Status: %1$s</string>
+    <string name="features_ble_ble_title_discovered_devices">Discovered Devices (%1$d)</string>
+    <string name="features_ble_ble_text_scanning_for_devices">Scanning for devices…</string>
+    <string name="features_ble_ble_text_no_devices_found">No devices found.</string>
+    <string name="features_ble_ble_text_no_named_devices_found">No usable named devices found. (Total scanned: %1$d)</string>
+    <string name="features_ble_ble_title_gatt_services">GATT Services</string>
+    <string name="features_ble_ble_text_service_uuid">Service: %1$s</string>
+    <string name="features_ble_ble_text_characteristic_details">	Char: %1$s - Value: %2$s</string>
+    <string name="features_ble_ble_error_no_services_discovered">No services discovered or available for this device.</string>
+    <string name="features_ble_ble_text_device_address">Address: %1$s</string>
+    <string name="features_ble_ble_text_device_rssi">RSSI: %1$d dBm</string>
 
     <!-- Simple labels (if needed separately from formatted strings) -->
-    <string name="ble_label_service">Service:</string>
-    <string name="ble_label_characteristic">Characteristic:</string>
-    <string name="ble_label_value">Value:</string>
-    <string name="ble_label_address">Address:</string>
-    <string name="ble_label_rssi">RSSI:</string>
-    <string name="ble_unit_rssi_dbm">dBm</string>
+    <string name="features_ble_ble_label_service">Service:</string>
+    <string name="features_ble_ble_label_characteristic">Characteristic:</string>
+    <string name="features_ble_ble_label_value">Value:</string>
+    <string name="features_ble_ble_label_address">Address:</string>
+    <string name="features_ble_ble_label_rssi">RSSI:</string>
+    <string name="features_ble_ble_unit_rssi_dbm">dBm</string>
 
     <!-- Strings for PermissionsRationale.kt -->
-    <string name="ble_title_permissions_rationale">Bluetooth Permissions Required</string>
-    <string name="ble_message_permissions_rationale_scan_connect_location">This app needs Bluetooth scan, connect, and location permissions to discover and interact with nearby BLE devices. Android requires location for Bluetooth scanning.</string>
-    <string name="ble_message_permissions_rationale_scan_connect">This app needs Bluetooth scan and connect permissions to discover and interact with nearby BLE devices.</string>
-    <string name="ble_message_permissions_rationale_scan_location">This app needs Bluetooth scan and location permissions to discover nearby BLE devices. Android requires location for Bluetooth scanning.</string>
-    <string name="ble_message_permissions_rationale_scan">This app needs Bluetooth scan permission to discover nearby BLE devices.</string>
-    <string name="ble_message_permissions_rationale_connect_location">This app needs Bluetooth connect and location permissions to interact with BLE devices. Location might be needed for full functionality with some devices.</string>
-    <string name="ble_message_permissions_rationale_connect">This app needs Bluetooth connect permission to interact with BLE devices.</string>
-    <string name="ble_message_permissions_rationale_location">This app needs location permission for Bluetooth functionality as required by Android.</string>
-    <string name="ble_message_permissions_rationale_advertise">This app needs Bluetooth advertise permission to broadcast information.</string>
-    <string name="ble_message_permissions_rationale_generic">This app needs Bluetooth permissions to function correctly.</string>
-    <string name="ble_title_bluetooth_disabled">Bluetooth Disabled</string>
-    <string name="ble_message_bluetooth_disabled">Bluetooth is currently disabled. Please enable it in settings to allow BLE functionality.</string>
-    <string name="ble_action_open_settings">Open Settings</string>
+    <string name="features_ble_ble_title_permissions_rationale">Bluetooth Permissions Required</string>
+    <string name="features_ble_ble_message_permissions_rationale_scan_connect_location">This app needs Bluetooth scan, connect, and location permissions to discover and interact with nearby BLE devices. Android requires location for Bluetooth scanning.</string>
+    <string name="features_ble_ble_message_permissions_rationale_scan_connect">This app needs Bluetooth scan and connect permissions to discover and interact with nearby BLE devices.</string>
+    <string name="features_ble_ble_message_permissions_rationale_scan_location">This app needs Bluetooth scan and location permissions to discover nearby BLE devices. Android requires location for Bluetooth scanning.</string>
+    <string name="features_ble_ble_message_permissions_rationale_scan">This app needs Bluetooth scan permission to discover nearby BLE devices.</string>
+    <string name="features_ble_ble_message_permissions_rationale_connect_location">This app needs Bluetooth connect and location permissions to interact with BLE devices. Location might be needed for full functionality with some devices.</string>
+    <string name="features_ble_ble_message_permissions_rationale_connect">This app needs Bluetooth connect permission to interact with BLE devices.</string>
+    <string name="features_ble_ble_message_permissions_rationale_location">This app needs location permission for Bluetooth functionality as required by Android.</string>
+    <string name="features_ble_ble_message_permissions_rationale_advertise">This app needs Bluetooth advertise permission to broadcast information.</string>
+    <string name="features_ble_ble_message_permissions_rationale_generic">This app needs Bluetooth permissions to function correctly.</string>
+    <string name="features_ble_ble_title_bluetooth_disabled">Bluetooth Disabled</string>
+    <string name="features_ble_ble_message_bluetooth_disabled">Bluetooth is currently disabled. Please enable it in settings to allow BLE functionality.</string>
+    <string name="features_ble_ble_action_open_settings">Open Settings</string>
 
     <!-- Strings for PermissionsDenied.kt -->
-    <string name="ble_message_permissions_denied">Bluetooth permissions are denied. Please enable them in settings.</string>
-    <string name="ble_action_enable_permissions">Please enable permissions</string> <!-- Kept specific wording -->
+    <string name="features_ble_ble_message_permissions_denied">Bluetooth permissions are denied. Please enable them in settings.</string>
+    <string name="features_ble_ble_action_enable_permissions">Please enable permissions</string> <!-- Kept specific wording -->
 
     <!-- Strings for GattCharTable.kt & related GATT details -->
-    <string name="ble_label_uuid">UUID:</string> <!-- Generic UUID label -->
-    <string name="ble_title_characteristics">Characteristics:</string>
-    <string name="ble_action_read_battery_level">Read Battery Level</string>
-    <string name="ble_text_characteristic_name">Characteristic: %1$s</string> <!-- Added this line -->
-    <string name="ble_cd_read_characteristic">Read characteristic</string>
-    <string name="ble_title_sensor_tag_details">Sensor Tag Details</string>
-    <string name="ble_label_battery_level_formatted">Battery Level: %1$d%%</string>
-    <string name="ble_label_temperature_formatted">Temperature: %1$s</string>
-    <string name="ble_label_humidity_formatted">Humidity: %1$s</string>
-    <string name="ble_label_last_synced_formatted">Last Synced: %1$s</string>
-    <string name="ble_text_characteristic_value_label">Value: %1$s</string> <!-- Added this line -->
-    <string name="ble_unit_percent">%%</string>
-    <string name="ble_unit_celsius">°C</string>
+    <string name="features_ble_ble_label_uuid">UUID:</string> <!-- Generic UUID label -->
+    <string name="features_ble_ble_title_characteristics">Characteristics:</string>
+    <string name="features_ble_ble_action_read_battery_level">Read Battery Level</string>
+    <string name="features_ble_ble_text_characteristic_name">Characteristic: %1$s</string> <!-- Added this line -->
+    <string name="features_ble_ble_cd_read_characteristic">Read characteristic</string>
+    <string name="features_ble_ble_title_sensor_tag_details">Sensor Tag Details</string>
+    <string name="features_ble_ble_label_battery_level_formatted">Battery Level: %1$d%%</string>
+    <string name="features_ble_ble_label_temperature_formatted">Temperature: %1$s</string>
+    <string name="features_ble_ble_label_humidity_formatted">Humidity: %1$s</string>
+    <string name="features_ble_ble_label_last_synced_formatted">Last Synced: %1$s</string>
+    <string name="features_ble_ble_text_characteristic_value_label">Value: %1$s</string> <!-- Added this line -->
+    <string name="features_ble_ble_unit_percent">%%</string>
+    <string name="features_ble_ble_unit_celsius">°C</string>
 </resources>


### PR DESCRIPTION
This commit prefixes all string resource identifiers in the BLE feature module with `features_ble_` to prevent resource collisions and improve module isolation. It also replaces several hardcoded strings in the UI components with localized resources.

- **`features/ble/src/main/res/values/strings.xml`**:
    - Renamed all resource keys to include the `features_ble_` prefix (e.g., `ble_status_bar_title` to `features_ble_ble_status_bar_title`).
- **`features/ble/src/main/java/com/zoewave/probase/features/ble/ui/components/`**:
    - Updated `PermissionsRationale.kt`, `GattServicesCarousel.kt`, `BluetoothLeSuccessScreen.kt`, `ScanControls.kt`, `PermissionsDenied.kt`, `StatusBar.kt`, `GattCharTable.kt`, and `GattServicesList.kt` to use the new prefixed resource IDs.
- **`GattServicesCarousel.kt`**:
    - Converted hardcoded text for "Read Battery Level", "GATT Services", "UUID:", and "Characteristics:" to use `stringResource`.
    - Added a parameterized string for characteristic values.