### PR TITLE
Calendar

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-03-14T18:49:01.370230Z">
+        <DropdownSelection timestamp="2026-04-10T21:30:14.157341Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_9a.avd" />

--- a/features/calendar/build.gradle.kts
+++ b/features/calendar/build.gradle.kts
@@ -20,4 +20,5 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.google.accompanist.permissions)
 }

--- a/features/calendar/build.gradle.kts
+++ b/features/calendar/build.gradle.kts
@@ -18,4 +18,6 @@ dependencies {
     // --- Third Party ---
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.hilt.navigation.compose)
 }

--- a/features/calendar/src/main/AndroidManifest.xml
+++ b/features/calendar/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+</manifest>

--- a/features/calendar/src/main/java/com/zoewave/probase/features/calendar/ui/CalendarUiRoute.kt
+++ b/features/calendar/src/main/java/com/zoewave/probase/features/calendar/ui/CalendarUiRoute.kt
@@ -1,22 +1,145 @@
 package com.zoewave.probase.features.calendar.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.zoewave.probase.features.calendar.domain.CalendarEventModel
+import com.zoewave.probase.features.calendar.ui.state.CalendarUiState
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @Composable
-fun CalendarUiRoute() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        contentAlignment = Alignment.Center
+fun CalendarUiRoute(
+    viewModel: CalendarViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    CalendarScreen(
+        uiState = uiState,
+        onDeleteEvent = viewModel::deleteEvent
+    )
+}
+
+@Composable
+internal fun CalendarScreen(
+    uiState: CalendarUiState,
+    onDeleteEvent: (Long) -> Unit
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        if (uiState.isLoading) {
+            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+        } else if (uiState.errorMessage != null) {
+            Text(
+                text = "Error: ${uiState.errorMessage}",
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.align(Alignment.Center).padding(16.dp)
+            )
+        } else if (uiState.events.isEmpty()) {
+            Text(
+                text = "No calendar events found for the current month.",
+                modifier = Modifier.align(Alignment.Center).padding(16.dp)
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                item {
+                    Text(
+                        text = "System Calendar Events",
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                }
+                items(uiState.events, key = { it.id }) { event ->
+                    CalendarEventItem(
+                        event = event,
+                        onDelete = { onDeleteEvent(event.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CalendarEventItem(
+    event: CalendarEventModel,
+    onDelete: () -> Unit
+) {
+    val dateFormatter = SimpleDateFormat("MMM dd, HH:mm", Locale.getDefault())
+    val startStr = dateFormatter.format(Date(event.startTimeMillis))
+    val endStr = dateFormatter.format(Date(event.endTimeMillis))
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
     ) {
-        Text("System Calendar feature logic implemented (Provider/Repository). UI coming soon.")
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Event,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(end = 16.dp)
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = event.title,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = "$startStr - $endStr",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (!event.location.isNullOrBlank()) {
+                    Text(
+                        text = event.location,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+            IconButton(onClick = onDelete) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete Event",
+                    tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f)
+                )
+            }
+        }
     }
 }

--- a/features/calendar/src/main/java/com/zoewave/probase/features/calendar/ui/CalendarUiRoute.kt
+++ b/features/calendar/src/main/java/com/zoewave/probase/features/calendar/ui/CalendarUiRoute.kt
@@ -5,15 +5,19 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Event
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -26,24 +30,85 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.google.accompanist.permissions.shouldShowRationale
 import com.zoewave.probase.features.calendar.domain.CalendarEventModel
 import com.zoewave.probase.features.calendar.ui.state.CalendarUiState
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun CalendarUiRoute(
     viewModel: CalendarViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-
-    CalendarScreen(
-        uiState = uiState,
-        onDeleteEvent = viewModel::deleteEvent
+    val calendarPermissionsState = rememberMultiplePermissionsState(
+        listOf(
+            android.Manifest.permission.READ_CALENDAR,
+            android.Manifest.permission.WRITE_CALENDAR
+        )
     )
+
+    if (calendarPermissionsState.allPermissionsGranted) {
+        val uiState by viewModel.uiState.collectAsState()
+        CalendarScreen(
+            uiState = uiState,
+            onDeleteEvent = viewModel::deleteEvent
+        )
+    } else {
+        PermissionRequestContent(
+            permissionsState = calendarPermissionsState
+        )
+    }
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+private fun PermissionRequestContent(
+    permissionsState: MultiplePermissionsState
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.Event,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Calendar Permissions Required",
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        val textToShow = if (permissionsState.shouldShowRationale) {
+            "PhotoDo needs access to your calendar to sync your tasks and events. Please grant the permission."
+        } else {
+            "Access to your system calendar is required to use this feature. Please grant the necessary permissions."
+        }
+        Text(
+            text = textToShow,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = { permissionsState.launchMultiplePermissionRequest() }) {
+            Text("Grant Permissions")
+        }
+    }
 }
 
 @Composable

--- a/features/calendar/src/main/java/com/zoewave/probase/features/calendar/ui/CalendarViewModel.kt
+++ b/features/calendar/src/main/java/com/zoewave/probase/features/calendar/ui/CalendarViewModel.kt
@@ -1,0 +1,46 @@
+package com.zoewave.probase.features.calendar.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zoewave.probase.features.calendar.domain.CalendarEventModel
+import com.zoewave.probase.features.calendar.domain.CalendarRepository
+import com.zoewave.probase.features.calendar.ui.state.CalendarUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CalendarViewModel @Inject constructor(
+    private val calendarRepository: CalendarRepository
+) : ViewModel() {
+
+    // Default query range: last 30 days to next 30 days
+    private val currentTime = System.currentTimeMillis()
+    private val monthInMillis = 30L * 24 * 60 * 60 * 1000
+
+    val uiState: StateFlow<CalendarUiState> = calendarRepository
+        .queryEvents(currentTime - monthInMillis, currentTime + monthInMillis)
+        .map { events ->
+            CalendarUiState(events = events)
+        }
+        .catch { e ->
+            emit(CalendarUiState(errorMessage = e.message))
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = CalendarUiState(isLoading = true)
+        )
+
+    fun deleteEvent(eventId: Long) {
+        viewModelScope.launch {
+            calendarRepository.deleteEvent(eventId)
+        }
+    }
+}

--- a/features/calendar/src/main/java/com/zoewave/probase/features/calendar/ui/state/CalendarUiState.kt
+++ b/features/calendar/src/main/java/com/zoewave/probase/features/calendar/ui/state/CalendarUiState.kt
@@ -1,0 +1,11 @@
+package com.zoewave.probase.features.calendar.ui.state
+
+import androidx.compose.runtime.Immutable
+import com.zoewave.probase.features.calendar.domain.CalendarEventModel
+
+@Immutable
+data class CalendarUiState(
+    val isLoading: Boolean = false,
+    val events: List<CalendarEventModel> = emptyList(),
+    val errorMessage: String? = null
+)


### PR DESCRIPTION
feat(calendar): implement runtime permissions for calendar access

This commit introduces a runtime permission handling flow for the calendar feature using the Accompanist Permissions library. It ensures the application requests and verifies access to system calendar data before displaying the event list, providing a better user experience and adhering to Android's privacy requirements.

- **`CalendarUiRoute.kt`**:
    - Integrated `rememberMultiplePermissionsState` to manage `READ_CALENDAR` and `WRITE_CALENDAR` permissions.
    - Added a `PermissionRequestContent` composable to display rationale and a "Grant Permissions" button when access is not yet provided.
    - Updated the main entry point to conditionally display either the calendar content or the permission request screen based on the current state.
- **`AndroidManifest.xml`**:
    - Declared `READ_CALENDAR` and `WRITE_CALENDAR` permissions for the calendar feature module.
- **`build.gradle.kts`**:
    - Added the `google.accompanist.permissions` dependency to support the modern permission request flow in Compose.
- **`.idea/deploymentTargetSelector.xml`**:
    - Updated deployment target metadata.