### PR TITLE
chore(photodo): bump versions and configure privacy/analytics settings

### DIFF
--- a/applications/photodo/apps/mobile/build.gradle.kts
+++ b/applications/photodo/apps/mobile/build.gradle.kts
@@ -16,8 +16,8 @@ android {
 
     defaultConfig {
         applicationId = "com.zoewave.probase.photodo"
-        versionCode = 2
-        versionName = "0.0.1"
+        versionCode = 8
+        versionName = "0.0.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/applications/photodo/apps/mobile/src/main/AndroidManifest.xml
+++ b/applications/photodo/apps/mobile/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
 
     <application
         android:name=".PhotoDoApp"
@@ -45,6 +46,12 @@
             </intent-filter>
         </service>
 
+        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
+        <!-- meta-data android:name="firebase_crashlytics_collection_enabled" android:value="false" />
+        <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />
+        <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="false" />
+        <meta-data android:name="google_analytics_default_allow_ad_personalization_signals" android:value="false" />
+        <meta-data android:name="firebase_performance_collection_enabled" android:value="false" />
+        <meta-data android:name="google_analytics_ssaid_collection_enabled" android:value="false" /-->
     </application>
-
 </manifest>

--- a/applications/photodo/apps/wear/build.gradle.kts
+++ b/applications/photodo/apps/wear/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("composetemplate.android.application")
     id("composetemplate.android.application.compose")
     id("composetemplate.android.hilt")
+    id("composetemplate.android.application.firebase")
     alias(libs.plugins.ksp)
 }
 
@@ -10,8 +11,8 @@ android {
 
     defaultConfig {
         applicationId = "com.zoewave.probase.photodo"
-        versionCode = 3
-        versionName = "0.0.1"
+        versionCode = 7
+        versionName = "0.0.2"
         minSdk = 34
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         proguardFiles(

--- a/applications/photodo/apps/wear/src/main/AndroidManifest.xml
+++ b/applications/photodo/apps/wear/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:name="android.hardware.type.watch" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".PhotoDoWearApp"
@@ -10,6 +13,11 @@
         android:label="PhotoDo"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.DeviceDefault">
+
+        <!-- meta-data android:name="firebase_crashlytics_collection_enabled" android:value="false" />
+        <meta-data android:name="firebase_performance_collection_enabled" android:value="false" />
+        <meta-data android:name="google_analytics_ssaid_collection_enabled" android:value="false" />
+        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" /-->
 
         <uses-library
             android:name="com.google.android.wearable"
@@ -43,6 +51,8 @@
                     android:scheme="wear" />
             </intent-filter>
         </service>
+
+        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
 
     </application>
 


### PR DESCRIPTION
This commit updates the application version to 0.0.2 across the mobile and wear modules. It also introduces privacy-related manifest changes to disable Ad ID collection and configures the Wear module with Firebase support.

- **`AndroidManifest.xml` (Mobile & Wear)**:
    - Explicitly removed the `com.google.android.gms.permission.AD_ID` permission using `tools:node="remove"`.
    - Set `google_analytics_adid_collection_enabled` to `false` in the application metadata.
    - Added the `POST_NOTIFICATIONS` permission to the Wear manifest.
- **`build.gradle.kts` (Mobile & Wear)**:
    - Incremented `versionCode` (8 for mobile, 7 for wear) and updated `versionName` to `0.0.2`.
    - Applied the `composetemplate.android.application.firebase` plugin to the Wear module.