### PR TITLE
Sea weed camera

### DIFF
--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -148,46 +149,61 @@ fun AddTransactionScreen(
                     value = uiState.category,
                     onValueChange = { onEvent(AddTransactionUiEvent.CategoryChanged(it)) },
                     label = { Text("Category") },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .onFocusChanged { focusState ->
+                            onEvent(AddTransactionUiEvent.SetCategorySuggestionsVisible(focusState.isFocused))
+                        },
                     trailingIcon = { Icon(Icons.Default.Category, contentDescription = null) }
                 )
 
-                if (uiState.recentCategories.isNotEmpty()) {
-                    Text("Recent", style = MaterialTheme.typography.labelMedium)
-                    LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        contentPadding = PaddingValues(bottom = 8.dp)
-                    ) {
-                        items(uiState.recentCategories) { category ->
-                            AssistChip(
-                                onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(category)) },
-                                label = { Text(category) }
-                            )
+                AnimatedVisibility(visible = uiState.isCategorySuggestionsVisible) {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        if (uiState.recentCategories.isNotEmpty()) {
+                            Text("Recent", style = MaterialTheme.typography.labelMedium)
+                            LazyRow(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                contentPadding = PaddingValues(bottom = 8.dp)
+                            ) {
+                                items(uiState.recentCategories) { category ->
+                                    AssistChip(
+                                        onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(category)) },
+                                        label = { Text(category) }
+                                    )
+                                }
+                            }
                         }
-                    }
-                }
 
