### PR TITLE
Sea weed camera

### DIFF
--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -28,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -181,6 +184,51 @@ fun AddTransactionScreen(
                     )
                 }
             }
+
+            TextButton(
+                onClick = { onEvent(AddTransactionUiEvent.ToggleSplitWidget) },
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            ) {
+                Text(if (uiState.isSplitWidgetVisible) "Hide Split Bill" else "Split Bill")
+            }
+
+            AnimatedVisibility(visible = uiState.isSplitWidgetVisible) {
+                val base = uiState.amount.toDoubleOrNull() ?: 0.0
+                val tip = uiState.customTipAmount.toDoubleOrNull() ?: 0.0
+                val total = base + tip
+                val perPerson = if (uiState.splitCount > 0) total / uiState.splitCount else total
+
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text("Split among", style = MaterialTheme.typography.labelMedium)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        IconButton(onClick = { onEvent(AddTransactionUiEvent.SplitCountChanged(uiState.splitCount - 1)) }) {
+                            Icon(Icons.Default.Remove, contentDescription = "Remove person")
+                        }
+                        Text(
+                            text = "${uiState.splitCount} people",
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Bold
+                        )
+                        IconButton(onClick = { onEvent(AddTransactionUiEvent.SplitCountChanged(uiState.splitCount + 1)) }) {
+                            Icon(Icons.Default.Add, contentDescription = "Add person")
+                        }
+                    }
+                    if (uiState.splitCount > 1) {
+                        Text(
+                            text = "Each person pays: $${String.format(Locale.getDefault(), "%.2f", perPerson)}",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            }
         }
     }
 }
