### PR TITLE
feat(transaction): implement receipt photo attachment support

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -51,7 +51,7 @@
       </SelectionState>
       <SelectionState runConfigName="applications.seaweed.apps.mobile">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-09T20:22:18.170424Z">
+        <DropdownSelection timestamp="2026-04-11T20:16:00.200066Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_9a.avd" />
@@ -84,10 +84,10 @@
       </SelectionState>
       <SelectionState runConfigName="applications.photodo.apps.wear">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-10T22:14:56.492424Z">
+        <DropdownSelection timestamp="2026-04-11T02:17:42.822951Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_10_Pro_Fold.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Wear_OS_XL_Round.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/applications/seaweed/apps/mobile/build.gradle.kts
+++ b/applications/seaweed/apps/mobile/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(project(":applications:seaweed:apps:mobile:features:settings"))
     implementation(project(":applications:seaweed:apps:mobile:features:bills"))
     implementation(project(":applications:seaweed:apps:mobile:features:budget"))
+    implementation(project(":features:camera"))
 
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
@@ -60,7 +61,6 @@ dependencies {
     implementation(libs.androidx.window.core)
     implementation(libs.androidx.compose.material3.window.size)
     implementation(libs.hilt.navigation.compose)
-
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/applications/seaweed/apps/mobile/features/transaction/build.gradle.kts
+++ b/applications/seaweed/apps/mobile/features/transaction/build.gradle.kts
@@ -20,6 +20,8 @@ dependencies {
     implementation(project(":applications:seaweed:data"))
     implementation(project(":applications:seaweed:features:main"))
     implementation(project(":applications:seaweed:apps:mobile:features:bills"))
+
+    implementation(libs.coil.compose)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.compose.material3.adaptive)

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -4,15 +4,18 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 
 @Composable
@@ -60,6 +63,11 @@ fun AddTransactionScreen(
                     IconButton(onClick = { onEvent(AddTransactionUiEvent.BackClicked) }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
+                },
+                actions = {
+                    IconButton(onClick = { navTo(SeaweedDestination.Camera) }) {
+                        Icon(Icons.Default.CameraAlt, contentDescription = "Take Receipt Photo")
+                    }
                 }
             )
         },
