### PR TITLE
feat(navigation): implement auto-navigation to home when no categorie…

### DIFF
--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/navigation/photoTodoNavEntryProvider.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/navigation/photoTodoNavEntryProvider.kt
@@ -13,7 +13,6 @@ import androidx.navigation3.runtime.NavEntry
 import com.zoewave.probase.features.camera.ui.CameraUIRoute
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.HomeOverviewScreen
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.AdaptiveHomeScreen
-import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.HomeScreen
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.HomeViewModel
 import com.zoewave.probase.photodo.mobile.features.settings.ui.SettingsUiRoute
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.SavePhotoViewModel
@@ -99,6 +98,13 @@ fun photoTodoNavEntryProvider(
                     }
 
                     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+                    // 🚀 NEW: Auto-navigate Home if no categories exist
+                    LaunchedEffect(uiState.isNoCategoriesYet) {
+                        if (uiState.isNoCategoriesYet) {
+                            navigateBack()
+                        }
+                    }
 
                     LaunchedEffect(viewModel.effects) {
                         viewModel.effects.collect { effect ->
@@ -237,6 +243,14 @@ fun photoTodoNavEntryProvider(
             is PhotoTodoRoute.CategoryTasks -> {
                 val viewModel: TasksViewModel = hiltViewModel()
                 val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+                // 🚀 NEW: Auto-navigate Home if no categories exist
+                LaunchedEffect(uiState.isNoCategoriesYet) {
+                    if (uiState.isNoCategoriesYet) {
+                        navigateBack()
+                    }
+                }
+
                 TasksListScreen(
                     uiState = uiState,
                     onEvent = viewModel::onEvent,


### PR DESCRIPTION
…s exist

This commit adds logic to automatically navigate the user back to the home screen if the UI state indicates that no categories are available. This ensures a consistent user experience when accessing task-related screens without existing category data.

- **`photoTodoNavEntryProvider.kt`**:
    - Added a `LaunchedEffect` to the `Tasks` and `CategoryTasks` route definitions to trigger `navigateBack()` when `uiState.isNoCategoriesYet` is true.
    - Removed an unused import for `HomeScreen`.