@@ -196,7 +244,9 @@ private fun AddTransactionScreenPreview() {
                 description = "Lunch with friends",
                 isTipWidgetVisible = true,
                 tipPercentage = 15,
-                customTipAmount = "6.30"
+                customTipAmount = "6.30",
+                isSplitWidgetVisible = true,
+                splitCount = 3
             ),
             onEvent = {},
             navTo = {}

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -1,22 +1,41 @@
 package com.zoewave.probase.seaweed.mobile.transaction.ui
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CameraAlt
-import androidx.compose.material3.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
+import java.util.Locale
 
 @Composable
 fun AddTransactionUiRoute(
@@ -113,8 +132,86 @@ fun AddTransactionScreen(
                 onClick = { onEvent(AddTransactionUiEvent.SaveTransaction) },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Save")
+                val base = uiState.amount.toDoubleOrNull() ?: 0.0
+                val tip = uiState.customTipAmount.toDoubleOrNull() ?: 0.0
+                val total = base + tip
+                if (total > 0 && tip > 0) {
+                    Text("Save (Total: $${String.format(Locale.getDefault(), "%.2f", total)})")
+                } else {
+                    Text("Save")
+                }
+            }
+
+            TextButton(
+                onClick = { onEvent(AddTransactionUiEvent.ToggleTipWidget) },
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            ) {
+                Text(if (uiState.isTipWidgetVisible) "Hide Tip Options" else "Add Tip")
+            }
+
+            AnimatedVisibility(visible = uiState.isTipWidgetVisible) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text("Standard Tips", style = MaterialTheme.typography.labelMedium)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        listOf(10, 15, 18, 20).forEach { percentage ->
+                            FilterChip(
+                                selected = uiState.tipPercentage == percentage,
+                                onClick = { onEvent(AddTransactionUiEvent.SelectTipPercentage(percentage)) },
+                                label = { Text("$percentage%") }
+                            )
+                        }
+                        FilterChip(
+                            selected = uiState.tipPercentage == null && uiState.customTipAmount.isNotEmpty(),
+                            onClick = { onEvent(AddTransactionUiEvent.SelectTipPercentage(null)) },
+                            label = { Text("None") }
+                        )
+                    }
+                    OutlinedTextField(
+                        value = uiState.customTipAmount,
+                        onValueChange = { onEvent(AddTransactionUiEvent.CustomTipAmountChanged(it)) },
+                        label = { Text("Tip Amount") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddTransactionScreenPreview() {
+    MaterialTheme {
+        AddTransactionScreen(
+            uiState = AddTransactionUiState(
+                amount = "42.00",
+                category = "Food",
+                description = "Lunch with friends",
+                isTipWidgetVisible = true,
+                tipPercentage = 15,
+                customTipAmount = "6.30"
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Empty State")
+@Composable
+private fun AddTransactionScreenEmptyPreview() {
+    MaterialTheme {
+        AddTransactionScreen(
+            uiState = AddTransactionUiState(),
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -24,7 +24,9 @@ data class AddTransactionUiState(
     val errorMessage: String? = null,
     val isTipWidgetVisible: Boolean = false,
     val tipPercentage: Int? = null,
-    val customTipAmount: String = ""
+    val customTipAmount: String = "",
+    val isSplitWidgetVisible: Boolean = false,
+    val splitCount: Int = 1
 )
 
 sealed interface AddTransactionUiEvent {
@@ -38,6 +40,8 @@ sealed interface AddTransactionUiEvent {
     object ToggleTipWidget : AddTransactionUiEvent
     data class SelectTipPercentage(val percentage: Int?) : AddTransactionUiEvent
     data class CustomTipAmountChanged(val value: String) : AddTransactionUiEvent
+    object ToggleSplitWidget : AddTransactionUiEvent
+    data class SplitCountChanged(val count: Int) : AddTransactionUiEvent
 }
 
 @HiltViewModel
@@ -75,6 +79,8 @@ class AddTransactionViewModel @Inject constructor(
             is AddTransactionUiEvent.CustomTipAmountChanged -> {
                 _uiState.update { it.copy(customTipAmount = event.value, tipPercentage = null) }
             }
+            AddTransactionUiEvent.ToggleSplitWidget -> _uiState.update { it.copy(isSplitWidgetVisible = !it.isSplitWidgetVisible) }
+            is AddTransactionUiEvent.SplitCountChanged -> _uiState.update { it.copy(splitCount = event.count.coerceAtLeast(1)) }
         }
     }
 

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
 
@@ -20,7 +21,10 @@ data class AddTransactionUiState(
     val receiptUri: String? = null,
     val isSuccess: Boolean = false,
     val isLoading: Boolean = false,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val isTipWidgetVisible: Boolean = false,
+    val tipPercentage: Int? = null,
+    val customTipAmount: String = ""
 )
 
 sealed interface AddTransactionUiEvent {
@@ -31,6 +35,9 @@ sealed interface AddTransactionUiEvent {
     object SaveTransaction : AddTransactionUiEvent
     object BackClicked : AddTransactionUiEvent
     object SuccessConsumed : AddTransactionUiEvent
+    object ToggleTipWidget : AddTransactionUiEvent
+    data class SelectTipPercentage(val percentage: Int?) : AddTransactionUiEvent
+    data class CustomTipAmountChanged(val value: String) : AddTransactionUiEvent
 }
 
 @HiltViewModel
@@ -50,12 +57,33 @@ class AddTransactionViewModel @Inject constructor(
             AddTransactionUiEvent.SaveTransaction -> saveTransaction()
             AddTransactionUiEvent.BackClicked -> { /* Handled in Route */ }
             AddTransactionUiEvent.SuccessConsumed -> _uiState.update { it.copy(isSuccess = false) }
+            AddTransactionUiEvent.ToggleTipWidget -> _uiState.update { it.copy(isTipWidgetVisible = !it.isTipWidgetVisible) }
+            is AddTransactionUiEvent.SelectTipPercentage -> {
+                _uiState.update { state ->
+                    val baseAmount = state.amount.toDoubleOrNull() ?: 0.0
+                    val tipAmount = if (event.percentage != null) {
+                        baseAmount * (event.percentage / 100.0)
+                    } else {
+                        0.0
+                    }
+                    state.copy(
+                        tipPercentage = event.percentage,
+                        customTipAmount = if (event.percentage != null) String.format(Locale.getDefault(), "%.2f", tipAmount) else ""
+                    )
+                }
+            }
+            is AddTransactionUiEvent.CustomTipAmountChanged -> {
+                _uiState.update { it.copy(customTipAmount = event.value, tipPercentage = null) }
+            }
         }
     }
 
     private fun saveTransaction() {
         val amountValue = _uiState.value.amount.toDoubleOrNull() ?: 0.0
-        if (amountValue <= 0.0 || _uiState.value.category.isBlank()) {
+        val tipValue = _uiState.value.customTipAmount.toDoubleOrNull() ?: 0.0
+        val totalAmount = amountValue + tipValue
+
+        if (totalAmount <= 0.0 || _uiState.value.category.isBlank()) {
             _uiState.update { it.copy(errorMessage = "Please enter a valid amount and category") }
             return
         }
@@ -64,7 +92,7 @@ class AddTransactionViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
             val transaction = Transaction(
                 id = UUID.randomUUID().toString(),
-                amount = amountValue,
+                amount = totalAmount,
                 category = _uiState.value.category,
                 description = _uiState.value.description,
                 date = System.currentTimeMillis(),


### PR DESCRIPTION
feat(transaction): add bill splitting functionality to transaction entry

This commit introduces a bill splitting widget to the "Add Transaction" screen, allowing users to calculate costs per person. The feature includes a toggleable UI component with increment/decrement controls and real-time calculation based on the total transaction amount and optional tip.

- **`AddTransactionUiRoute.kt`**:
    - Added a `TextButton` to toggle the visibility of the split bill widget.
    - Implemented an `AnimatedVisibility` block containing controls to adjust the number of people.
    - Added logic to calculate and display the per-person cost formatted to two decimal places.
    - Updated the UI preview to reflect the new state properties.
- **`AddTransactionViewModel.kt`**:
    - Updated `AddTransactionUiState` to include `isSplitWidgetVisible` and `splitCount` (defaulting to 1).
    - Introduced `ToggleSplitWidget` and `SplitCountChanged` events.
    - Implemented event handling to update the state, ensuring the split count is at least 1.