### PR TITLE
Photodo polish

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-10T21:30:14.157341Z">
+        <DropdownSelection timestamp="2026-04-10T21:43:03.074403Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_9a.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_10_Pro_Fold.avd" />
             </handle>
           </Target>
         </DropdownSelection>
@@ -37,10 +37,10 @@
       </SelectionState>
       <SelectionState runConfigName="applications.photodo.apps.mobile">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-10T20:29:47.689366Z">
+        <DropdownSelection timestamp="2026-04-10T21:44:08.899768Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_9a.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_10_Pro_Fold.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -84,7 +84,7 @@
       </SelectionState>
       <SelectionState runConfigName="applications.photodo.apps.wear">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-10T00:30:13.354442Z">
+        <DropdownSelection timestamp="2026-04-10T22:14:56.492424Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_10_Pro_Fold.avd" />

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/HomeUiModels.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/HomeUiModels.kt
@@ -19,6 +19,7 @@ data class HomeOverviewSummaryUiModel(
 data class CategoryQuickJumpUiModel(
     val id: Long,
     val name: String,
+    val totalProjects: Int,
     val progressText: String, // e.g., "5/50 Tasks"
     val progressPercentage: Float, // For the tiny progress bar
     val containerColor: Color,

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/CategoryOverviewUiModel.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/CategoryOverviewUiModel.kt
@@ -3,6 +3,7 @@ package com.zoewave.probase.photodo.mobile.features.home.ui.components.categorie
 data class CategoryOverviewUiModel(
     val id: Long,
     val name: String,
+    val totalProjects: Int,
     val totalTasks: Int,
     val completedTasks: Int,
     val progressPercentage: Float // 0.0f to 1.0f

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
@@ -562,9 +562,14 @@ fun CategoryDashboardCard(
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
+                    text = "${category.totalProjects} Projects",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = contentColor.copy(alpha = 0.8f)
+                )
+                Text(
                     text = stringResource(R.string.applications_photodo_apps_mobile_features_home_tasks_count, category.completedTasks, category.totalTasks),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = contentColor.copy(alpha = 0.8f) // Slightly dim the subtitle
+                    color = contentColor.copy(alpha = 0.8f)
                 )
             }
 
@@ -628,6 +633,7 @@ private fun HomeOverviewScreenPopulatedPreview() {
             CategoryOverviewUiModel(
                 id = 1L,
                 name = "Real Estate",
+                totalProjects = 3,
                 totalTasks = 24,
                 completedTasks = 18,
                 progressPercentage = 0.75f
@@ -635,6 +641,7 @@ private fun HomeOverviewScreenPopulatedPreview() {
             CategoryOverviewUiModel(
                 id = 2L,
                 name = "Development",
+                totalProjects = 5,
                 totalTasks = 50,
                 completedTasks = 5,
                 progressPercentage = 0.10f
@@ -642,6 +649,7 @@ private fun HomeOverviewScreenPopulatedPreview() {
             CategoryOverviewUiModel(
                 id = 3L,
                 name = "Business",
+                totalProjects = 2,
                 totalTasks = 12,
                 completedTasks = 12,
                 progressPercentage = 1.0f
@@ -649,6 +657,7 @@ private fun HomeOverviewScreenPopulatedPreview() {
             CategoryOverviewUiModel(
                 id = 4L,
                 name = "Personal",
+                totalProjects = 4,
                 totalTasks = 8,
                 completedTasks = 4,
                 progressPercentage = 0.50f
@@ -656,6 +665,7 @@ private fun HomeOverviewScreenPopulatedPreview() {
             CategoryOverviewUiModel(
                 id = 5L,
                 name = "Hobbies",
+                totalProjects = 0,
                 totalTasks = 0,
                 completedTasks = 0,
                 progressPercentage = 0.0f

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
@@ -1,5 +1,8 @@
 package com.zoewave.probase.photodo.mobile.features.home.ui.components.categories
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -94,6 +97,7 @@ fun HomeOverviewScreen(
     var showAddCategorySheet by rememberSaveable { mutableStateOf(false) }
     var categoryToDelete by remember { mutableStateOf<CategoryOverviewUiModel?>(null) }
     var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
+    var isSearchMode by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -120,6 +124,8 @@ fun HomeOverviewScreen(
     ) { innerPadding ->
         HomeOverviewContent(
             uiState = uiState,
+            isSearchMode = isSearchMode,
+            onSearchModeChange = { isSearchMode = it },
             onEvent = onEvent,
             navTo = navTo,
             onDeleteClicked = { categoryToDelete = it },
@@ -191,12 +197,22 @@ fun HomeOverviewFab(
 @Composable
 fun HomeOverviewContent(
     uiState: HomeUiState,
+    isSearchMode: Boolean,
+    onSearchModeChange: (Boolean) -> Unit,
     onEvent: (HomeEvent) -> Unit,
     navTo: (PhotoTodoRoute?) -> Unit,
     onDeleteClicked: (CategoryOverviewUiModel) -> Unit,
     modifier: Modifier = Modifier,
     showSummaryHeader: Boolean = true
 ) {
+    val filteredCategories = remember(uiState.categories, uiState.searchQuery) {
+        if (uiState.searchQuery.isBlank()) {
+            uiState.categories
+        } else {
+            uiState.categories.filter { it.name.contains(uiState.searchQuery, ignoreCase = true) }
+        }
+    }
+
     Box(
         modifier = modifier.fillMaxSize()
     ) {
@@ -218,36 +234,68 @@ fun HomeOverviewContent(
             ) {
                 // --- 🚀 NEW: Header Row (Shortcuts) ---
                 item(span = { GridItemSpan(2) }) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 8.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
+                    AnimatedVisibility(
+                        visible = isSearchMode,
+                        enter = fadeIn(),
+                        exit = fadeOut()
                     ) {
-                        Text(
-                            text = "PhotoDo",
-                            style = MaterialTheme.typography.headlineMedium,
-                            fontWeight = FontWeight.Black,
-                            color = MaterialTheme.colorScheme.primary
+                        OutlinedTextField(
+                            value = uiState.searchQuery,
+                            onValueChange = { onEvent(HomeEvent.OnSearchQueryChanged(it)) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 8.dp),
+                            placeholder = { Text("Search categories...") },
+                            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                            trailingIcon = {
+                                IconButton(onClick = {
+                                    onEvent(HomeEvent.OnSearchQueryChanged(""))
+                                    onSearchModeChange(false)
+                                }) {
+                                    Icon(Icons.Default.Close, contentDescription = "Close search")
+                                }
+                            },
+                            singleLine = true,
+                            shape = RoundedCornerShape(16.dp)
                         )
-                        IconButton(
-                            onClick = { /* TODO: Search */ },
-                            modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
+                    }
+
+                    AnimatedVisibility(
+                        visible = !isSearchMode,
+                        enter = fadeIn(),
+                        exit = fadeOut()
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 8.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Icon(Icons.Default.Search, contentDescription = "Search")
+                            Text(
+                                text = "PhotoDo",
+                                style = MaterialTheme.typography.headlineMedium,
+                                fontWeight = FontWeight.Black,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            IconButton(
+                                onClick = { onSearchModeChange(true) },
+                                modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
+                            ) {
+                                Icon(Icons.Default.Search, contentDescription = "Search")
+                            }
                         }
                     }
                 }
 
-                if (showSummaryHeader) {
+                if (showSummaryHeader && !isSearchMode) {
                     item(span = { GridItemSpan(2) }) {
                         OverviewSummaryCard(categories = uiState.categories)
                     }
                 }
 
                 itemsIndexed(
-                    items = uiState.categories,
+                    items = filteredCategories,
                     key = { _, category -> category.id }
                 ) { index, category ->
                     CategoryDashboardCard(

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
@@ -1,5 +1,7 @@
 package com.zoewave.probase.photodo.mobile.features.home.ui.components.categories
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,6 +18,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -23,8 +26,15 @@ import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Flight
 import androidx.compose.material.icons.filled.FolderSpecial
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.Work
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -37,6 +47,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -44,6 +55,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.ToggleFloatingActionButton
 import androidx.compose.material3.ToggleFloatingActionButtonDefaults.animateIcon
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -54,6 +66,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -78,7 +91,7 @@ fun HomeOverviewScreen(
 ) {
 
     // Add these state variables at the top of your composable
-    var showAddCategoryDialog by rememberSaveable { mutableStateOf(false) }
+    var showAddCategorySheet by rememberSaveable { mutableStateOf(false) }
     var categoryToDelete by remember { mutableStateOf<CategoryOverviewUiModel?>(null) }
     var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
 
@@ -91,7 +104,7 @@ fun HomeOverviewScreen(
                 onFabToggle = { fabMenuExpanded = it },
                 onAddCategoryClick = {
                     fabMenuExpanded = false
-                    showAddCategoryDialog = true
+                    showAddCategorySheet = true
                 },
                 onHomeProjectClick = { // Updated parameter name
                     fabMenuExpanded = false
@@ -117,8 +130,8 @@ fun HomeOverviewScreen(
     // ... inside HomeOverviewScreen, just below the Scaffold closing brace ...
 
     HomeOverviewDialogs(
-        showAddCategoryDialog = showAddCategoryDialog,
-        onDismissAddCategory = { showAddCategoryDialog = false },
+        showAddCategorySheet = showAddCategorySheet,
+        onDismissAddCategory = { showAddCategorySheet = false },
         uiState = uiState, // Pass the UI State!
         categoryToDelete = categoryToDelete,
         onDismissDeleteConfirmation = { categoryToDelete = null },
@@ -203,6 +216,30 @@ fun HomeOverviewContent(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier.fillMaxSize()
             ) {
+                // --- 🚀 NEW: Header Row (Shortcuts) ---
+                item(span = { GridItemSpan(2) }) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "PhotoDo",
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.Black,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        IconButton(
+                            onClick = { /* TODO: Search */ },
+                            modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
+                        ) {
+                            Icon(Icons.Default.Search, contentDescription = "Search")
+                        }
+                    }
+                }
+
                 if (showSummaryHeader) {
                     item(span = { GridItemSpan(2) }) {
                         OverviewSummaryCard(categories = uiState.categories)
@@ -228,46 +265,19 @@ fun HomeOverviewContent(
 
 @Composable
 fun HomeOverviewDialogs(
-    showAddCategoryDialog: Boolean,
+    showAddCategorySheet: Boolean,
     onDismissAddCategory: () -> Unit,
     uiState: HomeUiState,
     categoryToDelete: CategoryOverviewUiModel?,
     onDismissDeleteConfirmation: () -> Unit,
     onEvent: (HomeEvent) -> Unit
 ) {
-    var newCategoryName by rememberSaveable { mutableStateOf("") }
-
-    if (showAddCategoryDialog) {
-        AlertDialog(
-            onDismissRequest = onDismissAddCategory,
-            title = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_new_category)) },
-            text = {
-                OutlinedTextField(
-                    value = newCategoryName,
-                    onValueChange = { newCategoryName = it },
-                    placeholder = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_category_placeholder)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        if (newCategoryName.isNotBlank()) {
-                            onEvent(HomeEvent.OnAddCategory(newCategoryName.trim()))
-                            newCategoryName = "" // Reset
-                            onDismissAddCategory()
-                        }
-                    }
-                ) { Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_create)) }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        newCategoryName = ""
-                        onDismissAddCategory()
-                    }
-                ) { Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_cancel)) }
+    if (showAddCategorySheet) {
+        AddCategoryBottomSheet(
+            onDismiss = onDismissAddCategory,
+            onCategoryCreated = { name, iconName ->
+                onEvent(HomeEvent.OnAddCategory(name = name, iconUri = iconName))
+                onDismissAddCategory()
             }
         )
     }
@@ -309,6 +319,106 @@ fun HomeOverviewDialogs(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddCategoryBottomSheet(
+    onDismiss: () -> Unit,
+    onCategoryCreated: (String, String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var newCategoryName by rememberSaveable { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.applications_photodo_apps_mobile_features_home_new_category),
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            // --- QUICK PICK SECTION ---
+            Text(
+                text = "Quick Pick",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                categoryTemplates.forEach { template ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Surface(
+                            modifier = Modifier
+                                .size(48.dp)
+                                .clip(CircleShape)
+                                .clickable {
+                                    onCategoryCreated(template.name, template.iconName)
+                                },
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            shape = CircleShape
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(
+                                    imageVector = template.icon,
+                                    contentDescription = template.name,
+                                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                            }
+                        }
+                        Text(
+                            text = template.name,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = newCategoryName,
+                onValueChange = { newCategoryName = it },
+                label = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_category_placeholder)) },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Button(
+                onClick = { onCategoryCreated(newCategoryName, "FolderSpecial") },
+                enabled = newCategoryName.isNotBlank(),
+                modifier = Modifier.align(Alignment.End)
+            ) {
+                Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_create))
+            }
+        }
+    }
+}
+
+private data class CategoryTemplate(val name: String, val icon: ImageVector, val iconName: String)
+
+private val categoryTemplates = listOf(
+    CategoryTemplate("Work", Icons.Default.Work, "Work"),
+    CategoryTemplate("Personal", Icons.Default.Person, "Person"),
+    CategoryTemplate("Home", Icons.Default.Home, "Home"),
+    CategoryTemplate("Shopping", Icons.Default.ShoppingCart, "ShoppingCart"),
+    CategoryTemplate("Travel", Icons.Default.Flight, "Flight")
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -367,16 +477,30 @@ fun CategoryDashboardCard(
                     }
                 }
 
-                IconButton(
-                    onClick = { onDeleteClicked(category) },
-                    modifier = Modifier.size(32.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Delete,
-                        contentDescription = "Delete Category",
-                        tint = contentColor.copy(alpha = 0.7f),
-                        modifier = Modifier.size(20.dp)
-                    )
+                Row {
+                    /*IconButton(
+                        onClick = { onEvent(HomeEvent.OnAddQuickProjectClicked(category.name)) },
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = "Quick Project",
+                            tint = contentColor.copy(alpha = 0.7f),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }*/
+
+                    IconButton(
+                        onClick = { onDeleteClicked(category) },
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete Category",
+                            tint = contentColor.copy(alpha = 0.7f),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
             }
 

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeScreenCat.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeScreenCat.kt
@@ -90,6 +90,10 @@ private fun CategoryCard(
                     style = MaterialTheme.typography.titleLarge
                 )
                 Text(
+                    text = "${category.totalProjects} Projects",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
                     text = "${category.completedTasks} / ${category.totalTasks} tasks completed",
                     style = MaterialTheme.typography.bodyMedium
                 )
@@ -120,10 +124,10 @@ fun HomeScreenCatPreview_Success() {
         uiState = HomeUiState(
             categories = listOf(
                 CategoryOverviewUiModel(
-                    1, "Work", 10, 5, 0.5f
+                    1, "Work", 3, 10, 5, 0.5f
                 ),
                 CategoryOverviewUiModel(
-                    2, "Personal", 5, 5, 1.0f
+                    2, "Personal", 2, 5, 5, 1.0f
                 )
             ),
             urgentProjects = emptyList()

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
@@ -187,8 +187,8 @@ fun AdaptiveHomeScreenPreviewCompact() {
         AdaptiveHomeScreen(
             uiState = HomeUiState(
                 categories = listOf(
-                    CategoryOverviewUiModel(1L, "Work", 10, 5, 0.5f),
-                    CategoryOverviewUiModel(2L, "Personal", 5, 2, 0.4f)
+                    CategoryOverviewUiModel(1L, "Work", 3, 10, 5, 0.5f),
+                    CategoryOverviewUiModel(2L, "Personal", 2, 5, 2, 0.4f)
                 ),
                 urgentProjects = listOf(
                     ProjectListUiModel(1L, "Project A", "Work", isUrgent = true),
@@ -210,8 +210,8 @@ fun AdaptiveHomeScreenPreviewExpanded() {
         AdaptiveHomeScreen(
             uiState = HomeUiState(
                 categories = listOf(
-                    CategoryOverviewUiModel(1L, "Work", 10, 5, 0.5f),
-                    CategoryOverviewUiModel(2L, "Personal", 5, 2, 0.4f)
+                    CategoryOverviewUiModel(1L, "Work", 3, 10, 5, 0.5f),
+                    CategoryOverviewUiModel(2L, "Personal", 2, 5, 2, 0.4f)
                 ),
                 urgentProjects = listOf(
                     ProjectListUiModel(1L, "Project A", "Work", isUrgent = true),

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
@@ -66,6 +66,7 @@ fun AdaptiveHomeScreen(
         var showAddCategoryDialog by rememberSaveable { mutableStateOf(false) }
         var categoryToDelete by remember { mutableStateOf<CategoryOverviewUiModel?>(null) }
         var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
+        var isSearchMode by rememberSaveable { mutableStateOf(false) }
 
         Scaffold(
             modifier = modifier.fillMaxSize(),
@@ -154,6 +155,8 @@ fun AdaptiveHomeScreen(
                     // RIGHT PANE: The Directory (Full Category Grid)
                     HomeOverviewContent(
                         uiState = uiState,
+                        isSearchMode = isSearchMode,
+                        onSearchModeChange = { isSearchMode = it },
                         onEvent = onEvent,
                         navTo = { route -> if (route != null) navTo(route) },
                         onDeleteClicked = { categoryToDelete = it },

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
@@ -166,7 +166,7 @@ fun AdaptiveHomeScreen(
         }
 
         HomeOverviewDialogs(
-            showAddCategoryDialog = showAddCategoryDialog,
+            showAddCategorySheet = showAddCategoryDialog,
             onDismissAddCategory = { showAddCategoryDialog = false },
             uiState = uiState,
             categoryToDelete = categoryToDelete,

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/CategoryQuickJumpCard.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/CategoryQuickJumpCard.kt
@@ -70,9 +70,12 @@ fun CategoryQuickJumpCard(
             // Progress details
             Column {
                 Text(
+                    text = "${model.totalProjects} Projects",
+                    style = MaterialTheme.typography.labelSmall,
+                )
+                Text(
                     text = model.progressText,
-                    style = MaterialTheme.typography.bodySmall,
-                    // color = contentColor.copy(alpha = 0.8f) 
+                    style = MaterialTheme.typography.labelSmall,
                 )
 
                 // Tiny progress bar
@@ -98,6 +101,7 @@ private fun CategoryQuickJumpCardPreview() {
             model = CategoryQuickJumpUiModel(
                 id = 1L,
                 name = "Nature",
+                totalProjects = 12,
                 progressText = "5/10 Tasks",
                 progressPercentage = 0.5f,
                 containerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/CategoryQuickJumpRow.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/CategoryQuickJumpRow.kt
@@ -121,6 +121,7 @@ fun CategoryQuickJumpRow(
                     val mappedModel = CategoryQuickJumpUiModel(
                         id = category.id,
                         name = category.name,
+                        totalProjects = category.totalProjects,
                         progressText = stringResource(R.string.applications_photodo_apps_mobile_features_home_tasks_count, category.completedTasks, category.totalTasks),
                         progressPercentage = category.progressPercentage,
                         containerColor = containerColor,
@@ -146,6 +147,7 @@ private fun CategoryQuickJumpRowPreview() {
             CategoryOverviewUiModel(
                 id = 1L,
                 name = "Real Estate",
+                totalProjects = 3,
                 totalTasks = 24,
                 completedTasks = 18,
                 progressPercentage = 0.75f
@@ -153,6 +155,7 @@ private fun CategoryQuickJumpRowPreview() {
             CategoryOverviewUiModel(
                 id = 2L,
                 name = "Development",
+                totalProjects = 5,
                 totalTasks = 50,
                 completedTasks = 5,
                 progressPercentage = 0.10f
@@ -160,6 +163,7 @@ private fun CategoryQuickJumpRowPreview() {
             CategoryOverviewUiModel(
                 id = 3L,
                 name = "Business",
+                totalProjects = 2,
                 totalTasks = 12,
                 completedTasks = 12,
                 progressPercentage = 1.0f
@@ -167,6 +171,7 @@ private fun CategoryQuickJumpRowPreview() {
             CategoryOverviewUiModel(
                 id = 4L,
                 name = "Personal",
+                totalProjects = 4,
                 totalTasks = 8,
                 completedTasks = 4,
                 progressPercentage = 0.50f

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
@@ -14,5 +14,6 @@ sealed interface HomeEvent {
     data class OnDeleteCategory(val categoryId: Long) : HomeEvent
 
     data class OnAddQuickProjectClicked(val overrideCategoryName: String? = null) : HomeEvent
+    data class OnSearchQueryChanged(val query: String) : HomeEvent
     data object OnDismissBottomSheet : HomeEvent
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
@@ -9,7 +9,7 @@ sealed interface HomeEvent {
 
     data class OnCategoryClicked(val categoryId: Long, val categoryName: String) :HomeEvent
     // ✅ ADD THE NEW EVENT
-    data class OnAddCategory(val name: String, val description: String? = null) : HomeEvent
+    data class OnAddCategory(val name: String, val iconUri: String? = null, val colorHex: String? = null, val description: String? = null) : HomeEvent
     data class OnCreateFromTemplate(val template: ProjectTemplate) : HomeEvent
     data class OnDeleteCategory(val categoryId: Long) : HomeEvent
 

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeOverviewVisualMapper.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeOverviewVisualMapper.kt
@@ -60,10 +60,10 @@ fun mapCategoriesToWheelSlices(
 @Composable
 fun MapCategoriesToWheelSlicesPreview() {
     val sampleCategories = listOf(
-        CategoryOverviewUiModel(1, "Work", 10, 5, 0.5f),
-        CategoryOverviewUiModel(2, "Personal", 5, 2, 0.4f),
-        CategoryOverviewUiModel(3, "Shopping", 3, 3, 1.0f),
-        CategoryOverviewUiModel(4, "Health", 2, 0, 0f)
+        CategoryOverviewUiModel(1, "Work", 3, 10, 5, 0.5f),
+        CategoryOverviewUiModel(2, "Personal", 2, 5, 2, 0.4f),
+        CategoryOverviewUiModel(3, "Shopping", 1, 3, 3, 1.0f),
+        CategoryOverviewUiModel(4, "Health", 1, 2, 0, 0f)
     )
 
     PhotoDoTheme {

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
@@ -175,8 +175,8 @@ private fun HomeScreenPreview() {
         HomeScreen(
             uiState = HomeUiState(
                 categories = listOf(
-                    CategoryOverviewUiModel(1L, "Nature", 10, 5, 0.5f),
-                    CategoryOverviewUiModel(2L, "Urban", 8, 2, 0.25f)
+                    CategoryOverviewUiModel(1L, "Nature", 3, 10, 5, 0.5f),
+                    CategoryOverviewUiModel(2L, "Urban", 2, 8, 2, 0.25f)
                 ),
                 urgentProjects = listOf(
                     ProjectListUiModel(

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
@@ -8,13 +8,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -32,12 +28,11 @@ import androidx.compose.ui.unit.dp
 import com.zoewave.probase.photodo.mobile.core.ui.theme.PhotoDoTheme
 import com.zoewave.probase.photodo.mobile.features.home.R
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.CategoryOverviewUiModel
+import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.HomeOverviewDialogs
+import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.HomeOverviewFab
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.state.ProjectListUiModel
 import com.zoewave.probase.photodo.model.navigation.PhotoTodoRoute
 import components.home.CategoryQuickJumpRow
-
-import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.HomeOverviewDialogs
-import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.HomeOverviewFab
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -161,7 +156,7 @@ fun HomeScreen(
     }
 
     HomeOverviewDialogs(
-        showAddCategoryDialog = showAddCategoryDialog,
+        showAddCategorySheet = showAddCategoryDialog,
         onDismissAddCategory = { showAddCategoryDialog = false },
         uiState = uiState,
         categoryToDelete = categoryToDelete,

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
@@ -10,7 +10,8 @@ data class HomeUiState(
     val categories: List<CategoryOverviewUiModel> = emptyList(),
     val urgentProjects: List<ProjectListUiModel> = emptyList(),
     val isQuickProjectSheetOpen: Boolean = false,
-    val quickProjectCategoryOverride: String? = null
+    val quickProjectCategoryOverride: String? = null,
+    val searchQuery: String = ""
 ) {
     val isEmpty: Boolean = !isLoading && categories.isEmpty()
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
@@ -34,7 +34,8 @@ class HomeViewModel @Inject constructor(
 
     private data class UiFlags(
         val isQuickProjectSheetOpen: Boolean = false,
-        val quickProjectCategoryOverride: String? = null
+        val quickProjectCategoryOverride: String? = null,
+        val searchQuery: String = ""
     )
 
     private val _uiFlags = MutableStateFlow(UiFlags())
@@ -101,7 +102,8 @@ class HomeViewModel @Inject constructor(
                 categories = overviewModels,
                 urgentProjects = urgentProjects,
                 isQuickProjectSheetOpen = flags.isQuickProjectSheetOpen,
-                quickProjectCategoryOverride = flags.quickProjectCategoryOverride
+                quickProjectCategoryOverride = flags.quickProjectCategoryOverride,
+                searchQuery = flags.searchQuery
             )
         }
         .flowOn(Dispatchers.Default)
@@ -192,6 +194,12 @@ class HomeViewModel @Inject constructor(
                     } catch (e: Exception) {
                         Log.e(TAG, "Error deleting category", e)
                     }
+                }
+            }
+
+            is HomeEvent.OnSearchQueryChanged -> {
+                _uiFlags.update { 
+                    it.copy(searchQuery = event.query)
                 }
             }
         }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
@@ -91,6 +91,7 @@ class HomeViewModel @Inject constructor(
                     CategoryOverviewUiModel(
                         id = category.categoryId,
                         name = category.name,
+                        totalProjects = projectsWithTasks.size,
                         totalTasks = totalTasksInCategory,
                         completedTasks = completedTasksInCategory,
                         progressPercentage = progressPercentage

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/OverviewSummaryCard.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/OverviewSummaryCard.kt
@@ -177,6 +177,7 @@ private fun OverviewSummaryCardPreview() {
         CategoryOverviewUiModel(
             id = 1L,
             name = "Real Estate",
+            totalProjects = 3,
             totalTasks = 24,
             completedTasks = 18,
             progressPercentage = 0.75f
@@ -184,6 +185,7 @@ private fun OverviewSummaryCardPreview() {
         CategoryOverviewUiModel(
             id = 2L,
             name = "Development",
+            totalProjects = 5,
             totalTasks = 50,
             completedTasks = 5,
             progressPercentage = 0.10f
@@ -191,6 +193,7 @@ private fun OverviewSummaryCardPreview() {
         CategoryOverviewUiModel(
             id = 3L,
             name = "Business",
+            totalProjects = 2,
             totalTasks = 12,
             completedTasks = 12,
             progressPercentage = 1.0f
@@ -198,6 +201,7 @@ private fun OverviewSummaryCardPreview() {
         CategoryOverviewUiModel(
             id = 4L,
             name = "Personal",
+            totalProjects = 4,
             totalTasks = 8,
             completedTasks = 4,
             progressPercentage = 0.50f

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksEvent.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksEvent.kt
@@ -27,6 +27,7 @@ sealed interface TasksEvent {
     data class OnDraftPhotoAttached(val uri: String) : TasksEvent
 
     data class OnDraftBudgetChanged(val budgetInput: String) : TasksEvent
+    data class OnAdjustDraftBudget(val adjustment: Double) : TasksEvent
 
     data object OnSaveDraftClicked : TasksEvent
 

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksViewModel.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksViewModel.kt
@@ -239,6 +239,19 @@ class TasksViewModel @Inject constructor(
             }
 
             is TasksEvent.OnDraftBudgetChanged -> _draftState.update { it.copy(budgetInput = event.budgetInput) }
+            is TasksEvent.OnAdjustDraftBudget -> {
+                _draftState.update { state ->
+                    val currentBudget = state.budgetInput.toDoubleOrNull() ?: 0.0
+                    val newBudget = (currentBudget + event.adjustment).coerceAtLeast(0.0)
+                    // If it's a whole number, drop the .0 for a cleaner string
+                    val formattedBudget = if (newBudget % 1 == 0.0) {
+                        newBudget.toLong().toString()
+                    } else {
+                        newBudget.toString()
+                    }
+                    state.copy(budgetInput = formattedBudget)
+                }
+            }
             is TasksEvent.OnDraftDueDateChanged -> _draftState.update { it.copy(dueDateMillis = event.timestamp) }
 
             is TasksEvent.OnAddQuickProject -> {

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddCategorySheet.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddCategorySheet.kt
@@ -1,19 +1,36 @@
 package com.zoewave.probase.photodo.mobile.features.tasks.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Flight
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.Work
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -61,7 +78,34 @@ fun AddCategorySheetContent(
             .padding(bottom = 32.dp), // Extra padding for system nav bar
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_new_category), style = MaterialTheme.typography.titleLarge)
+        Text(
+            text = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_new_category),
+            style = MaterialTheme.typography.titleLarge
+        )
+
+        // --- QUICK PICK SECTION ---
+        Text(
+            text = "Quick Pick",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            categoryTemplates.forEach { template ->
+                QuickCategoryIcon(
+                    template = template,
+                    onClick = {
+                        onDraftCategoryNameChanged(template.name)
+                        onSaveDraftClicked()
+                    }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
 
         OutlinedTextField(
             value = newCategoryName,
@@ -79,6 +123,50 @@ fun AddCategorySheetContent(
         }
     }
 }
+
+@Composable
+private fun QuickCategoryIcon(
+    template: CategoryTemplate,
+    onClick: () -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Surface(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+                .clickable { onClick() },
+            color = MaterialTheme.colorScheme.primaryContainer,
+            shape = CircleShape
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = template.icon,
+                    contentDescription = template.name,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+        Text(
+            text = template.name,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+private data class CategoryTemplate(val name: String, val icon: ImageVector)
+
+private val categoryTemplates = listOf(
+    CategoryTemplate("Work", Icons.Default.Work),
+    CategoryTemplate("Personal", Icons.Default.Person),
+    CategoryTemplate("Home", Icons.Default.Home),
+    CategoryTemplate("Shopping", Icons.Default.ShoppingCart),
+    CategoryTemplate("Travel", Icons.Default.Flight)
+)
 
 @Preview(showBackground = true)
 @Composable

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddProjectBottomSheet.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddProjectBottomSheet.kt
@@ -1,6 +1,8 @@
 package com.zoewave.probase.photodo.mobile.features.tasks.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,7 +10,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -23,6 +27,7 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -34,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -44,6 +50,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.zoewave.probase.applications.photodo.db.model.quickTemplates
 import com.zoewave.probase.photodo.mobile.core.ui.theme.PhotoDoTheme
 import com.zoewave.probase.photodo.mobile.features.tasks.R
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.TasksEvent
@@ -65,139 +72,16 @@ fun AddProjectBottomSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var showDatePicker by remember { mutableStateOf(false) }
 
-    val focusRequester = remember { FocusRequester() }
-    val focusManager = LocalFocusManager.current
-
     ModalBottomSheet(
         onDismissRequest = { onEvent(TasksEvent.OnDismissBottomSheet) },
         modifier = modifier,
         sheetState = sheetState
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .navigationBarsPadding()
-                .imePadding()
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-
-            // --- HEADER ---
-            val hasDueDate = uiState.dueDateMillis != null
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_new_project),
-                    style = MaterialTheme.typography.headlineSmall,
-                    color = MaterialTheme.colorScheme.primary
-                )
-
-                IconButton(
-                    onClick = { showDatePicker = true },
-                    colors = IconButtonDefaults.iconButtonColors(
-                        // 🚀 Color changes so they know it is active!
-                        contentColor = if (hasDueDate) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                ) {
-                    Icon(Icons.Default.CalendarMonth, contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_set_due_date_content_desc))
-                }
-            }
-
-            // 🚀 ACTUAL DATE FORMATTER: Turns 1709234000000 into "Oct 24, 2026"
-            if (hasDueDate) {
-                val formatter = remember { SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()) }
-                val dateString = formatter.format(Date(uiState.dueDateMillis!!))
-
-                Text(
-                    text = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_due_date, dateString),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(bottom = 8.dp)
-                )
-            }
-
-            // --- TITLE FIELD ---
-            OutlinedTextField(
-                value = uiState.listTitle,
-                onValueChange = { onEvent(TasksEvent.OnDraftTitleChanged(it)) },
-                label = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_project_name_label)) },
-                placeholder = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_project_name_placeholder)) },
-                singleLine = true,
-                shape = MaterialTheme.shapes.medium,
-                keyboardOptions = KeyboardOptions(
-                    capitalization = KeyboardCapitalization.Words,
-                    imeAction = ImeAction.Next
-                ),
-                keyboardActions = KeyboardActions(
-                    onNext = { focusManager.moveFocus(FocusDirection.Down) }
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(focusRequester)
-            )
-
-            // --- BUDGET FIELD ---
-            OutlinedTextField(
-                value = uiState.budgetInput,
-                onValueChange = { onEvent(TasksEvent.OnDraftBudgetChanged(it)) },
-                label = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_total_budget_optional_label)) },
-                placeholder = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_expense_amount_placeholder)) },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.AttachMoney,
-                        contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_currency_content_desc),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                },
-                singleLine = true,
-                shape = MaterialTheme.shapes.medium,
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Decimal,
-                    imeAction = ImeAction.Done
-                ),
-                keyboardActions = KeyboardActions(
-                    onDone = {
-                        if (uiState.listTitle.isNotBlank()) {
-                            onEvent(TasksEvent.OnSaveDraftClicked)
-                        }
-                    }
-                ),
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            // --- BUTTONS ---
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp),
-                horizontalArrangement = Arrangement.End,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                TextButton(
-                    onClick = { onEvent(TasksEvent.OnDismissBottomSheet) }
-                ) {
-                    Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_cancel_button))
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Button(
-                    onClick = { onEvent(TasksEvent.OnSaveDraftClicked) },
-                    enabled = uiState.listTitle.isNotBlank(),
-                    elevation = ButtonDefaults.buttonElevation(defaultElevation = 0.dp)
-                ) {
-                    Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_create_button))
-                }
-            }
-        }
-
-        LaunchedEffect(Unit) {
-            delay(100)
-            focusRequester.requestFocus()
-        }
+        AddProjectBottomSheetContent(
+            uiState = uiState,
+            onEvent = onEvent,
+            onShowDatePicker = { showDatePicker = true }
+        )
 
         // 🚀 ONLY ONE DATE PICKER REMAINS
         if (showDatePicker) {
@@ -211,14 +95,198 @@ fun AddProjectBottomSheet(
     }
 }
 
-@Preview
+@Composable
+fun AddProjectBottomSheetContent(
+    uiState: TaskDraftState,
+    onEvent: (TasksEvent) -> Unit,
+    onShowDatePicker: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .imePadding()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+
+        // --- HEADER ---
+        val hasDueDate = uiState.dueDateMillis != null
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_new_project),
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+
+            IconButton(
+                onClick = onShowDatePicker,
+                colors = IconButtonDefaults.iconButtonColors(
+                    // 🚀 Color changes so they know it is active!
+                    contentColor = if (hasDueDate) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Icon(Icons.Default.CalendarMonth, contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_set_due_date_content_desc))
+            }
+        }
+
+        // --- QUICK PICK SECTION ---
+        Text(
+            text = "Quick Pick",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            quickTemplates.forEach { template ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Surface(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .clip(CircleShape)
+                            .clickable {
+                                onEvent(TasksEvent.OnCreateFromTemplate(template))
+                                onEvent(TasksEvent.OnDismissBottomSheet)
+                            },
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        shape = CircleShape
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = template.icon,
+                                contentDescription = template.title,
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                modifier = Modifier.size(24.dp)
+                            )
+                        }
+                    }
+                    Text(
+                        text = template.title.split(" ").firstOrNull() ?: template.title,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        // 🚀 ACTUAL DATE FORMATTER: Turns 1709234000000 into "Oct 24, 2026"
+        if (hasDueDate) {
+            val formatter = remember { SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()) }
+            val dateString = formatter.format(Date(uiState.dueDateMillis!!))
+
+            Text(
+                text = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_due_date, dateString),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+
+        // --- TITLE FIELD ---
+        OutlinedTextField(
+            value = uiState.listTitle,
+            onValueChange = { onEvent(TasksEvent.OnDraftTitleChanged(it)) },
+            label = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_project_name_label)) },
+            placeholder = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_project_name_placeholder)) },
+            singleLine = true,
+            shape = MaterialTheme.shapes.medium,
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Words,
+                imeAction = ImeAction.Next
+            ),
+            keyboardActions = KeyboardActions(
+                onNext = { focusManager.moveFocus(FocusDirection.Down) }
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester)
+        )
+
+        // --- BUDGET FIELD ---
+        OutlinedTextField(
+            value = uiState.budgetInput,
+            onValueChange = { onEvent(TasksEvent.OnDraftBudgetChanged(it)) },
+            label = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_total_budget_optional_label)) },
+            placeholder = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_expense_amount_placeholder)) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.AttachMoney,
+                    contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_currency_content_desc),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            },
+            singleLine = true,
+            shape = MaterialTheme.shapes.medium,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Decimal,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    if (uiState.listTitle.isNotBlank()) {
+                        onEvent(TasksEvent.OnSaveDraftClicked)
+                    }
+                }
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        // --- BUTTONS ---
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TextButton(
+                onClick = { onEvent(TasksEvent.OnDismissBottomSheet) }
+            ) {
+                Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_cancel_button))
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Button(
+                onClick = { onEvent(TasksEvent.OnSaveDraftClicked) },
+                enabled = uiState.listTitle.isNotBlank(),
+                elevation = ButtonDefaults.buttonElevation(defaultElevation = 0.dp)
+            ) {
+                Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_create_button))
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        delay(100)
+        focusRequester.requestFocus()
+    }
+}
+
+@Preview(showBackground = true)
 @Composable
 private fun AddProjectBottomSheetPreview() {
     PhotoDoTheme {
-        AddProjectBottomSheet(
-            uiState = TaskDraftState(),
-            onEvent = {},
-            navTo = {}
-        )
+        Surface {
+            AddProjectBottomSheetContent(
+                uiState = TaskDraftState(),
+                onEvent = {},
+                onShowDatePicker = {}
+            )
+        }
     }
 }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddProjectBottomSheet.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddProjectBottomSheet.kt
@@ -163,8 +163,8 @@ fun AddProjectBottomSheetContent(
                             .size(48.dp)
                             .clip(CircleShape)
                             .clickable {
-                                onEvent(TasksEvent.OnCreateFromTemplate(template))
-                                onEvent(TasksEvent.OnDismissBottomSheet)
+                                onEvent(TasksEvent.OnDraftTitleChanged(template.title))
+                                onEvent(TasksEvent.OnDraftBudgetChanged(template.defaultBudget.toInt().toString()))
                             },
                         color = MaterialTheme.colorScheme.primaryContainer,
                         shape = CircleShape

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddProjectBottomSheet.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddProjectBottomSheet.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -246,6 +248,22 @@ fun AddProjectBottomSheetContent(
             ),
             modifier = Modifier.fillMaxWidth()
         )
+
+        // --- QUICK BUDGET SECTION ---
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            listOf("10", "50", "100", "500").forEach { amount ->
+                AssistChip(
+                    onClick = { onEvent(TasksEvent.OnDraftBudgetChanged(amount)) },
+                    label = { Text("$$amount") },
+                    colors = AssistChipDefaults.assistChipColors(
+                        labelColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+            }
+        }
 
         // --- BUTTONS ---
         Row(

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddProjectBottomSheet.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/AddProjectBottomSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -16,6 +17,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material3.AssistChip
@@ -57,6 +59,7 @@ import com.zoewave.probase.photodo.mobile.core.ui.theme.PhotoDoTheme
 import com.zoewave.probase.photodo.mobile.features.tasks.R
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.TasksEvent
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.state.TaskDraftState
+import com.zoewave.probase.photodo.mobile.features.tasks.ui.detail.QuickExpenseBar
 import com.zoewave.probase.photodo.model.navigation.PhotoTodoRoute
 import kotlinx.coroutines.delay
 import java.text.SimpleDateFormat
@@ -250,19 +253,17 @@ fun AddProjectBottomSheetContent(
         )
 
         // --- QUICK BUDGET SECTION ---
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            listOf("10", "50", "100", "500").forEach { amount ->
-                AssistChip(
-                    onClick = { onEvent(TasksEvent.OnDraftBudgetChanged(amount)) },
-                    label = { Text("$$amount") },
-                    colors = AssistChipDefaults.assistChipColors(
-                        labelColor = MaterialTheme.colorScheme.primary
-                    )
-                )
-            }
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = "Adjust Budget",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+            QuickExpenseBar(
+                onAdjustSpend = { adjustment -> 
+                    onEvent(TasksEvent.OnAdjustDraftBudget(adjustment)) 
+                }
+            )
         }
 
         // --- BUTTONS ---

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/SavePhotoBottomSheet.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/SavePhotoBottomSheet.kt
@@ -1,22 +1,44 @@
 package com.zoewave.probase.photodo.mobile.features.tasks.ui.components
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.List
-import androidx.compose.material3.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.zoewave.probase.applications.photodo.db.entity.CategoryEntity
+import com.zoewave.probase.applications.photodo.db.entity.ProjectEntity
+import com.zoewave.probase.photodo.mobile.core.ui.theme.PhotoDoTheme
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.SavePhotoUiState
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -40,128 +62,214 @@ fun SavePhotoBottomSheet(
         sheetState = sheetState,
         modifier = modifier
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ) {
-            Text(
-                text = "Save to which project?",
-                style = MaterialTheme.typography.headlineSmall,
-                modifier = Modifier.padding(bottom = 16.dp)
-            )
+        SavePhotoBottomSheetContent(
+            uiState = uiState,
+            onCategorySelected = onCategorySelected,
+            onProjectSelected = onProjectSelected,
+            onNewCategoryNameChanged = onNewCategoryNameChanged,
+            onNewProjectNameChanged = onNewProjectNameChanged,
+            onAddCategoryClicked = onAddCategoryClicked,
+            onAddProjectClicked = onAddProjectClicked,
+            onSaveClicked = onSaveClicked,
+            onDismiss = onDismiss
+        )
+    }
+}
 
-            if (uiState.selectedCategoryId == null) {
-                // Show Category Selection
-                Text(text = "Select Category", style = MaterialTheme.typography.titleMedium)
-                
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    OutlinedTextField(
-                        value = uiState.newCategoryName,
-                        onValueChange = onNewCategoryNameChanged,
-                        label = { Text("New Category Name") },
-                        modifier = Modifier.weight(1f),
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                        keyboardActions = KeyboardActions(onDone = {
-                            if (uiState.newCategoryName.isNotBlank()) onAddCategoryClicked()
-                        })
-                    )
-                    Button(
-                        onClick = onAddCategoryClicked,
-                        enabled = uiState.newCategoryName.isNotBlank()
-                    ) {
-                        Text("Create")
-                    }
-                }
+@Composable
+fun SavePhotoBottomSheetContent(
+    uiState: SavePhotoUiState,
+    onCategorySelected: (Long) -> Unit,
+    onProjectSelected: (Long) -> Unit,
+    onNewCategoryNameChanged: (String) -> Unit,
+    onNewProjectNameChanged: (String) -> Unit,
+    onAddCategoryClicked: () -> Unit,
+    onAddProjectClicked: () -> Unit,
+    onSaveClicked: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Save to which project?",
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
 
-                LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
-                    items(uiState.categories) { category ->
-                        ListItem(
-                            headlineContent = { Text(category.name) },
-                            leadingContent = { Icon(Icons.Default.Folder, contentDescription = null) },
-                            modifier = Modifier.clickable { onCategorySelected(category.categoryId) }
-                        )
-                    }
-                }
-            } else {
-                // Show Project Selection
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    TextButton(onClick = { onCategorySelected(-1L) /* Use a marker to go back */ }) {
-                        Text("Categories")
-                    }
-                    Text(">")
-                    Text(
-                        uiState.categories.find { it.categoryId == uiState.selectedCategoryId }?.name ?: "",
-                        modifier = Modifier.padding(start = 8.dp)
-                    )
-                }
-
-                Text(
-                    text = "Select Project",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(vertical = 8.dp)
+        if (uiState.selectedCategoryId == null) {
+            // Show Category Selection
+            Text(text = "Select Category", style = MaterialTheme.typography.titleMedium)
+            
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedTextField(
+                    value = uiState.newCategoryName,
+                    onValueChange = onNewCategoryNameChanged,
+                    label = { Text("New Category Name") },
+                    modifier = Modifier.weight(1f),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = {
+                        if (uiState.newCategoryName.isNotBlank()) onAddCategoryClicked()
+                    })
                 )
-
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    OutlinedTextField(
-                        value = uiState.newProjectName,
-                        onValueChange = onNewProjectNameChanged,
-                        label = { Text("New Project Name") },
-                        modifier = Modifier.weight(1f),
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                        keyboardActions = KeyboardActions(onDone = {
-                            if (uiState.newProjectName.isNotBlank()) onAddProjectClicked()
-                        })
-                    )
-                    Button(
-                        onClick = onAddProjectClicked,
-                        enabled = uiState.newProjectName.isNotBlank()
-                    ) {
-                        Text("Create")
-                    }
-                }
-
-                LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
-                    items(uiState.projects) { project ->
-                        ListItem(
-                            headlineContent = { Text(project.name) },
-                            leadingContent = { Icon(Icons.Default.List, contentDescription = null) },
-                            trailingContent = {
-                                if (uiState.selectedProjectId == project.projectId) {
-                                    Icon(Icons.Default.Check, contentDescription = null)
-                                }
-                            },
-                            modifier = Modifier.clickable { onProjectSelected(project.projectId) }
-                        )
-                    }
-                }
-
                 Button(
-                    onClick = if (uiState.isSaved) onDismiss else onSaveClicked,
-                    enabled = (uiState.isSaved || uiState.selectedProjectId != null || uiState.newProjectName.isNotBlank()) && !uiState.isSaving,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 16.dp),
-                    colors = if (uiState.isSaved) ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary) else ButtonDefaults.buttonColors()
+                    onClick = onAddCategoryClicked,
+                    enabled = uiState.newCategoryName.isNotBlank()
                 ) {
-                    if (uiState.isSaving) {
-                        CircularProgressIndicator(modifier = Modifier.size(24.dp), color = MaterialTheme.colorScheme.onPrimary)
-                    } else {
-                        Text(if (uiState.isSaved) "Saved! Close" else "Save Photo")
-                    }
+                    Text("Create")
                 }
             }
-            Spacer(modifier = Modifier.height(32.dp))
+
+            LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
+                items(uiState.categories) { category ->
+                    ListItem(
+                        headlineContent = { Text(category.name) },
+                        leadingContent = { Icon(Icons.Default.Folder, contentDescription = null) },
+                        modifier = Modifier.clickable { onCategorySelected(category.categoryId) }
+                    )
+                }
+            }
+        } else {
+            // Show Project Selection
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                TextButton(onClick = { onCategorySelected(-1L) /* Use a marker to go back */ }) {
+                    Text("Categories")
+                }
+                Text(">")
+                Text(
+                    uiState.categories.find { it.categoryId == uiState.selectedCategoryId }?.name ?: "",
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+
+            Text(
+                text = "Select Project",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedTextField(
+                    value = uiState.newProjectName,
+                    onValueChange = onNewProjectNameChanged,
+                    label = { Text("New Project Name") },
+                    modifier = Modifier.weight(1f),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = {
+                        if (uiState.newProjectName.isNotBlank()) onAddProjectClicked()
+                    })
+                )
+                Button(
+                    onClick = onAddProjectClicked,
+                    enabled = uiState.newProjectName.isNotBlank()
+                ) {
+                    Text("Create")
+                }
+            }
+
+            LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
+                items(uiState.projects) { project ->
+                    ListItem(
+                        headlineContent = { Text(project.name) },
+                        leadingContent = { Icon(Icons.Default.List, contentDescription = null) },
+                        trailingContent = {
+                            if (uiState.selectedProjectId == project.projectId) {
+                                Icon(Icons.Default.Check, contentDescription = null)
+                            }
+                        },
+                        modifier = Modifier.clickable { onProjectSelected(project.projectId) }
+                    )
+                }
+            }
+
+            Button(
+                onClick = if (uiState.isSaved) onDismiss else onSaveClicked,
+                enabled = (uiState.isSaved || uiState.selectedProjectId != null || uiState.newProjectName.isNotBlank()) && !uiState.isSaving,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                colors = if (uiState.isSaved) ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary) else ButtonDefaults.buttonColors()
+            ) {
+                if (uiState.isSaving) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp), color = MaterialTheme.colorScheme.onPrimary)
+                } else {
+                    Text(if (uiState.isSaved) "Saved! Close" else "Save Photo")
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(32.dp))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SavePhotoBottomSheetCategoryPreview() {
+    PhotoDoTheme {
+        Surface {
+            SavePhotoBottomSheetContent(
+                uiState = SavePhotoUiState(
+                    photoUri = "",
+                    categories = listOf(
+                        CategoryEntity(categoryId = 1, name = "Home"),
+                        CategoryEntity(categoryId = 2, name = "Work"),
+                        CategoryEntity(categoryId = 3, name = "Personal")
+                    )
+                ),
+                onCategorySelected = {},
+                onProjectSelected = {},
+                onNewCategoryNameChanged = {},
+                onNewProjectNameChanged = {},
+                onAddCategoryClicked = {},
+                onAddProjectClicked = {},
+                onSaveClicked = {},
+                onDismiss = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SavePhotoBottomSheetProjectPreview() {
+    PhotoDoTheme {
+        Surface {
+            SavePhotoBottomSheetContent(
+                uiState = SavePhotoUiState(
+                    photoUri = "",
+                    categories = listOf(
+                        CategoryEntity(categoryId = 1, name = "Home"),
+                        CategoryEntity(categoryId = 2, name = "Work"),
+                        CategoryEntity(categoryId = 3, name = "Personal")
+                    ),
+                    selectedCategoryId = 1,
+                    projects = listOf(
+                        ProjectEntity(projectId = 1, categoryId = 1, name = "Kitchen Remodel"),
+                        ProjectEntity(projectId = 2, categoryId = 1, name = "Garden Maintenance")
+                    ),
+                    selectedProjectId = 1
+                ),
+                onCategorySelected = {},
+                onProjectSelected = {},
+                onNewCategoryNameChanged = {},
+                onNewProjectNameChanged = {},
+                onAddCategoryClicked = {},
+                onAddProjectClicked = {},
+                onSaveClicked = {},
+                onDismiss = {}
+            )
         }
     }
 }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/TasksListScreen.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/TasksListScreen.kt
@@ -171,7 +171,7 @@ fun TasksListScreen(
                 // Scenario C: We have data! Render the list cleanly.
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(16.dp),
+                    contentPadding = PaddingValues(top = 16.dp, start = 16.dp, end = 16.dp, bottom = 80.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     // Iterate over the new projectLists state!

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/TasksListScreen.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/TasksListScreen.kt
@@ -83,11 +83,13 @@ fun TasksListScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { showDeleteConfirmation = true }) {
-                        Icon(
-                            Icons.Default.Delete,
-                            contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_delete_category_content_desc)
-                        )
+                    if (!uiState.isNoCategoriesYet) {
+                        IconButton(onClick = { showDeleteConfirmation = true }) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_delete_category_content_desc)
+                            )
+                        }
                     }
                 }
             )

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailScreen.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailScreen.kt
@@ -135,11 +135,13 @@ fun TaskDetailScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { showDeleteProjectConfirmation = true }) {
-                        Icon(
-                            Icons.Default.DeleteForever,
-                            contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_delete_project_content_desc)
-                        )
+                    if (uiState.loadState is DetailLoadState.Success) {
+                        IconButton(onClick = { showDeleteProjectConfirmation = true }) {
+                            Icon(
+                                Icons.Default.DeleteForever,
+                                contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_delete_project_content_desc)
+                            )
+                        }
                     }
                 }
             )


### PR DESCRIPTION
feat(tasks): implement incremental budget adjustments in project creation

This commit enhances the budget input experience in the task creation flow by replacing static preset chips with a dynamic adjustment bar. Users can now increment or decrement the draft budget relative to its current value.

- **`TasksEvent.kt`**:
    - Added `OnAdjustDraftBudget` event to support relative currency adjustments.
- **`TasksViewModel.kt`**:
    - Implemented handling for `OnAdjustDraftBudget` which parses the current input, applies the adjustment, and ensures the value remains non-negative.
    - Added logic to format the resulting budget string, stripping unnecessary decimal places for whole numbers.
- **`AddProjectBottomSheet.kt`**:
    - Replaced the hardcoded budget `AssistChip` row with a `QuickExpenseBar` component.
    - Integrated the new adjustment event to allow for more flexible budget fine-tuning.
    - Added an "Adjust Budget" label for better visual hierarchy.