### PR TITLE
Photo do bugfixs

### DIFF
--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/PhotoDoMainScreen.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/PhotoDoMainScreen.kt
@@ -9,8 +9,10 @@ import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSiz
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass.Companion.calculateFromSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -30,7 +32,7 @@ fun PhotoDoMainScreen(
         photoTodoNavEntryProvider(key, size, to, back)
     }
 ) {
-    val backStack = remember { mutableStateListOf<PhotoTodoRoute>(PhotoTodoRoute.Home) }
+    var backStack by remember { mutableStateOf(listOf<PhotoTodoRoute>(PhotoTodoRoute.Home)) }
     val currentRoute = backStack.lastOrNull() ?: PhotoTodoRoute.Home
 
     Scaffold(
@@ -40,10 +42,11 @@ fun PhotoDoMainScreen(
                 currentRoute = currentRoute,
                 navTo = { selectedRoute ->
                     if (currentRoute != selectedRoute) {
-                        backStack.clear()
-                        backStack.add(PhotoTodoRoute.Home)
-                        if (selectedRoute != PhotoTodoRoute.Home) {
-                            backStack.add(selectedRoute)
+                        // 🚀 ATOMIC UPDATE: Ensure backstack is never transiently empty
+                        backStack = if (selectedRoute == PhotoTodoRoute.Home) {
+                            listOf(PhotoTodoRoute.Home)
+                        } else {
+                            listOf(PhotoTodoRoute.Home, selectedRoute)
                         }
                     }
                 }
@@ -53,16 +56,24 @@ fun PhotoDoMainScreen(
         NavDisplay(
             backStack = backStack,
             modifier = Modifier.padding(innerPadding),
-            onBack = { backStack.removeLastOrNull() },
+            onBack = { 
+                if (backStack.size > 1) {
+                    backStack = backStack.dropLast(1)
+                }
+            },
             entryProvider = { key ->
                 // ✅ DELEGATE: Call the provider function
                 entryProvider(
                     key,
                     windowSizeClass,
-                    { backStack.removeLastOrNull() },
+                    { 
+                        if (backStack.size > 1) {
+                            backStack = backStack.dropLast(1)
+                        }
+                    },
                     { dest ->
                         if (dest != backStack.lastOrNull()) {
-                            backStack.add(dest)
+                            backStack = backStack + dest
                         }
                     }
                 )

--- a/applications/photodo/docs/GenAI/BugFixs/implementation_plan_nav_crash.md
+++ b/applications/photodo/docs/GenAI/BugFixs/implementation_plan_nav_crash.md
@@ -1,0 +1,73 @@
+# Fix "NavDisplay backstack cannot be empty" Crash
+
+The goal is to prevent the app from crashing when the navigation backstack becomes empty, which typically happens during certain navigation transitions or when `navigateBack()` is called from a root screen.
+
+## Proposed Changes
+
+### App Components
+
+#### [PhotoDoMainScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/PhotoDoMainScreen.kt)
+
+- Refactor `backStack` from `mutableStateListOf` to `mutableStateOf(listOf(...))`. This ensures that updates to the backstack are atomic and prevents intermediate empty states.
+- Add safety checks to `onBack` and `navigateBack` to ensure the backstack always contains at least one route.
+- Refactor the `navTo` logic in the bottom bar to use atomic state replacement.
+
+```kotlin
+    var backStack by remember { mutableStateOf(listOf<PhotoTodoRoute>(PhotoTodoRoute.Home)) }
+    val currentRoute = backStack.lastOrNull() ?: PhotoTodoRoute.Home
+
+    Scaffold(
+        // ...
+        bottomBar = {
+            PhotoTodoBottomBar(
+                currentRoute = currentRoute,
+                navTo = { selectedRoute ->
+                    if (currentRoute != selectedRoute) {
+                        // 🚀 ATOMIC UPDATE: Ensure backstack is never transiently empty
+                        backStack = if (selectedRoute == PhotoTodoRoute.Home) {
+                            listOf(PhotoTodoRoute.Home)
+                        } else {
+                            listOf(PhotoTodoRoute.Home, selectedRoute)
+                        }
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        NavDisplay(
+            backStack = backStack,
+            modifier = Modifier.padding(innerPadding),
+            onBack = {
+                if (backStack.size > 1) {
+                    backStack = backStack.dropLast(1)
+                }
+            },
+            entryProvider = { key ->
+                entryProvider(
+                    key,
+                    windowSizeClass,
+                    {
+                        if (backStack.size > 1) {
+                            backStack = backStack.dropLast(1)
+                        }
+                    },
+                    { dest ->
+                        if (dest != backStack.lastOrNull()) {
+                            backStack = backStack + dest
+                        }
+                    }
+                )
+            }
+        )
+    }
+```
+
+## Verification Plan
+
+### Automated Tests
+- Run build to ensure compilation.
+
+### Manual Verification
+- Verify that bottom bar navigation still works correctly.
+- Verify that deleting the last category in the Tasks tab still navigates home without crashing.
+- Verify that pressing the system back button on the Home screen doesn't crash the app (it should ideally minimize the app or do nothing, but not crash).

--- a/applications/photodo/docs/GenAI/BugFixs/walkthrough_crash_back.md
+++ b/applications/photodo/docs/GenAI/BugFixs/walkthrough_crash_back.md
@@ -1,0 +1,55 @@
+# Walkthrough: Add Project Photo and Enhanced Quick Project Logic
+
+I've completed the implementation of project photo support and the differentiated logic for "Quick Project" and "Home Project".
+
+## Key Changes
+
+### Database & UI Models
+- **Project Photos**: Updated [ProjectWithTasks.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/entity/ProjectWithTasks.kt) and [CategoryWithProjectsAndTasks.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/entity/CategoryWithProjectsAndTasks.kt) to support fetching project photos.
+- **Thumbnail Support**: Added `thumbnailUri` to [ProjectListUiModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/state/ProjectListUiModel.kt) and updated ViewModels to populate it.
+
+### UI Components
+- **Project Thumbnails**: Modified [ProjectRow.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/ProjectRow.kt) and [ProjectCard.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/ProjectCard.kt) to display photo thumbnails using Coil's `AsyncImage`.
+- **Quick Project Bottom Sheet**: Created [QuickProjectBottomSheet.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/QuickProjectBottomSheet.kt) with templates for Quick Fix, Quick Buy, and Quick Find.
+
+### Project Creation Logic
+- **Differentiated Category Assignment**:
+    - **Quick Project** (from project list screen) adds projects to the **current category**. If no categories exist yet, it defaults to a "**Default**" category.
+    - **Home Project** (from home screen) always adds projects to the "**Home**" category (creating it if it doesn't exist).
+- **Fixed Empty State Visibility**: Refactored `HomeUiState` to ensure the "**Home Project**" menu can be opened even when no categories exist yet.
+- **Default Task Creation**: Projects created via these templates automatically include a default task (e.g., "fix quick task").
+- **Name Collision Handling**: Automatically appends a number (e.g., "fix 1", "fix 2") if a project with the same name already exists.
+
+## Navigation Enhancements
+- **Automatic Back Navigation**: Implemented a side-effect mechanism to automatically navigate the user back to the previous screen level after a successful deletion.
+    - Deleting a **Category** takes you back to the **Home** dashboard.
+    - Deleting a **Project** takes you back to the **Category's project list**.
+- **Empty Tasks Tab Redirection**: Added logic to automatically navigate to the Home screen if the user is on the Tasks tab and no categories exist in the database.
+- **Side Effect Channel**: Added a `TasksSideEffect` channel to `TasksViewModel` and `TaskDetailViewModel` to decouple business logic from navigation.
+
+## Crash Fixes
+- **NavDisplay Stability**: Fixed a `java.lang.IllegalArgumentException: NavDisplay backstack cannot be empty` crash by refactoring the navigation backstack to use atomic updates. This ensures the backstack always contains at least one route during transitions.
+
+## Dark Code: Time Tracking & Budgeting
+- **Reusable Feature Module**: Created a new `:applications:photodo:features:timebudgeting` module to house the UI and logic for time management. This module is currently "**dark code**" and is not linked to the rest of the application.
+- **Isolated Schema**: Integrated "**Time Tracking**" and "**Time Budgeting**" in the database layer.
+- **Architectural Isolation**:
+    - Created new sub-packages: `entity/time` and `repo/time` in the `db` module.
+    - Implemented `TimeBudgetScreen` and `TimeBudgetViewModel` within the new feature module, using `internal` visibility to keep them encapsulated.
+- **AutoMigrations**: Incremented database version to **3** and implemented Room `AutoMigrations` (from 1 to 2, and 2 to 3).
+- **New Budgeting Features**:
+    - Added `estimatedTimeMillis` to `TaskEntity`.
+    - Introduced `TimeBudgetEntity` for category-level goals.
+    - Created a reactive `TimeBudgetViewModel` that aggregates category data and spending limits.
+
+## Verification Summary
+
+### Automated Tests
+- Successfully ran builds for `:applications:photodo:apps:mobile:features:home`, `:applications:photodo:apps:mobile:features:tasks`, `:applications:photodo:db`, and the new `:applications:photodo:features:timebudgeting`.
+- Verified that Room generated the `2.json` and `3.json` schema files.
+
+### Manual Verification
+- Verified the dynamic UI of the `QuickProjectBottomSheet` through Compose Previews, confirming it correctly switches between "Quick Project" and "Home Project" based on the context.
+- Confirmed project thumbnail rendering and fallback logic in `ProjectRow` and `ProjectCard`.
+
+![Quick Project Bottom Sheet](file:///Users/developer/Library/Caches/Google/AndroidStudio2025.3.4/projects/probase.459da513/.artifacts/20260408-121845-f050a219-5417-4b19-9eb3-6b3efdb80dfe/QuickProjectBottomSheetPreview.png)


### PR DESCRIPTION
refactor(ui): implement atomic backstack updates for navigation

This commit refactors the backstack management in `PhotoDoMainScreen` to use an immutable list state instead of a mutable state list. This ensures that navigation updates are atomic, preventing transiently empty states and ensuring the root destination is preserved.

- **`PhotoDoMainScreen.kt`**:
    - Replaced `mutableStateListOf` with `mutableStateOf(listOf(...))` to enable atomic state overrides for the `backStack`.
    - Updated `navTo` logic to assign a new list based on the selected route, ensuring the `Home` route remains the base of the stack.
    - Modified `onBack` and the navigation provider's back logic to prevent dropping the last remaining element in the stack.
    - Transitioned from imperative `add` and `removeLastOrNull` operations to functional list concatenations and `dropLast` calls.