### PR TITLE
refactor(nfc): namespace string resources

### DIFF
--- a/features/nfc/src/main/java/com/zoewave/probase/features/nfc/ui/components/screens/NfcNotSupportedScreen.kt
+++ b/features/nfc/src/main/java/com/zoewave/probase/features/nfc/ui/components/screens/NfcNotSupportedScreen.kt
@@ -26,13 +26,13 @@ fun NfcNotSupportedScreen(onRetry: () -> Unit) {
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            text = stringResource(id = R.string.nfc_not_supported_message),
+            text = stringResource(id = R.string.features_nfc_nfc_not_supported_message),
             style = MaterialTheme.typography.headlineSmall,
             color = MaterialTheme.colorScheme.error
         )
         Spacer(modifier = Modifier.height(16.dp))
         Button(onClick = onRetry) {
-            Text(stringResource(id = R.string.nfc_action_retry))
+            Text(stringResource(id = R.string.features_nfc_nfc_action_retry))
         }
     }
 }

--- a/features/nfc/src/main/java/com/zoewave/probase/features/nfc/ui/components/screens/NfcStatusBar.kt
+++ b/features/nfc/src/main/java/com/zoewave/probase/features/nfc/ui/components/screens/NfcStatusBar.kt
@@ -22,25 +22,25 @@ import com.zoewave.probase.features.nfc.ui.NfcUiState
 @Composable
 fun NfcStatusBar(uiState: NfcUiState) {
     val statusMessage = when (uiState) {
-        is NfcUiState.NfcNotSupported -> stringResource(R.string.nfc_status_not_supported)
-        is NfcUiState.NfcDisabled -> stringResource(R.string.nfc_status_disabled)
-        is NfcUiState.Stopped -> stringResource(R.string.nfc_status_ready_not_scanning)
-        is NfcUiState.WaitingForTag -> stringResource(R.string.nfc_status_waiting_for_tag)
-        is NfcUiState.TagScanned -> stringResource(R.string.nfc_status_tag_scanned)
-        is NfcUiState.Loading -> stringResource(R.string.nfc_status_loading)
-        is NfcUiState.Error -> stringResource(R.string.nfc_status_error, uiState.message)
-        is NfcUiState.WriteError -> stringResource(R.string.nfc_status_write_error, uiState.error)
+        is NfcUiState.NfcNotSupported -> stringResource(R.string.features_nfc_nfc_status_not_supported)
+        is NfcUiState.NfcDisabled -> stringResource(R.string.features_nfc_nfc_status_disabled)
+        is NfcUiState.Stopped -> stringResource(R.string.features_nfc_nfc_status_ready_not_scanning)
+        is NfcUiState.WaitingForTag -> stringResource(R.string.features_nfc_nfc_status_waiting_for_tag)
+        is NfcUiState.TagScanned -> stringResource(R.string.features_nfc_nfc_status_tag_scanned)
+        is NfcUiState.Loading -> stringResource(R.string.features_nfc_nfc_status_loading)
+        is NfcUiState.Error -> stringResource(R.string.features_nfc_nfc_status_error, uiState.message)
+        is NfcUiState.WriteError -> stringResource(R.string.features_nfc_nfc_status_write_error, uiState.error)
         is NfcUiState.WriteSuccess -> stringResource(
-            R.string.nfc_status_write_success,
+            R.string.features_nfc_nfc_status_write_success,
             uiState.message
         )
 
-        NfcUiState.Writing -> stringResource(R.string.nfc_status_writing_to_tag)
+        NfcUiState.Writing -> stringResource(R.string.features_nfc_nfc_status_writing_to_tag)
     }
 
     Row(modifier = Modifier.padding(8.dp)) {
         Text(
-            text = stringResource(R.string.nfc_status_label),
+            text = stringResource(R.string.features_nfc_nfc_status_label),
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.padding(end = 4.dp)
         )

--- a/features/nfc/src/main/res/values/strings.xml
+++ b/features/nfc/src/main/res/values/strings.xml
@@ -1,16 +1,16 @@
 <resources>
     <!-- ... existing strings ... -->
-    <string name="nfc_status_label">NFC Status:</string>
-    <string name="nfc_status_not_supported">NFC Not Supported</string>
-    <string name="nfc_status_disabled">NFC Disabled</string>
-    <string name="nfc_status_ready_not_scanning">NFC Ready (Not Scanning)</string>
-    <string name="nfc_status_waiting_for_tag">Scanning: Waiting for Tag</string>
-    <string name="nfc_status_tag_scanned">Tag Scanned</string>
-    <string name="nfc_status_loading">Loading…</string>
-    <string name="nfc_status_error" formatted="true">Error: %1$s</string>
-    <string name="nfc_status_write_error" formatted="true">Write Error: %1$s</string>
-    <string name="nfc_status_write_success" formatted="true">Write Success: %1$s</string>
-    <string name="nfc_status_writing_to_tag">Writing to Tag…</string>
-    <string name="nfc_not_supported_message">Your device does not support NFC.</string>
-    <string name="nfc_action_retry">Retry</string>
+    <string name="features_nfc_nfc_status_label">NFC Status:</string>
+    <string name="features_nfc_nfc_status_not_supported">NFC Not Supported</string>
+    <string name="features_nfc_nfc_status_disabled">NFC Disabled</string>
+    <string name="features_nfc_nfc_status_ready_not_scanning">NFC Ready (Not Scanning)</string>
+    <string name="features_nfc_nfc_status_waiting_for_tag">Scanning: Waiting for Tag</string>
+    <string name="features_nfc_nfc_status_tag_scanned">Tag Scanned</string>
+    <string name="features_nfc_nfc_status_loading">Loading…</string>
+    <string name="features_nfc_nfc_status_error" formatted="true">Error: %1$s</string>
+    <string name="features_nfc_nfc_status_write_error" formatted="true">Write Error: %1$s</string>
+    <string name="features_nfc_nfc_status_write_success" formatted="true">Write Success: %1$s</string>
+    <string name="features_nfc_nfc_status_writing_to_tag">Writing to Tag…</string>
+    <string name="features_nfc_nfc_not_supported_message">Your device does not support NFC.</string>
+    <string name="features_nfc_nfc_action_retry">Retry</string>
 </resources>


### PR DESCRIPTION
This commit prefixes all string resource identifiers in the NFC feature module with `features_nfc_` to prevent resource collisions and improve module isolation within the project.

- **`features/nfc/src/main/res/values/strings.xml`**:
    - Renamed all resource keys to include the `features_nfc_` prefix (e.g., `nfc_status_label` to `features_nfc_nfc_status_label`).
- **`NfcStatusBar.kt`**:
    - Updated all `stringResource` calls within the `NfcStatusBar` component to use the new prefixed resource IDs for various NFC UI states.
- **`NfcNotSupportedScreen.kt`**:
    - Updated resource references for the error message and retry button to use the namespaced identifiers.