### PR TITLE
Charts

### DIFF
--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
@@ -1,15 +1,41 @@
 package com.zoewave.probase.seaweed.mobile.transaction.ui
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Analytics
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -68,6 +94,7 @@ fun AnalyticsScreen(
     modifier: Modifier = Modifier
 ) {
     var selectedPeriod by remember { mutableStateOf(SpendingPeriod.DAILY) }
+    var selectedTrendPoint by remember { mutableStateOf<TrendPoint?>(null) }
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
@@ -91,7 +118,10 @@ fun AnalyticsScreen(
                             SpendingPeriod.entries.forEach { period ->
                                 FilterChip(
                                     selected = selectedPeriod == period,
-                                    onClick = { selectedPeriod = period },
+                                    onClick = { 
+                                        selectedPeriod = period 
+                                        selectedTrendPoint = null // Reset selection on period change
+                                    },
                                     label = { Text(period.name.lowercase().replaceFirstChar { it.uppercase() }) },
                                     modifier = Modifier.padding(start = 4.dp)
                                 )
@@ -105,11 +135,66 @@ fun AnalyticsScreen(
                     if (trendData.isNotEmpty()) {
                         SimpleBarChart(
                             data = trendData.map { BarData(it.label, it.value) },
+                            onBarClick = { barData ->
+                                selectedTrendPoint = trendData.find { it.label == barData.label }
+                            },
+                            selectedBar = selectedTrendPoint?.let { BarData(it.label, it.value) },
                             modifier = Modifier.fillMaxWidth()
                         )
                     } else {
                         Box(Modifier.fillMaxWidth().height(150.dp), contentAlignment = Alignment.Center) {
                             Text("No data for this period")
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            AnimatedVisibility(visible = selectedTrendPoint != null) {
+                selectedTrendPoint?.let { point ->
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text(
+                                text = "Details for ${point.label}",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Column {
+                                    Text("Total spent", style = MaterialTheme.typography.labelSmall)
+                                    Text(
+                                        text = String.format(Locale.getDefault(), "$%.2f", point.value),
+                                        style = MaterialTheme.typography.headlineSmall,
+                                        fontWeight = FontWeight.Black
+                                    )
+                                }
+                                Column(horizontalAlignment = Alignment.End) {
+                                    Text("Transactions", style = MaterialTheme.typography.labelSmall)
+                                    Text(
+                                        text = "${point.transactionCount}",
+                                        style = MaterialTheme.typography.headlineSmall,
+                                        fontWeight = FontWeight.Black
+                                    )
+                                }
+                            }
+                            val topCategory = point.topCategory
+                            if (topCategory != null) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text("Top Category", style = MaterialTheme.typography.labelSmall)
+                                Text(
+                                    text = topCategory,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
                         }
                     }
                 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
@@ -1,0 +1,172 @@
+package com.zoewave.probase.seaweed.mobile.transaction.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Analytics
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zoewave.probase.core.ui.components.BarData
+import com.zoewave.probase.core.ui.components.SimpleBarChart
+import com.zoewave.probase.seaweed.model.HabitInsight
+import com.zoewave.probase.seaweed.model.SpendingPeriod
+import com.zoewave.probase.seaweed.model.TrendPoint
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnalyticsUiRoute(
+    modifier: Modifier = Modifier,
+    viewModel: AnalyticsViewModel = hiltViewModel(),
+    onBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Spending Analytics") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        modifier = modifier
+    ) { padding ->
+        if (uiState.isLoading) {
+            Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else {
+            AnalyticsScreen(
+                spendingTrends = uiState.spendingTrends,
+                habitInsights = uiState.habitInsights,
+                modifier = Modifier.padding(padding)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnalyticsScreen(
+    spendingTrends: Map<SpendingPeriod, List<TrendPoint>>,
+    habitInsights: List<HabitInsight>,
+    modifier: Modifier = Modifier
+) {
+    var selectedPeriod by remember { mutableStateOf(SpendingPeriod.DAILY) }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text("Spending Trends", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                        
+                        Row {
+                            SpendingPeriod.entries.forEach { period ->
+                                FilterChip(
+                                    selected = selectedPeriod == period,
+                                    onClick = { selectedPeriod = period },
+                                    label = { Text(period.name.lowercase().replaceFirstChar { it.uppercase() }) },
+                                    modifier = Modifier.padding(start = 4.dp)
+                                )
+                            }
+                        }
+                    }
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    val trendData = spendingTrends[selectedPeriod] ?: emptyList()
+                    if (trendData.isNotEmpty()) {
+                        SimpleBarChart(
+                            data = trendData.map { BarData(it.label, it.value) },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    } else {
+                        Box(Modifier.fillMaxWidth().height(150.dp), contentAlignment = Alignment.Center) {
+                            Text("No data for this period")
+                        }
+                    }
+                }
+            }
+        }
+
+        if (habitInsights.isNotEmpty()) {
+            item {
+                Text("Spending Habits", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            }
+            
+            items(habitInsights) { insight ->
+                HabitInsightCard(insight = insight)
+            }
+        }
+    }
+}
+
+@Composable
+fun HabitInsightCard(insight: HabitInsight) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Default.Analytics,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+            
+            Spacer(modifier = Modifier.width(16.dp))
+            
+            Column(modifier = Modifier.weight(1f)) {
+                Text(insight.category, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(
+                    text = insight.trendMessage,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = String.format(Locale.getDefault(), "Total: $%.2f this month", insight.totalAmount),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
@@ -1,0 +1,128 @@
+package com.zoewave.probase.seaweed.mobile.transaction.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.zoewave.probase.seaweed.data.TransactionRepository
+import com.zoewave.probase.seaweed.model.HabitInsight
+import com.zoewave.probase.seaweed.model.SpendingPeriod
+import com.zoewave.probase.seaweed.model.Transaction
+import com.zoewave.probase.seaweed.model.TrendPoint
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.WeekFields
+import java.util.Locale
+import javax.inject.Inject
+
+data class AnalyticsUiState(
+    val isLoading: Boolean = true,
+    val spendingTrends: Map<SpendingPeriod, List<TrendPoint>> = emptyMap(),
+    val habitInsights: List<HabitInsight> = emptyList()
+)
+
+@HiltViewModel
+class AnalyticsViewModel @Inject constructor(
+    private val repository: TransactionRepository
+) : ViewModel() {
+
+    val uiState: StateFlow<AnalyticsUiState> = repository.getAllTransactions()
+        .map { transactions ->
+            AnalyticsUiState(
+                isLoading = false,
+                spendingTrends = calculateTrends(transactions),
+                habitInsights = calculateHabitInsights(transactions)
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = AnalyticsUiState()
+        )
+
+    private fun calculateTrends(transactions: List<Transaction>): Map<SpendingPeriod, List<TrendPoint>> {
+        val zoneId = ZoneId.systemDefault()
+        
+        // Daily Trends (last 7 days)
+        val daily = transactions
+            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
+            .groupBy { it.second }
+            .map { (date, dailyTransactions) ->
+                TrendPoint(
+                    label = date.format(DateTimeFormatter.ofPattern("MMM dd")),
+                    value = dailyTransactions.sumOf { it.first.amount },
+                    timestamp = dailyTransactions.first().first.date
+                )
+            }.sortedBy { it.timestamp }.takeLast(7)
+
+        // Weekly Trends (last 4 weeks)
+        val weekFields = WeekFields.of(Locale.getDefault())
+        val weekly = transactions
+            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
+            .groupBy { it.second.get(weekFields.weekOfWeekBasedYear()) }
+            .map { (week, weeklyTransactions) ->
+                TrendPoint(
+                    label = "Week $week",
+                    value = weeklyTransactions.sumOf { it.first.amount },
+                    timestamp = weeklyTransactions.minOf { it.first.date }
+                )
+            }.sortedBy { it.timestamp }.takeLast(4)
+
+        // Monthly Trends (last 6 months)
+        val monthly = transactions
+            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
+            .groupBy { it.second.month }
+            .map { (month, monthlyTransactions) ->
+                TrendPoint(
+                    label = month.name.lowercase(Locale.ROOT).replaceFirstChar { it.uppercase() }.take(3),
+                    value = monthlyTransactions.sumOf { it.first.amount },
+                    timestamp = monthlyTransactions.minOf { it.first.date }
+                )
+            }.sortedBy { it.timestamp }.takeLast(6)
+
+        return mapOf(
+            SpendingPeriod.DAILY to daily,
+            SpendingPeriod.WEEKLY to weekly,
+            SpendingPeriod.MONTHLY to monthly
+        )
+    }
+
+    private fun calculateHabitInsights(transactions: List<Transaction>): List<HabitInsight> {
+        if (transactions.isEmpty()) return emptyList()
+        
+        val zoneId = ZoneId.systemDefault()
+        val now = LocalDate.now(zoneId)
+        val thirtyDaysAgo = now.minusDays(30)
+        
+        val recentTransactions = transactions.filter {
+            Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate().isAfter(thirtyDaysAgo)
+        }
+
+        return recentTransactions.groupBy { it.category }
+            .mapNotNull { (category, categoryTransactions) ->
+                val frequency = categoryTransactions.size
+                if (frequency < 4) return@mapNotNull null
+                
+                val totalAmount = categoryTransactions.sumOf { it.amount }
+                val dailyAverage = totalAmount / 30.0
+                
+                val trendMessage = when {
+                    dailyAverage > 10.0 -> "This habit costs you over $${String.format(Locale.getDefault(), "%.0f", dailyAverage * 365 / 12)} per month!"
+                    frequency > 15 -> "You're doing this almost every other day."
+                    else -> "Frequent spending in this category."
+                }
+
+                HabitInsight(
+                    category = category,
+                    frequency = frequency,
+                    totalAmount = totalAmount,
+                    dailyAverage = dailyAverage,
+                    trendMessage = trendMessage
+                )
+            }.sortedByDescending { it.totalAmount }
+    }
+}

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
@@ -55,7 +55,9 @@ class AnalyticsViewModel @Inject constructor(
                 TrendPoint(
                     label = date.format(DateTimeFormatter.ofPattern("MMM dd")),
                     value = dailyTransactions.sumOf { it.first.amount },
-                    timestamp = dailyTransactions.first().first.date
+                    timestamp = dailyTransactions.first().first.date,
+                    transactionCount = dailyTransactions.size,
+                    topCategory = dailyTransactions.groupBy { it.first.category }.maxByOrNull { it.value.size }?.key
                 )
             }.sortedBy { it.timestamp }.takeLast(7)
 
@@ -68,7 +70,9 @@ class AnalyticsViewModel @Inject constructor(
                 TrendPoint(
                     label = "Week $week",
                     value = weeklyTransactions.sumOf { it.first.amount },
-                    timestamp = weeklyTransactions.minOf { it.first.date }
+                    timestamp = weeklyTransactions.minOf { it.first.date },
+                    transactionCount = weeklyTransactions.size,
+                    topCategory = weeklyTransactions.groupBy { it.first.category }.maxByOrNull { it.value.size }?.key
                 )
             }.sortedBy { it.timestamp }.takeLast(4)
 
@@ -80,7 +84,9 @@ class AnalyticsViewModel @Inject constructor(
                 TrendPoint(
                     label = month.name.lowercase(Locale.ROOT).replaceFirstChar { it.uppercase() }.take(3),
                     value = monthlyTransactions.sumOf { it.first.amount },
-                    timestamp = monthlyTransactions.minOf { it.first.date }
+                    timestamp = monthlyTransactions.minOf { it.first.date },
+                    transactionCount = monthlyTransactions.size,
+                    topCategory = monthlyTransactions.groupBy { it.first.category }.maxByOrNull { it.value.size }?.key
                 )
             }.sortedBy { it.timestamp }.takeLast(6)
 

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiRoute.kt
@@ -1,20 +1,26 @@
 package com.zoewave.probase.seaweed.mobile.transaction.ui
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.PieChart
 import androidx.compose.material3.Card
@@ -38,16 +44,24 @@ import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaf
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.seaweed.mobile.bills.ui.BillsScreen
 import com.zoewave.probase.seaweed.mobile.bills.ui.BillsViewModel
+import com.zoewave.probase.core.ui.components.BarData
+import com.zoewave.probase.core.ui.components.SimpleBarChart
 import com.zoewave.probase.seaweed.mobile.transaction.ui.components.TransactionItem
+import com.zoewave.probase.seaweed.model.HabitInsight
+import com.zoewave.probase.seaweed.model.SpendingPeriod
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import com.zoewave.probase.seaweed.model.navigation.TransactionTab
 import kotlinx.coroutines.launch
@@ -177,6 +191,11 @@ fun TransactionsListPane(
                             onClick = { onEvent(TransactionsUiEvent.SelectTab(TransactionTab.CYCLIC)) },
                             text = { Text("Cyclic") }
                         )
+                        Tab(
+                            selected = uiState.selectedTab == TransactionTab.ANALYTICS,
+                            onClick = { onEvent(TransactionsUiEvent.SelectTab(TransactionTab.ANALYTICS)) },
+                            text = { Text("Analytics") }
+                        )
                     }
 
                     when (uiState.selectedTab) {
@@ -196,6 +215,13 @@ fun TransactionsListPane(
                                     modifier = Modifier.fillMaxSize()
                                 )
                             }
+                        }
+                        TransactionTab.ANALYTICS -> {
+                            AnalyticsPane(
+                                spendingTrends = uiState.spendingTrends,
+                                habitInsights = uiState.habitInsights,
+                                modifier = Modifier.fillMaxSize()
+                            )
                         }
                     }
                 }
@@ -325,6 +351,116 @@ fun TransactionDetailPane(
         } else {
             Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
                 Text("Select a transaction to see details")
+            }
+        }
+    }
+}
+
+@Composable
+fun AnalyticsPane(
+    spendingTrends: Map<SpendingPeriod, List<com.zoewave.probase.seaweed.model.TrendPoint>>,
+    habitInsights: List<HabitInsight>,
+    modifier: Modifier = Modifier
+) {
+    var selectedPeriod by remember { mutableStateOf(SpendingPeriod.DAILY) }
+
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text("Spending Trends", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                        
+                        Row {
+                            SpendingPeriod.entries.forEach { period ->
+                                FilterChip(
+                                    selected = selectedPeriod == period,
+                                    onClick = { selectedPeriod = period },
+                                    label = { Text(period.name.lowercase().replaceFirstChar { it.uppercase() }) },
+                                    modifier = Modifier.padding(start = 4.dp)
+                                )
+                            }
+                        }
+                    }
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    val trendData = spendingTrends[selectedPeriod] ?: emptyList()
+                    if (trendData.isNotEmpty()) {
+                        SimpleBarChart(
+                            data = trendData.map { BarData(it.label, it.value) },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    } else {
+                        Box(Modifier.fillMaxWidth().height(150.dp), contentAlignment = Alignment.Center) {
+                            Text("No data for this period")
+                        }
+                    }
+                }
+            }
+        }
+
+        if (habitInsights.isNotEmpty()) {
+            item {
+                Text("Spending Habits", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            }
+            
+            items(habitInsights) { insight ->
+                HabitInsightCard(insight = insight)
+            }
+        }
+    }
+}
+
+@Composable
+fun HabitInsightCard(insight: HabitInsight) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(androidx.compose.foundation.shape.CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Default.Analytics,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+            
+            Spacer(modifier = Modifier.width(16.dp))
+            
+            Column(modifier = Modifier.weight(1f)) {
+                Text(insight.category, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(
+                    text = insight.trendMessage,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = String.format(Locale.getDefault(), "Total: $%.2f this month", insight.totalAmount),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiRoute.kt
@@ -57,11 +57,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.seaweed.mobile.bills.ui.BillsScreen
 import com.zoewave.probase.seaweed.mobile.bills.ui.BillsViewModel
-import com.zoewave.probase.core.ui.components.BarData
-import com.zoewave.probase.core.ui.components.SimpleBarChart
 import com.zoewave.probase.seaweed.mobile.transaction.ui.components.TransactionItem
-import com.zoewave.probase.seaweed.model.HabitInsight
-import com.zoewave.probase.seaweed.model.SpendingPeriod
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import com.zoewave.probase.seaweed.model.navigation.TransactionTab
 import kotlinx.coroutines.launch
@@ -151,6 +147,9 @@ fun TransactionsListPane(
             TopAppBar(
                 title = { Text("Transactions") },
                 actions = {
+                    IconButton(onClick = { navTo(SeaweedDestination.Analytics) }) {
+                        Icon(Icons.Default.Analytics, contentDescription = "Analytics")
+                    }
                     IconButton(onClick = { navTo(SeaweedDestination.Budget) }) {
                         Icon(Icons.Default.PieChart, contentDescription = "Budget")
                     }
@@ -191,11 +190,6 @@ fun TransactionsListPane(
                             onClick = { onEvent(TransactionsUiEvent.SelectTab(TransactionTab.CYCLIC)) },
                             text = { Text("Cyclic") }
                         )
-                        Tab(
-                            selected = uiState.selectedTab == TransactionTab.ANALYTICS,
-                            onClick = { onEvent(TransactionsUiEvent.SelectTab(TransactionTab.ANALYTICS)) },
-                            text = { Text("Analytics") }
-                        )
                     }
 
                     when (uiState.selectedTab) {
@@ -215,13 +209,6 @@ fun TransactionsListPane(
                                     modifier = Modifier.fillMaxSize()
                                 )
                             }
-                        }
-                        TransactionTab.ANALYTICS -> {
-                            AnalyticsPane(
-                                spendingTrends = uiState.spendingTrends,
-                                habitInsights = uiState.habitInsights,
-                                modifier = Modifier.fillMaxSize()
-                            )
                         }
                     }
                 }
@@ -351,116 +338,6 @@ fun TransactionDetailPane(
         } else {
             Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
                 Text("Select a transaction to see details")
-            }
-        }
-    }
-}
-
-@Composable
-fun AnalyticsPane(
-    spendingTrends: Map<SpendingPeriod, List<com.zoewave.probase.seaweed.model.TrendPoint>>,
-    habitInsights: List<HabitInsight>,
-    modifier: Modifier = Modifier
-) {
-    var selectedPeriod by remember { mutableStateOf(SpendingPeriod.DAILY) }
-
-    LazyColumn(
-        modifier = modifier,
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
-    ) {
-        item {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text("Spending Trends", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-                        
-                        Row {
-                            SpendingPeriod.entries.forEach { period ->
-                                FilterChip(
-                                    selected = selectedPeriod == period,
-                                    onClick = { selectedPeriod = period },
-                                    label = { Text(period.name.lowercase().replaceFirstChar { it.uppercase() }) },
-                                    modifier = Modifier.padding(start = 4.dp)
-                                )
-                            }
-                        }
-                    }
-                    
-                    Spacer(modifier = Modifier.height(16.dp))
-                    
-                    val trendData = spendingTrends[selectedPeriod] ?: emptyList()
-                    if (trendData.isNotEmpty()) {
-                        SimpleBarChart(
-                            data = trendData.map { BarData(it.label, it.value) },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    } else {
-                        Box(Modifier.fillMaxWidth().height(150.dp), contentAlignment = Alignment.Center) {
-                            Text("No data for this period")
-                        }
-                    }
-                }
-            }
-        }
-
-        if (habitInsights.isNotEmpty()) {
-            item {
-                Text("Spending Habits", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            }
-            
-            items(habitInsights) { insight ->
-                HabitInsightCard(insight = insight)
-            }
-        }
-    }
-}
-
-@Composable
-fun HabitInsightCard(insight: HabitInsight) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(androidx.compose.foundation.shape.CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    Icons.Default.Analytics,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
-            
-            Spacer(modifier = Modifier.width(16.dp))
-            
-            Column(modifier = Modifier.weight(1f)) {
-                Text(insight.category, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-                Text(
-                    text = insight.trendMessage,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Text(
-                    text = String.format(Locale.getDefault(), "Total: $%.2f this month", insight.totalAmount),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
             }
         }
     }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiState.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiState.kt
@@ -1,8 +1,6 @@
 package com.zoewave.probase.seaweed.mobile.transaction.ui
 
 import com.zoewave.probase.seaweed.model.Transaction
-import com.zoewave.probase.seaweed.model.TrendPoint
-import com.zoewave.probase.seaweed.model.HabitInsight
 import com.zoewave.probase.seaweed.model.navigation.TransactionTab
 
 sealed interface TransactionsUiState {
@@ -14,9 +12,7 @@ sealed interface TransactionsUiState {
         val selectedCategory: String? = null,
         val selectedTransactionId: String? = null,
         val selectedTransaction: Transaction? = null,
-        val selectedTab: TransactionTab = TransactionTab.RECENT,
-        val spendingTrends: Map<com.zoewave.probase.seaweed.model.SpendingPeriod, List<TrendPoint>> = emptyMap(),
-        val habitInsights: List<HabitInsight> = emptyList()
+        val selectedTab: TransactionTab = TransactionTab.RECENT
     ) : TransactionsUiState
 }
 

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiState.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiState.kt
@@ -1,6 +1,8 @@
 package com.zoewave.probase.seaweed.mobile.transaction.ui
 
 import com.zoewave.probase.seaweed.model.Transaction
+import com.zoewave.probase.seaweed.model.TrendPoint
+import com.zoewave.probase.seaweed.model.HabitInsight
 import com.zoewave.probase.seaweed.model.navigation.TransactionTab
 
 sealed interface TransactionsUiState {
@@ -12,7 +14,9 @@ sealed interface TransactionsUiState {
         val selectedCategory: String? = null,
         val selectedTransactionId: String? = null,
         val selectedTransaction: Transaction? = null,
-        val selectedTab: TransactionTab = TransactionTab.RECENT
+        val selectedTab: TransactionTab = TransactionTab.RECENT,
+        val spendingTrends: Map<com.zoewave.probase.seaweed.model.SpendingPeriod, List<TrendPoint>> = emptyMap(),
+        val habitInsights: List<HabitInsight> = emptyList()
     ) : TransactionsUiState
 }
 

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsViewModel.kt
@@ -3,7 +3,10 @@ package com.zoewave.probase.seaweed.mobile.transaction.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.seaweed.data.TransactionRepository
+import com.zoewave.probase.seaweed.model.HabitInsight
+import com.zoewave.probase.seaweed.model.SpendingPeriod
 import com.zoewave.probase.seaweed.model.Transaction
+import com.zoewave.probase.seaweed.model.TrendPoint
 import com.zoewave.probase.seaweed.model.navigation.TransactionTab
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,8 +15,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.time.temporal.WeekFields
+import java.util.Locale
 import javax.inject.Inject
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -58,6 +69,10 @@ class TransactionsViewModel @Inject constructor(
         } else {
             transactions.filter { it.category == selectedCategory }
         }
+
+        val trends = calculateTrends(transactions)
+        val insights = calculateHabitInsights(transactions)
+
         TransactionsUiState.Success(
             transactions = transactions,
             filteredTransactions = filteredTransactions,
@@ -65,7 +80,9 @@ class TransactionsViewModel @Inject constructor(
             selectedCategory = selectedCategory,
             selectedTransactionId = selectedTransactionId,
             selectedTransaction = selectedTransaction,
-            selectedTab = selectedTab
+            selectedTab = selectedTab,
+            spendingTrends = trends,
+            habitInsights = insights
         )
     }.stateIn(
         scope = viewModelScope,
@@ -90,5 +107,88 @@ class TransactionsViewModel @Inject constructor(
                 _selectedTab.value = event.tab
             }
         }
+    }
+
+    private fun calculateTrends(transactions: List<Transaction>): Map<SpendingPeriod, List<TrendPoint>> {
+        val zoneId = ZoneId.systemDefault()
+        
+        // Daily Trends (last 7 days)
+        val daily = transactions
+            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
+            .groupBy { it.second }
+            .map { (date, dailyTransactions) ->
+                TrendPoint(
+                    label = date.format(DateTimeFormatter.ofPattern("MMM dd")),
+                    value = dailyTransactions.sumOf { it.first.amount },
+                    timestamp = dailyTransactions.first().first.date
+                )
+            }.sortedBy { it.timestamp }.takeLast(7)
+
+        // Weekly Trends (last 4 weeks)
+        val weekFields = WeekFields.of(Locale.getDefault())
+        val weekly = transactions
+            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
+            .groupBy { it.second.get(weekFields.weekOfWeekBasedYear()) }
+            .map { (week, weeklyTransactions) ->
+                TrendPoint(
+                    label = "Week $week",
+                    value = weeklyTransactions.sumOf { it.first.amount },
+                    timestamp = weeklyTransactions.minOf { it.first.date }
+                )
+            }.sortedBy { it.timestamp }.takeLast(4)
+
+        // Monthly Trends (last 6 months)
+        val monthly = transactions
+            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
+            .groupBy { it.second.month }
+            .map { (month, monthlyTransactions) ->
+                TrendPoint(
+                    label = month.name.lowercase(Locale.ROOT).replaceFirstChar { it.uppercase() }.take(3),
+                    value = monthlyTransactions.sumOf { it.first.amount },
+                    timestamp = monthlyTransactions.minOf { it.first.date }
+                )
+            }.sortedBy { it.timestamp }.takeLast(6)
+
+        return mapOf(
+            SpendingPeriod.DAILY to daily,
+            SpendingPeriod.WEEKLY to weekly,
+            SpendingPeriod.MONTHLY to monthly
+        )
+    }
+
+    private fun calculateHabitInsights(transactions: List<Transaction>): List<HabitInsight> {
+        if (transactions.isEmpty()) return emptyList()
+        
+        val zoneId = ZoneId.systemDefault()
+        val now = LocalDate.now(zoneId)
+        val thirtyDaysAgo = now.minusDays(30)
+        
+        val recentTransactions = transactions.filter {
+            Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate().isAfter(thirtyDaysAgo)
+        }
+
+        return recentTransactions.groupBy { it.category }
+            .mapNotNull { (category, categoryTransactions) ->
+                val frequency = categoryTransactions.size
+                // Focus on high-frequency habits (at least 4 times in 30 days)
+                if (frequency < 4) return@mapNotNull null
+                
+                val totalAmount = categoryTransactions.sumOf { it.amount }
+                val dailyAverage = totalAmount / 30.0
+                
+                val trendMessage = when {
+                    dailyAverage > 10.0 -> "This habit costs you over $${String.format(Locale.getDefault(), "%.0f", dailyAverage * 365 / 12)} per month!"
+                    frequency > 15 -> "You're doing this almost every other day."
+                    else -> "Frequent spending in this category."
+                }
+
+                HabitInsight(
+                    category = category,
+                    frequency = frequency,
+                    totalAmount = totalAmount,
+                    dailyAverage = dailyAverage,
+                    trendMessage = trendMessage
+                )
+            }.sortedByDescending { it.totalAmount }
     }
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsViewModel.kt
@@ -3,10 +3,6 @@ package com.zoewave.probase.seaweed.mobile.transaction.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.seaweed.data.TransactionRepository
-import com.zoewave.probase.seaweed.model.HabitInsight
-import com.zoewave.probase.seaweed.model.SpendingPeriod
-import com.zoewave.probase.seaweed.model.Transaction
-import com.zoewave.probase.seaweed.model.TrendPoint
 import com.zoewave.probase.seaweed.model.navigation.TransactionTab
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,16 +11,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
-import java.time.temporal.WeekFields
-import java.util.Locale
 import javax.inject.Inject
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -69,10 +57,6 @@ class TransactionsViewModel @Inject constructor(
         } else {
             transactions.filter { it.category == selectedCategory }
         }
-
-        val trends = calculateTrends(transactions)
-        val insights = calculateHabitInsights(transactions)
-
         TransactionsUiState.Success(
             transactions = transactions,
             filteredTransactions = filteredTransactions,
@@ -80,9 +64,7 @@ class TransactionsViewModel @Inject constructor(
             selectedCategory = selectedCategory,
             selectedTransactionId = selectedTransactionId,
             selectedTransaction = selectedTransaction,
-            selectedTab = selectedTab,
-            spendingTrends = trends,
-            habitInsights = insights
+            selectedTab = selectedTab
         )
     }.stateIn(
         scope = viewModelScope,
@@ -107,88 +89,5 @@ class TransactionsViewModel @Inject constructor(
                 _selectedTab.value = event.tab
             }
         }
-    }
-
-    private fun calculateTrends(transactions: List<Transaction>): Map<SpendingPeriod, List<TrendPoint>> {
-        val zoneId = ZoneId.systemDefault()
-        
-        // Daily Trends (last 7 days)
-        val daily = transactions
-            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
-            .groupBy { it.second }
-            .map { (date, dailyTransactions) ->
-                TrendPoint(
-                    label = date.format(DateTimeFormatter.ofPattern("MMM dd")),
-                    value = dailyTransactions.sumOf { it.first.amount },
-                    timestamp = dailyTransactions.first().first.date
-                )
-            }.sortedBy { it.timestamp }.takeLast(7)
-
-        // Weekly Trends (last 4 weeks)
-        val weekFields = WeekFields.of(Locale.getDefault())
-        val weekly = transactions
-            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
-            .groupBy { it.second.get(weekFields.weekOfWeekBasedYear()) }
-            .map { (week, weeklyTransactions) ->
-                TrendPoint(
-                    label = "Week $week",
-                    value = weeklyTransactions.sumOf { it.first.amount },
-                    timestamp = weeklyTransactions.minOf { it.first.date }
-                )
-            }.sortedBy { it.timestamp }.takeLast(4)
-
-        // Monthly Trends (last 6 months)
-        val monthly = transactions
-            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
-            .groupBy { it.second.month }
-            .map { (month, monthlyTransactions) ->
-                TrendPoint(
-                    label = month.name.lowercase(Locale.ROOT).replaceFirstChar { it.uppercase() }.take(3),
-                    value = monthlyTransactions.sumOf { it.first.amount },
-                    timestamp = monthlyTransactions.minOf { it.first.date }
-                )
-            }.sortedBy { it.timestamp }.takeLast(6)
-
-        return mapOf(
-            SpendingPeriod.DAILY to daily,
-            SpendingPeriod.WEEKLY to weekly,
-            SpendingPeriod.MONTHLY to monthly
-        )
-    }
-
-    private fun calculateHabitInsights(transactions: List<Transaction>): List<HabitInsight> {
-        if (transactions.isEmpty()) return emptyList()
-        
-        val zoneId = ZoneId.systemDefault()
-        val now = LocalDate.now(zoneId)
-        val thirtyDaysAgo = now.minusDays(30)
-        
-        val recentTransactions = transactions.filter {
-            Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate().isAfter(thirtyDaysAgo)
-        }
-
-        return recentTransactions.groupBy { it.category }
-            .mapNotNull { (category, categoryTransactions) ->
-                val frequency = categoryTransactions.size
-                // Focus on high-frequency habits (at least 4 times in 30 days)
-                if (frequency < 4) return@mapNotNull null
-                
-                val totalAmount = categoryTransactions.sumOf { it.amount }
-                val dailyAverage = totalAmount / 30.0
-                
-                val trendMessage = when {
-                    dailyAverage > 10.0 -> "This habit costs you over $${String.format(Locale.getDefault(), "%.0f", dailyAverage * 365 / 12)} per month!"
-                    frequency > 15 -> "You're doing this almost every other day."
-                    else -> "Frequent spending in this category."
-                }
-
-                HabitInsight(
-                    category = category,
-                    frequency = frequency,
-                    totalAmount = totalAmount,
-                    dailyAverage = dailyAverage,
-                    trendMessage = trendMessage
-                )
-            }.sortedByDescending { it.totalAmount }
     }
 }

--- a/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/navigation/seaweedNavEntryProvider.kt
+++ b/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/navigation/seaweedNavEntryProvider.kt
@@ -11,6 +11,7 @@ import com.zoewave.probase.seaweed.mobile.budget.ui.BudgetUiRoute
 import com.zoewave.probase.seaweed.mobile.settings.ui.SettingsUiRoute
 import com.zoewave.probase.seaweed.mobile.transaction.ui.AddTransactionUiRoute
 import com.zoewave.probase.seaweed.mobile.transaction.ui.TransactionsUiRoute
+import com.zoewave.probase.seaweed.mobile.transaction.ui.AnalyticsUiRoute
 import com.zoewave.probase.seaweed.mobile.ui.components.AdaptiveSeaweedScreen
 import com.zoewave.probase.features.camera.ui.CameraUIRoute
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -83,6 +84,12 @@ fun seaweedNavEntryProvider(
                 SettingsUiRoute(
                     modifier = Modifier.fillMaxSize(),
                     navTo = navigateTo
+                )
+            }
+            SeaweedDestination.Analytics -> {
+                AnalyticsUiRoute(
+                    modifier = Modifier.fillMaxSize(),
+                    onBack = onBack
                 )
             }
             SeaweedDestination.Camera -> {

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/SpendingAnalytics.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/SpendingAnalytics.kt
@@ -1,0 +1,23 @@
+package com.zoewave.probase.seaweed.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TrendPoint(
+    val label: String,
+    val value: Double,
+    val timestamp: Long
+)
+
+@Serializable
+data class HabitInsight(
+    val category: String,
+    val frequency: Int,
+    val totalAmount: Double,
+    val dailyAverage: Double,
+    val trendMessage: String
+)
+
+enum class SpendingPeriod {
+    DAILY, WEEKLY, MONTHLY
+}

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/SpendingAnalytics.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/SpendingAnalytics.kt
@@ -6,7 +6,9 @@ import kotlinx.serialization.Serializable
 data class TrendPoint(
     val label: String,
     val value: Double,
-    val timestamp: Long
+    val timestamp: Long,
+    val transactionCount: Int = 0,
+    val topCategory: String? = null
 )
 
 @Serializable

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Transient
 
 @Serializable
 enum class TransactionTab {
-    RECENT, CYCLIC
+    RECENT, CYCLIC, ANALYTICS
 }
 
 @Serializable

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Transient
 
 @Serializable
 enum class TransactionTab {
-    RECENT, CYCLIC, ANALYTICS
+    RECENT, CYCLIC
 }
 
 @Serializable
@@ -69,6 +69,12 @@ sealed class SeaweedDestination(
     data object Settings : SeaweedDestination(
         titleRes = R.string.applications_seaweed_model_route_settings,
         icon = Icons.Default.Settings
+    )
+
+    @Serializable
+    data object Analytics : SeaweedDestination(
+        title = "Spending Analytics",
+        icon = Icons.Default.PieChart // We can use Analytics or PieChart
     )
 
     @Serializable

--- a/core/ui/src/main/java/com/zoewave/probase/core/ui/components/SimpleBarChart.kt
+++ b/core/ui/src/main/java/com/zoewave/probase/core/ui/components/SimpleBarChart.kt
@@ -1,0 +1,108 @@
+package com.zoewave.probase.core.ui.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.util.Locale
+
+data class BarData(
+    val label: String,
+    val value: Double,
+    val color: Color? = null
+)
+
+@Composable
+fun SimpleBarChart(
+    data: List<BarData>,
+    modifier: Modifier = Modifier,
+    barColor: Color = MaterialTheme.colorScheme.primary,
+    height: Int = 200
+) {
+    if (data.isEmpty()) return
+
+    val maxValue = remember(data) { data.maxOf { it.value }.coerceAtLeast(1.0) }
+    
+    Column(modifier = modifier.fillMaxWidth()) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(height.dp)
+                .padding(horizontal = 8.dp)
+        ) {
+            val canvasWidth = size.width
+            val canvasHeight = size.height
+            val barWidth = (canvasWidth / data.size) * 0.7f
+            val spacing = (canvasWidth / data.size) * 0.3f
+            
+            data.forEachIndexed { index, barData ->
+                val barHeight = (barData.value / maxValue).toFloat() * canvasHeight
+                val left = index * (barWidth + spacing) + (spacing / 2)
+                val top = canvasHeight - barHeight
+                
+                drawRoundRect(
+                    color = barData.color ?: barColor,
+                    topLeft = Offset(left, top),
+                    size = Size(barWidth, barHeight),
+                    cornerRadius = CornerRadius(4.dp.toPx(), 4.dp.toPx())
+                )
+                
+                // Draw Value Label
+                if (barHeight > 20.dp.toPx()) {
+                    drawIntoCanvas { canvas ->
+                        val paint = android.graphics.Paint().apply {
+                            color = android.graphics.Color.WHITE
+                            textSize = 10.sp.toPx()
+                            textAlign = android.graphics.Paint.Align.CENTER
+                            isAntiAlias = true
+                        }
+                        canvas.nativeCanvas.drawText(
+                            String.format(Locale.getDefault(), "$%.0f", barData.value),
+                            left + barWidth / 2,
+                            top + 15.dp.toPx(),
+                            paint
+                        )
+                    }
+                }
+            }
+        }
+        
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            data.forEach { barData ->
+                Text(
+                    text = barData.label,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.labelSmall,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                    maxLines = 1
+                )
+            }
+        }
+    }
+}

--- a/core/ui/src/main/java/com/zoewave/probase/core/ui/components/SimpleBarChart.kt
+++ b/core/ui/src/main/java/com/zoewave/probase/core/ui/components/SimpleBarChart.kt
@@ -1,8 +1,8 @@
 package com.zoewave.probase.core.ui.components
 
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,10 +18,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -37,7 +39,10 @@ data class BarData(
 fun SimpleBarChart(
     data: List<BarData>,
     modifier: Modifier = Modifier,
+    onBarClick: ((BarData) -> Unit)? = null,
+    selectedBar: BarData? = null,
     barColor: Color = MaterialTheme.colorScheme.primary,
+    selectedBarColor: Color = MaterialTheme.colorScheme.secondary,
     height: Int = 200
 ) {
     if (data.isEmpty()) return
@@ -50,6 +55,25 @@ fun SimpleBarChart(
                 .fillMaxWidth()
                 .height(height.dp)
                 .padding(horizontal = 8.dp)
+                .pointerInput(data) {
+                    detectTapGestures { offset ->
+                        val canvasWidth = size.width
+                        val barWidthWithSpacing = canvasWidth / data.size
+                        val barWidth = barWidthWithSpacing * 0.7f
+                        val spacing = barWidthWithSpacing * 0.3f
+                        
+                        data.forEachIndexed { index, barData ->
+                            val left = index * barWidthWithSpacing + (spacing / 2)
+                            val barHeight = (barData.value / maxValue).toFloat() * size.height
+                            val top = size.height - barHeight
+                            
+                            val rect = Rect(left, top, left + barWidth, size.height.toFloat())
+                            if (rect.contains(offset)) {
+                                onBarClick?.invoke(barData)
+                            }
+                        }
+                    }
+                }
         ) {
             val canvasWidth = size.width
             val canvasHeight = size.height
@@ -60,9 +84,10 @@ fun SimpleBarChart(
                 val barHeight = (barData.value / maxValue).toFloat() * canvasHeight
                 val left = index * (barWidth + spacing) + (spacing / 2)
                 val top = canvasHeight - barHeight
+                val isSelected = barData == selectedBar
                 
                 drawRoundRect(
-                    color = barData.color ?: barColor,
+                    color = if (isSelected) selectedBarColor else (barData.color ?: barColor),
                     topLeft = Offset(left, top),
                     size = Size(barWidth, barHeight),
                     cornerRadius = CornerRadius(4.dp.toPx(), 4.dp.toPx())
@@ -72,7 +97,7 @@ fun SimpleBarChart(
                 if (barHeight > 20.dp.toPx()) {
                     drawIntoCanvas { canvas ->
                         val paint = android.graphics.Paint().apply {
-                            color = android.graphics.Color.WHITE
+                            color = if (isSelected) android.graphics.Color.BLACK else android.graphics.Color.WHITE
                             textSize = 10.sp.toPx()
                             textAlign = android.graphics.Paint.Align.CENTER
                             isAntiAlias = true


### PR DESCRIPTION
feat(analytics): implement interactive bar chart and detailed trend insights

This commit enhances the spending analytics feature by adding interactivity to the trend bar chart. Users can now tap individual bars to view specific details for a given period, including total expenditure, transaction volume, and the most frequent spending category.

- **`AnalyticsViewModel.kt` & `SpendingAnalytics.kt`**:
    - Expanded the `TrendPoint` model to include `transactionCount` and `topCategory`.
    - Updated ViewModel logic to calculate the transaction count and the most frequent category for daily, weekly, and monthly trends.
- **`AnalyticsUiRoute.kt`**:
    - Introduced `selectedTrendPoint` state to track user interaction with the chart.
    - Added an `AnimatedVisibility` detail card that displays a summary (Total spent, Transaction count, Top Category) for the selected period.
    - Ensured selection resets when switching between different spending periods (Daily, Weekly, Monthly).
- **`SimpleBarChart.kt`**:
    - Implemented hit detection using `pointerInput` and `detectTapGestures` to identify which bar is clicked.
    - Added support for a `selectedBar` state to highlight the active selection with a distinct color.
    - Improved visual feedback by adjusting label text colors based on the bar's selection state.