@@ -72,6 +80,16 @@ fun AddTransactionScreen(
                 .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            uiState.receiptUri?.let { uri ->
+                AsyncImage(
+                    model = uri,
+                    contentDescription = "Receipt",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentScale = ContentScale.Crop
+                )
+            }
             OutlinedTextField(
                 value = uiState.description,
                 onValueChange = { onEvent(AddTransactionUiEvent.DescriptionChanged(it)) },

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -10,13 +10,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.util.*
+import java.util.UUID
 import javax.inject.Inject
 
 data class AddTransactionUiState(
     val amount: String = "",
     val category: String = "",
     val description: String = "",
+    val receiptUri: String? = null,
     val isSuccess: Boolean = false
 )
 
@@ -24,6 +25,7 @@ sealed interface AddTransactionUiEvent {
     data class AmountChanged(val value: String) : AddTransactionUiEvent
     data class CategoryChanged(val value: String) : AddTransactionUiEvent
     data class DescriptionChanged(val value: String) : AddTransactionUiEvent
+    data class ReceiptAttached(val uri: String) : AddTransactionUiEvent
     object SaveTransaction : AddTransactionUiEvent
     object BackClicked : AddTransactionUiEvent
 }
@@ -41,6 +43,7 @@ class AddTransactionViewModel @Inject constructor(
             is AddTransactionUiEvent.AmountChanged -> _uiState.update { it.copy(amount = event.value) }
             is AddTransactionUiEvent.CategoryChanged -> _uiState.update { it.copy(category = event.value) }
             is AddTransactionUiEvent.DescriptionChanged -> _uiState.update { it.copy(description = event.value) }
+            is AddTransactionUiEvent.ReceiptAttached -> _uiState.update { it.copy(receiptUri = event.uri) }
             AddTransactionUiEvent.SaveTransaction -> saveTransaction()
             AddTransactionUiEvent.BackClicked -> { /* Handled in Route */ }
         }
@@ -53,7 +56,8 @@ class AddTransactionViewModel @Inject constructor(
             amount = amountValue,
             category = _uiState.value.category,
             description = _uiState.value.description,
-            date = System.currentTimeMillis()
+            date = System.currentTimeMillis(),
+            receiptUri = _uiState.value.receiptUri
         )
         viewModelScope.launch {
             repository.addTransaction(transaction)

--- a/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/navigation/seaweedNavEntryProvider.kt
+++ b/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/navigation/seaweedNavEntryProvider.kt
@@ -12,6 +12,10 @@ import com.zoewave.probase.seaweed.mobile.settings.ui.SettingsUiRoute
 import com.zoewave.probase.seaweed.mobile.transaction.ui.AddTransactionUiRoute
 import com.zoewave.probase.seaweed.mobile.transaction.ui.TransactionsUiRoute
 import com.zoewave.probase.seaweed.mobile.ui.components.AdaptiveSeaweedScreen
+import com.zoewave.probase.features.camera.ui.CameraUIRoute
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.zoewave.probase.seaweed.mobile.transaction.ui.AddTransactionViewModel
+import com.zoewave.probase.seaweed.mobile.transaction.ui.AddTransactionUiEvent
 
 fun seaweedNavEntryProvider(
     key: SeaweedDestination,
@@ -79,6 +83,21 @@ fun seaweedNavEntryProvider(
                 SettingsUiRoute(
                     modifier = Modifier.fillMaxSize(),
                     navTo = navigateTo
+                )
+            }
+            SeaweedDestination.Camera -> {
+                val viewModel: AddTransactionViewModel = hiltViewModel()
+                CameraUIRoute(
+                    navTo = { routeString ->
+                        if (routeString.startsWith("result_ok:")) {
+                            val uriString = routeString.removePrefix("result_ok:")
+                            viewModel.onEvent(AddTransactionUiEvent.ReceiptAttached(uriString))
+                            onBack()
+                        } else {
+                            onBack()
+                        }
+                    },
+                    modifier = Modifier.fillMaxSize()
                 )
             }
         }

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/Transaction.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/Transaction.kt
@@ -8,5 +8,6 @@ data class Transaction(
     val amount: Double,
     val category: String,
     val description: String,
-    val date: Long
+    val date: Long,
+    val receiptUri: String? = null
 )

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
@@ -70,6 +70,12 @@ sealed class SeaweedDestination(
         titleRes = R.string.applications_seaweed_model_route_settings,
         icon = Icons.Default.Settings
     )
+
+    @Serializable
+    data object Camera : SeaweedDestination(
+        title = "Receipt Camera",
+        icon = Icons.Default.Home // Fallback icon
+    )
 }
 
 val topLevelDestinations = listOf(


### PR DESCRIPTION
This commit introduces the ability to capture and attach receipt photos to transactions. It integrates a camera feature into the transaction creation flow, updates the data model to persist receipt URIs, and adds an image preview using Coil.

- **`Transaction.kt`**:
    - Added an optional `receiptUri` property to the `Transaction` data model.
- **`AddTransactionUiRoute.kt`**:
    - Added a camera icon to the top app bar to initiate the receipt capture flow.
    - Integrated `AsyncImage` to display a preview of the attached receipt when a URI is present in the UI state.
- **`AddTransactionViewModel.kt`**:
    - Expanded `AddTransactionUiState` to include `receiptUri`.
    - Introduced a `ReceiptAttached` event to handle URI updates from the camera.
    - Updated the save logic to include the receipt URI in the created transaction.
- **`seaweedNavEntryProvider.kt`**:
    - Implemented navigation logic for the new `Camera` destination.
    - Integrated `CameraUIRoute` and added result handling to pass the captured image URI back to the `AddTransactionViewModel`.
- **`SeaweedDestination.kt`**:
    - Added a `Camera` data object to define the navigation destination for receipt capture.
- **Build Configuration**:
    - Added a dependency on the `:features:camera` module in the mobile app.
    - Added `coil-compose` to the transaction feature module for image loading.