-                Text("Suggestions", style = MaterialTheme.typography.labelMedium)
-                FlowRow(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    val suggestions = listOf(
-                        "Food" to Icons.Default.Fastfood,
-                        "Coffee" to Icons.Default.Coffee,
-                        "Transport" to Icons.Default.DirectionsBus,
-                        "Shopping" to Icons.Default.ShoppingBag,
-                        "Housing" to Icons.Default.Home,
-                        "Health" to Icons.Default.LocalHospital
-                    )
-                    suggestions.forEach { (name, icon) ->
-                        FilterChip(
-                            selected = uiState.category == name,
-                            onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(name)) },
-                            label = { Text(name) },
-                            leadingIcon = { Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp)) }
-                        )
+                        Text("Suggestions", style = MaterialTheme.typography.labelMedium)
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            val suggestions = listOf(
+                                "Food" to Icons.Default.Fastfood,
+                                "Coffee" to Icons.Default.Coffee,
+                                "Transport" to Icons.Default.DirectionsBus,
+                                "Shopping" to Icons.Default.ShoppingBag,
+                                "Housing" to Icons.Default.Home,
+                                "Health" to Icons.Default.LocalHospital
+                            )
+                            suggestions.forEach { (name, icon) ->
+                                val isSelected = uiState.category.equals(name, ignoreCase = true)
+                                FilterChip(
+                                    selected = isSelected,
+                                    onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(name)) },
+                                    label = { Text(name) },
+                                    leadingIcon = {
+                                        Icon(
+                                            icon,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    }
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -3,16 +3,32 @@ package com.zoewave.probase.seaweed.mobile.transaction.ui
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Category
+import androidx.compose.material.icons.filled.Coffee
+import androidx.compose.material.icons.filled.DirectionsBus
+import androidx.compose.material.icons.filled.Fastfood
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.LocalHospital
 import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.ShoppingBag
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -69,7 +85,7 @@ fun AddTransactionUiRoute(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun AddTransactionScreen(
     modifier: Modifier = Modifier,
@@ -99,7 +115,8 @@ fun AddTransactionScreen(
             modifier = Modifier
                 .padding(padding)
                 .padding(16.dp)
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             uiState.receiptUri?.let { uri ->
@@ -125,12 +142,56 @@ fun AddTransactionScreen(
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                 modifier = Modifier.fillMaxWidth()
             )
-            OutlinedTextField(
-                value = uiState.category,
-                onValueChange = { onEvent(AddTransactionUiEvent.CategoryChanged(it)) },
-                label = { Text("Category") },
-                modifier = Modifier.fillMaxWidth()
-            )
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = uiState.category,
+                    onValueChange = { onEvent(AddTransactionUiEvent.CategoryChanged(it)) },
+                    label = { Text("Category") },
+                    modifier = Modifier.fillMaxWidth(),
+                    trailingIcon = { Icon(Icons.Default.Category, contentDescription = null) }
+                )
+
+                if (uiState.recentCategories.isNotEmpty()) {
+                    Text("Recent", style = MaterialTheme.typography.labelMedium)
+                    LazyRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        contentPadding = PaddingValues(bottom = 8.dp)
+                    ) {
+                        items(uiState.recentCategories) { category ->
+                            AssistChip(
+                                onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(category)) },
+                                label = { Text(category) }
+                            )
+                        }
+                    }
+                }
+
+                Text("Suggestions", style = MaterialTheme.typography.labelMedium)
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    val suggestions = listOf(
+                        "Food" to Icons.Default.Fastfood,
+                        "Coffee" to Icons.Default.Coffee,
+                        "Transport" to Icons.Default.DirectionsBus,
+                        "Shopping" to Icons.Default.ShoppingBag,
+                        "Housing" to Icons.Default.Home,
+                        "Health" to Icons.Default.LocalHospital
+                    )
+                    suggestions.forEach { (name, icon) ->
+                        FilterChip(
+                            selected = uiState.category == name,
+                            onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(name)) },
+                            label = { Text(name) },
+                            leadingIcon = { Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp)) }
+                        )
+                    }
+                }
+            }
+
             Button(
                 onClick = { onEvent(AddTransactionUiEvent.SaveTransaction) },
                 modifier = Modifier.fillMaxWidth()
@@ -246,7 +307,8 @@ private fun AddTransactionScreenPreview() {
                 tipPercentage = 15,
                 customTipAmount = "6.30",
                 isSplitWidgetVisible = true,
-                splitCount = 3
+                splitCount = 3,
+                recentCategories = listOf("Groceries", "Entertainment", "Gifts")
             ),
             onEvent = {},
             navTo = {}

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -6,8 +6,11 @@ import com.zoewave.probase.seaweed.data.TransactionRepository
 import com.zoewave.probase.seaweed.model.Transaction
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.Locale
@@ -26,7 +29,8 @@ data class AddTransactionUiState(
     val tipPercentage: Int? = null,
     val customTipAmount: String = "",
     val isSplitWidgetVisible: Boolean = false,
-    val splitCount: Int = 1
+    val splitCount: Int = 1,
+    val recentCategories: List<String> = emptyList()
 )
 
 sealed interface AddTransactionUiEvent {
@@ -50,7 +54,19 @@ class AddTransactionViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AddTransactionUiState())
-    val uiState: StateFlow<AddTransactionUiState> = _uiState.asStateFlow()
+    
+    val uiState: StateFlow<AddTransactionUiState> = combine(
+        _uiState,
+        repository.getAllTransactions().map { transactions ->
+            transactions.map { it.category }.distinct().take(10)
+        }
+    ) { state, recent ->
+        state.copy(recentCategories = recent)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = AddTransactionUiState()
+    )
 
     fun onEvent(event: AddTransactionUiEvent) {
         when (event) {

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -30,7 +30,8 @@ data class AddTransactionUiState(
     val customTipAmount: String = "",
     val isSplitWidgetVisible: Boolean = false,
     val splitCount: Int = 1,
-    val recentCategories: List<String> = emptyList()
+    val recentCategories: List<String> = emptyList(),
+    val isCategorySuggestionsVisible: Boolean = false
 )
 
 sealed interface AddTransactionUiEvent {
@@ -46,6 +47,7 @@ sealed interface AddTransactionUiEvent {
     data class CustomTipAmountChanged(val value: String) : AddTransactionUiEvent
     object ToggleSplitWidget : AddTransactionUiEvent
     data class SplitCountChanged(val count: Int) : AddTransactionUiEvent
+    data class SetCategorySuggestionsVisible(val visible: Boolean) : AddTransactionUiEvent
 }
 
 @HiltViewModel
@@ -97,6 +99,7 @@ class AddTransactionViewModel @Inject constructor(
             }
             AddTransactionUiEvent.ToggleSplitWidget -> _uiState.update { it.copy(isSplitWidgetVisible = !it.isSplitWidgetVisible) }
             is AddTransactionUiEvent.SplitCountChanged -> _uiState.update { it.copy(splitCount = event.count.coerceAtLeast(1)) }
+            is AddTransactionUiEvent.SetCategorySuggestionsVisible -> _uiState.update { it.copy(isCategorySuggestionsVisible = event.visible) }
         }
     }
 


### PR DESCRIPTION
feat(transaction): show category suggestions on field focus

This commit enhances the user experience of the transaction creation screen by conditionally displaying category suggestions only when the category input field is focused. This declutters the interface and provides a smoother interaction through animated transitions.

- **`AddTransactionUiRoute.kt`**:
    - Added an `onFocusChanged` modifier to the Category `OutlinedTextField` to update the visibility state of suggestions.
    - Wrapped the "Recent" and "Suggestions" UI blocks in `AnimatedVisibility` to animate their appearance based on field focus.
    - Refined the `FilterChip` selection logic to perform case-insensitive comparisons between the current input and suggested categories.
- **`AddTransactionViewModel.kt`**:
    - Expanded `AddTransactionUiState` to include `isCategorySuggestionsVisible` for tracking the focus state of the category input.
    - Added a new `SetCategorySuggestionsVisible` event to the `AddTransactionUiEvent` sealed interface.
    - Updated the ViewModel's `onEvent` handler to manage the visibility state based on UI focus events.