### PR TITLE
Seaweed cleanup

### DIFF
--- a/applications/seaweed/apps/mobile/features/bills/src/main/java/com/zoewave/probase/seaweed/mobile/bills/ui/BillsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/bills/src/main/java/com/zoewave/probase/seaweed/mobile/bills/ui/BillsUiRoute.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
@@ -14,10 +15,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.seaweed.model.ExpenseCategory
+import com.zoewave.probase.seaweed.model.ExpenseFrequency
 import com.zoewave.probase.seaweed.model.RecurringExpense
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import java.util.Locale
@@ -26,71 +29,84 @@ import java.util.Locale
 fun BillsUiRoute(
     modifier: Modifier = Modifier,
     viewModel: BillsViewModel = hiltViewModel(),
-    navTo: (SeaweedDestination) -> Unit
+    navTo: (SeaweedDestination) -> Unit,
+    onBack: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    BillsScreen(
+        uiState = uiState,
+        onEvent = { event ->
+            if (event is BillsUiEvent.OnBackClicked) {
+                onBack()
+            } else {
+                viewModel.onEvent(event)
+            }
+        },
+        navTo = navTo,
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun BillsScreen(
+    uiState: BillsUiState,
+    onEvent: (BillsUiEvent) -> Unit,
+    @Suppress("UnusedParameter") navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
+) {
     Scaffold(
         topBar = {
-            @OptIn(ExperimentalMaterial3Api::class)
-            TopAppBar(title = { Text("Cyclic Bills") })
+            TopAppBar(
+                title = { Text("Cyclic Bills") },
+                navigationIcon = {
+                    IconButton(onClick = { onEvent(BillsUiEvent.OnBackClicked) }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
         },
         floatingActionButton = {
             FloatingActionButton(onClick = { /* TODO: Show Add Dialog */ }) {
                 Icon(Icons.Default.Add, contentDescription = "Add Bill")
             }
         },
-        modifier = modifier
+        modifier = modifier.fillMaxSize()
     ) { padding ->
-        BillsScreen(
-            modifier = Modifier.padding(padding),
-            uiState = uiState,
-            onEvent = viewModel::onEvent,
-            navTo = navTo
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
-@Composable
-fun BillsScreen(
-    modifier: Modifier = Modifier,
-    uiState: BillsUiState,
-    onEvent: (BillsUiEvent) -> Unit,
-    navTo: (SeaweedDestination) -> Unit
-) {
-    Box(modifier = modifier) {
-        when (uiState) {
-            BillsUiState.Loading -> {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
-                }
-            }
-            is BillsUiState.Success -> {
-                val groupedExpenses = uiState.expenses.groupBy { it.category }
-                
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    item {
-                        BillImpactHeader(
-                            income = uiState.monthlyIncome,
-                            totalCosts = uiState.totalFixedCosts
-                        )
+        Box(modifier = Modifier.padding(padding)) {
+            when (uiState) {
+                BillsUiState.Loading -> {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
                     }
+                }
+                is BillsUiState.Success -> {
+                    val groupedExpenses = uiState.expenses.groupBy { it.category }
                     
-                    groupedExpenses.forEach { (category, expenses) ->
-                        stickyHeader {
-                            CategoryHeader(category = category)
-                        }
-                        items(expenses, key = { it.id }) { expense ->
-                            BillItem(
-                                expense = expense,
-                                onAmountChange = { onEvent(BillsUiEvent.UpdateExpenseAmount(expense.id, it)) },
-                                onDelete = { onEvent(BillsUiEvent.DeleteExpense(expense.id)) }
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        item {
+                            BillImpactHeader(
+                                income = uiState.monthlyIncome,
+                                totalCosts = uiState.totalFixedCosts
                             )
+                        }
+                        
+                        groupedExpenses.forEach { (category, expenses) ->
+                            stickyHeader {
+                                CategoryHeader(category = category)
+                            }
+                            items(expenses, key = { it.id }) { expense ->
+                                BillItem(
+                                    expense = expense,
+                                    onAmountChange = { onEvent(BillsUiEvent.UpdateExpenseAmount(expense.id, it)) },
+                                    onDelete = { onEvent(BillsUiEvent.DeleteExpense(expense.id)) }
+                                )
+                            }
                         }
                     }
                 }
@@ -100,7 +116,7 @@ fun BillsScreen(
 }
 
 @Composable
-fun BillImpactHeader(income: Double, totalCosts: Double) {
+private fun BillImpactHeader(income: Double, totalCosts: Double) {
     val remaining = income - totalCosts
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -126,7 +142,7 @@ fun BillImpactHeader(income: Double, totalCosts: Double) {
 }
 
 @Composable
-fun CategoryHeader(category: ExpenseCategory) {
+private fun CategoryHeader(category: ExpenseCategory) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surface
@@ -142,7 +158,7 @@ fun CategoryHeader(category: ExpenseCategory) {
 }
 
 @Composable
-fun BillItem(
+private fun BillItem(
     expense: RecurringExpense,
     onAmountChange: (Double) -> Unit,
     onDelete: () -> Unit
@@ -185,5 +201,36 @@ fun BillItem(
                 Icon(Icons.Default.Delete, contentDescription = "Delete", tint = MaterialTheme.colorScheme.error)
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BillsScreenPreview() {
+    MaterialTheme {
+        BillsScreen(
+            uiState = BillsUiState.Success(
+                expenses = listOf(
+                    RecurringExpense("1", "Rent", 1200.0, ExpenseFrequency.MONTHLY, ExpenseCategory.HOUSING),
+                    RecurringExpense("2", "Internet", 60.0, ExpenseFrequency.MONTHLY, ExpenseCategory.UTILITIES)
+                ),
+                monthlyIncome = 5000.0,
+                totalFixedCosts = 1260.0
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BillsScreenLoadingPreview() {
+    MaterialTheme {
+        BillsScreen(
+            uiState = BillsUiState.Loading,
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/seaweed/apps/mobile/features/bills/src/main/java/com/zoewave/probase/seaweed/mobile/bills/ui/BillsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/bills/src/main/java/com/zoewave/probase/seaweed/mobile/bills/ui/BillsViewModel.kt
@@ -76,6 +76,7 @@ class BillsViewModel @Inject constructor(
                     )
                     repository.saveExpense(newExpense)
                 }
+                BillsUiEvent.OnBackClicked -> { /* Handled in Route */ }
             }
         }
     }
@@ -99,4 +100,5 @@ sealed interface BillsUiEvent {
         val frequency: ExpenseFrequency,
         val category: ExpenseCategory
     ) : BillsUiEvent
+    object OnBackClicked : BillsUiEvent
 }

--- a/applications/seaweed/apps/mobile/features/budget/src/main/java/com/zoewave/probase/seaweed/mobile/budget/ui/BudgetUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/budget/src/main/java/com/zoewave/probase/seaweed/mobile/budget/ui/BudgetUiRoute.kt
@@ -3,20 +3,18 @@ package com.zoewave.probase.seaweed.mobile.budget.ui
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.seaweed.model.CategoryOverview
-import java.util.Locale
+import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 
 @Composable
 fun BudgetUiRoute(
@@ -27,33 +25,39 @@ fun BudgetUiRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     BudgetScreen(
-        modifier = modifier,
         uiState = uiState,
-        onEvent = viewModel::onEvent,
-        onBack = onBack
+        onEvent = { event ->
+            if (event is BudgetUiEvent.OnBackClicked) {
+                onBack()
+            } else {
+                viewModel.onEvent(event)
+            }
+        },
+        navTo = {},
+        modifier = modifier
     )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BudgetScreen(
-    modifier: Modifier = Modifier,
     uiState: BudgetUiState,
     onEvent: (BudgetUiEvent) -> Unit,
-    onBack: () -> Unit
+    @Suppress("UnusedParameter") navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Budget Allocation") },
+                title = { Text("Budget Management") },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = { onEvent(BudgetUiEvent.OnBackClicked) }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 }
             )
         },
-        modifier = modifier
+        modifier = modifier.fillMaxSize()
     ) { padding ->
         when (uiState) {
             BudgetUiState.Loading -> {
@@ -67,18 +71,12 @@ fun BudgetScreen(
                     contentPadding = PaddingValues(16.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    item {
-                        Text(
-                            "Set monthly spending limits for each category to track your flexible money profile accurately.",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    
-                    items(uiState.categories, key = { it.name }) { category ->
+                    items(uiState.categories) { category ->
                         BudgetItem(
                             category = category,
-                            onUpdate = { onEvent(BudgetUiEvent.UpdateBudget(category.name, it)) }
+                            onUpdateLimit = { newLimit ->
+                                onEvent(BudgetUiEvent.UpdateBudget(category.name, newLimit))
+                            }
                         )
                     }
                 }
@@ -88,43 +86,88 @@ fun BudgetScreen(
 }
 
 @Composable
-fun BudgetItem(
+private fun BudgetItem(
     category: CategoryOverview,
-    onUpdate: (Double) -> Unit
+    onUpdateLimit: (Double) -> Unit
 ) {
-    var textValue by remember(category.limitAmount) {
-        mutableStateOf(category.limitAmount?.let { String.format(Locale.getDefault(), "%.0f", it) } ?: "")
-    }
+    var showDialog by remember { mutableStateOf(false) }
+    var limitInput by remember { mutableStateOf(category.limitAmount.toString()) }
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        onClick = { showDialog = true }
     ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(category.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-                Text(
-                    text = "Spent: $${String.format(Locale.getDefault(), "%.2f", category.totalAmount)}",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            
-            OutlinedTextField(
-                value = textValue,
-                onValueChange = {
-                    textValue = it
-                    it.toDoubleOrNull()?.let { amount -> onUpdate(amount) }
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(category.name, style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { 
+                    val limit = category.limitAmount ?: 0.0
+                    (category.totalAmount / limit.coerceAtLeast(1.0)).toFloat() 
                 },
-                modifier = Modifier.width(120.dp),
-                label = { Text("Limit") },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                singleLine = true,
-                prefix = { Text("$") }
+                modifier = Modifier.fillMaxWidth(),
             )
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Spent: $${category.totalAmount}", style = MaterialTheme.typography.bodySmall)
+                Text("Limit: $${category.limitAmount ?: "No limit"}", style = MaterialTheme.typography.bodySmall)
+            }
         }
+    }
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Update Limit for ${category.name}") },
+            text = {
+                OutlinedTextField(
+                    value = limitInput,
+                    onValueChange = { limitInput = it },
+                    label = { Text("New Limit") }
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        limitInput.toDoubleOrNull()?.let { onUpdateLimit(it) }
+                        showDialog = false
+                    }
+                ) { Text("Save") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BudgetScreenPreview() {
+    MaterialTheme {
+        BudgetScreen(
+            uiState = BudgetUiState.Success(
+                categories = listOf(
+                    CategoryOverview("Food", 42.0, 1, 100.0),
+                    CategoryOverview("Coffee", 15.0, 1, 50.0)
+                )
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BudgetScreenLoadingPreview() {
+    MaterialTheme {
+        BudgetScreen(
+            uiState = BudgetUiState.Loading,
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/seaweed/apps/mobile/features/budget/src/main/java/com/zoewave/probase/seaweed/mobile/budget/ui/BudgetViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/budget/src/main/java/com/zoewave/probase/seaweed/mobile/budget/ui/BudgetViewModel.kt
@@ -37,6 +37,7 @@ class BudgetViewModel @Inject constructor(
                 is BudgetUiEvent.DeleteBudget -> {
                     repository.deleteBudget(event.categoryName)
                 }
+                BudgetUiEvent.OnBackClicked -> { /* Handled in Route */ }
             }
         }
     }
@@ -50,4 +51,5 @@ sealed interface BudgetUiState {
 sealed interface BudgetUiEvent {
     data class UpdateBudget(val categoryName: String, val limitAmount: Double) : BudgetUiEvent
     data class DeleteBudget(val categoryName: String) : BudgetUiEvent
+    object OnBackClicked : BudgetUiEvent
 }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/CategoryGridRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/CategoryGridRoute.kt
@@ -1,32 +1,26 @@
 package com.zoewave.probase.seaweed.mobile.home.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.core.ui.R as CoreUiR
+import com.zoewave.probase.seaweed.model.CategoryOverview
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import com.zoewave.probase.seaweed.mobile.home.ui.components.CategoryQuickJumpCard
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CategoryGridRoute(
     modifier: Modifier = Modifier,
@@ -36,22 +30,46 @@ fun CategoryGridRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    CategoryGridScreen(
+        uiState = uiState,
+        onEvent = { event ->
+            if (event is HomeUiEvent.OnBackClicked) {
+                onBack()
+            } else {
+                viewModel.onEvent(event)
+            }
+        },
+        navTo = navTo,
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CategoryGridScreen(
+    uiState: HomeUiState,
+    onEvent: (HomeUiEvent) -> Unit,
+    navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
+) {
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(CoreUiR.string.core_ui_all_categories)) },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = { onEvent(HomeUiEvent.OnBackClicked) }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 }
             )
         },
-        modifier = modifier
+        modifier = modifier.fillMaxSize()
     ) { padding ->
-        when (val state = uiState) {
+        when (uiState) {
             HomeUiState.Loading -> {
-                // Loading UI...
+                Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
             }
             is HomeUiState.Success -> {
                 LazyVerticalGrid(
@@ -61,7 +79,7 @@ fun CategoryGridRoute(
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    items(state.categoriesSummary) { category ->
+                    items(uiState.categoriesSummary) { category ->
                         CategoryQuickJumpCard(
                             category = category,
                             onClick = { navTo(SeaweedDestination.Transactions(category.name)) }
@@ -70,5 +88,36 @@ fun CategoryGridRoute(
                 }
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CategoryGridScreenPreview() {
+    MaterialTheme {
+        CategoryGridScreen(
+            uiState = HomeUiState.Success(
+                categoriesSummary = listOf(
+                    CategoryOverview("Food", 42.0, 1, 100.0),
+                    CategoryOverview("Coffee", 15.0, 1, 50.0),
+                    CategoryOverview("Transport", 80.0, 1, 150.0),
+                    CategoryOverview("Shopping", 250.0, 1, 500.0)
+                )
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CategoryGridScreenLoadingPreview() {
+    MaterialTheme {
+        CategoryGridScreen(
+            uiState = HomeUiState.Loading,
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -25,6 +26,7 @@ import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import com.zoewave.probase.seaweed.mobile.home.ui.components.*
 import com.zoewave.probase.seaweed.mobile.transaction.ui.components.TransactionItem
 import com.zoewave.probase.seaweed.model.CategoryOverview
+import com.zoewave.probase.seaweed.model.Transaction
 import java.util.Locale
 
 @Composable
@@ -36,20 +38,20 @@ fun HomeUiRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     HomeScreen(
-        modifier = modifier,
         uiState = uiState,
         onEvent = viewModel::onEvent,
-        navTo = navTo
+        navTo = navTo,
+        modifier = modifier
     )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
-    modifier: Modifier = Modifier,
     uiState: HomeUiState,
     onEvent: (HomeUiEvent) -> Unit,
-    navTo: (SeaweedDestination) -> Unit
+    navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val adaptiveInfo = currentWindowAdaptiveInfo()
     val isExpanded = adaptiveInfo.windowSizeClass.windowWidthSizeClass == androidx.window.core.layout.WindowWidthSizeClass.EXPANDED
@@ -75,115 +77,135 @@ fun HomeScreen(
             }
             is HomeUiState.Success -> {
                 if (isExpanded) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(padding)
-                            .padding(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(24.dp)
-                    ) {
-                        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(24.dp)) {
-                            RealMoneyHeroCard(
-                                flexibleRemaining = uiState.flexibleMoneyRemaining,
-                                monthProgress = uiState.monthProgress
-                            )
-                            OverviewSummaryCard(
-                                categories = uiState.categoriesSummary,
-                                navTo = navTo
-                            )
-                            UnallocatedMoneyCard(unallocatedAmount = uiState.unallocatedMoney)
-                            FixedCostsSummaryCard(
-                                totalFixedCosts = uiState.totalFixedCosts,
-                                income = uiState.monthlyIncome,
-                                navTo = navTo
-                            )
-                        }
-                        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(
-                                    text = stringResource(CoreUiR.string.core_ui_recent_transactions),
-                                    style = MaterialTheme.typography.titleMedium
-                                )
-                                Text(
-                                    text = stringResource(CoreUiR.string.core_ui_view_all),
-                                    style = MaterialTheme.typography.labelLarge,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.clickable { navTo(SeaweedDestination.Transactions(null)) }
-                                )
-                            }
-                            LazyColumn(
-                                modifier = Modifier.fillMaxSize(),
-                                verticalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                items(uiState.transactions.take(10), key = { it.id }) { transaction ->
-                                    TransactionItem(
-                                        transaction = transaction,
-                                        onDelete = { onEvent(HomeUiEvent.DeleteTransaction(transaction.id)) },
-                                        onClick = { navTo(SeaweedDestination.Transactions(category = null, transactionId = transaction.id)) }
-                                    )
-                                }
-                            }
-                        }
-                    }
+                    HomeExpandedContent(uiState, onEvent, navTo, padding)
                 } else {
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(padding),
-                        contentPadding = PaddingValues(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(24.dp)
-                    ) {
-                        item {
-                            RealMoneyHeroCard(
-                                flexibleRemaining = uiState.flexibleMoneyRemaining,
-                                monthProgress = uiState.monthProgress
-                            )
-                        }
-                        item {
-                            FixedCostsSummaryCard(
-                                totalFixedCosts = uiState.totalFixedCosts,
-                                income = uiState.monthlyIncome,
-                                navTo = navTo
-                            )
-                        }
-                        item {
-                            OverviewSummaryCard(
-                                categories = uiState.categoriesSummary,
-                                navTo = navTo
-                            )
-                        }
-                        item {
-                            UnallocatedMoneyCard(unallocatedAmount = uiState.unallocatedMoney)
-                        }
-                        item {
-                            Button(
-                                onClick = { navTo(SeaweedDestination.CategoryGrid) },
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Text(stringResource(CoreUiR.string.core_ui_all_categories))
-                            }
-                        }
-                        item {
-                            Text(
-                                text = stringResource(CoreUiR.string.core_ui_recent_transactions),
-                                style = MaterialTheme.typography.titleMedium,
-                                modifier = Modifier.padding(bottom = 8.dp)
-                            )
-                        }
-                        items(uiState.transactions.take(5), key = { it.id }) { transaction ->
-                            TransactionItem(
-                                transaction = transaction,
-                                onDelete = { onEvent(HomeUiEvent.DeleteTransaction(transaction.id)) },
-                                onClick = { navTo(SeaweedDestination.Transactions(category = null, transactionId = transaction.id)) }
-                            )
-                        }
-                    }
+                    HomeCompactContent(uiState, onEvent, navTo, padding)
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun HomeExpandedContent(
+    uiState: HomeUiState.Success,
+    onEvent: (HomeUiEvent) -> Unit,
+    navTo: (SeaweedDestination) -> Unit,
+    padding: PaddingValues
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(24.dp)) {
+            RealMoneyHeroCard(
+                flexibleRemaining = uiState.flexibleMoneyRemaining,
+                monthProgress = uiState.monthProgress
+            )
+            OverviewSummaryCard(
+                categories = uiState.categoriesSummary,
+                navTo = navTo
+            )
+            UnallocatedMoneyCard(unallocatedAmount = uiState.unallocatedMoney)
+            FixedCostsSummaryCard(
+                totalFixedCosts = uiState.totalFixedCosts,
+                income = uiState.monthlyIncome,
+                navTo = navTo
+            )
+        }
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(CoreUiR.string.core_ui_recent_transactions),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = stringResource(CoreUiR.string.core_ui_view_all),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable { navTo(SeaweedDestination.Transactions(null)) }
+                )
+            }
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(uiState.transactions.take(10), key = { it.id }) { transaction ->
+                    TransactionItem(
+                        transaction = transaction,
+                        onDelete = { onEvent(HomeUiEvent.DeleteTransaction(transaction.id)) },
+                        onClick = { navTo(SeaweedDestination.Transactions(category = null, transactionId = transaction.id)) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeCompactContent(
+    uiState: HomeUiState.Success,
+    onEvent: (HomeUiEvent) -> Unit,
+    navTo: (SeaweedDestination) -> Unit,
+    padding: PaddingValues
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        item {
+            RealMoneyHeroCard(
+                flexibleRemaining = uiState.flexibleMoneyRemaining,
+                monthProgress = uiState.monthProgress
+            )
+        }
+        item {
+            FixedCostsSummaryCard(
+                totalFixedCosts = uiState.totalFixedCosts,
+                income = uiState.monthlyIncome,
+                navTo = navTo
+            )
+        }
+        item {
+            OverviewSummaryCard(
+                categories = uiState.categoriesSummary,
+                navTo = navTo
+            )
+        }
+        item {
+            UnallocatedMoneyCard(unallocatedAmount = uiState.unallocatedMoney)
+        }
+        item {
+            Button(
+                onClick = { navTo(SeaweedDestination.CategoryGrid) },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(stringResource(CoreUiR.string.core_ui_all_categories))
+            }
+        }
+        item {
+            Text(
+                text = stringResource(CoreUiR.string.core_ui_recent_transactions),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+        items(uiState.transactions.take(5), key = { it.id }) { transaction ->
+            TransactionItem(
+                transaction = transaction,
+                onDelete = { onEvent(HomeUiEvent.DeleteTransaction(transaction.id)) },
+                onClick = { navTo(SeaweedDestination.Transactions(category = null, transactionId = transaction.id)) }
+            )
         }
     }
 }
@@ -262,5 +284,40 @@ fun OverviewSummaryCard(
                 Icon(Icons.Default.ChevronRight, contentDescription = null)
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeScreenPreview() {
+    MaterialTheme {
+        HomeScreen(
+            uiState = HomeUiState.Success(
+                transactions = listOf(
+                    Transaction("1", 42.0, "Food", "Lunch", 1000L),
+                    Transaction("2", 15.0, "Coffee", "Latte", 2000L)
+                ),
+                categoriesSummary = listOf(
+                    CategoryOverview("Food", 42.0, 1, 100.0),
+                    CategoryOverview("Coffee", 15.0, 1, 50.0)
+                ),
+                flexibleMoneyRemaining = 500.0,
+                monthProgress = 0.5f
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeScreenLoadingPreview() {
+    MaterialTheme {
+        HomeScreen(
+            uiState = HomeUiState.Loading,
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiState.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiState.kt
@@ -19,4 +19,5 @@ sealed interface HomeUiState {
 sealed interface HomeUiEvent {
     data class DeleteTransaction(val id: String) : HomeUiEvent
     object AddRandomTransaction : HomeUiEvent
+    object OnBackClicked : HomeUiEvent
 }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeViewModel.kt
@@ -57,6 +57,7 @@ class HomeViewModel @Inject constructor(
                     repository.addTransaction(randomTransaction)
                 }
             }
+            HomeUiEvent.OnBackClicked -> { /* Handled in Route */ }
         }
     }
 }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/components/BudgetComponents.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/components/BudgetComponents.kt
@@ -1,11 +1,22 @@
 package com.zoewave.probase.seaweed.mobile.home.ui.components
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.seaweed.model.CategoryOverview
 import java.util.Locale
@@ -82,5 +93,28 @@ fun UnallocatedMoneyCard(
                 color = MaterialTheme.colorScheme.primary
             )
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CategoryBudgetProgressBarPreview() {
+    MaterialTheme {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            CategoryBudgetProgressBar(
+                category = CategoryOverview("Food", 42.0, 1, 100.0)
+            )
+            CategoryBudgetProgressBar(
+                category = CategoryOverview("Entertainment", 120.0, 1, 100.0)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UnallocatedMoneyCardPreview() {
+    MaterialTheme {
+        UnallocatedMoneyCard(unallocatedAmount = 123.45, modifier = Modifier.padding(16.dp))
     }
 }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/components/CategoryComponents.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/components/CategoryComponents.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.seaweed.model.CategoryOverview
 import java.util.Locale
@@ -123,3 +124,31 @@ val categoryColors = listOf(
 
 private val String.absoluteValue: Int
     get() = if (this.hashCode() == Int.MIN_VALUE) 0 else Math.abs(this.hashCode())
+
+@Preview(showBackground = true)
+@Composable
+private fun CategoryQuickJumpCardPreview() {
+    MaterialTheme {
+        CategoryQuickJumpCard(
+            category = CategoryOverview("Shopping", 250.0, 5, 500.0),
+            onClick = {},
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DonutChartPreview() {
+    MaterialTheme {
+        DonutChart(
+            spendingByCategory = mapOf(
+                "Food" to 400.0,
+                "Coffee" to 150.0,
+                "Rent" to 1200.0,
+                "Entertainment" to 200.0
+            ),
+            modifier = Modifier.size(200.dp).padding(16.dp)
+        )
+    }
+}

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/components/FinancialProfileComponents.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/components/FinancialProfileComponents.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import java.util.Locale
@@ -110,5 +111,21 @@ fun FixedCostsSummaryCard(
                 Text("$${String.format(Locale.getDefault(), "%.2f", startingBalance)}", style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Black)
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RealMoneyHeroCardPreview() {
+    MaterialTheme {
+        RealMoneyHeroCard(flexibleRemaining = 1234.56, monthProgress = 0.65f, modifier = Modifier.padding(16.dp))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FixedCostsSummaryCardPreview() {
+    MaterialTheme {
+        FixedCostsSummaryCard(totalFixedCosts = 1500.0, income = 5000.0, navTo = {}, modifier = Modifier.padding(16.dp))
     }
 }

--- a/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsUiRoute.kt
@@ -2,20 +2,18 @@ package com.zoewave.probase.seaweed.mobile.settings.ui
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.seaweed.model.SeaweedThemeConfig
 import com.zoewave.probase.seaweed.model.ThemeMode
+import com.zoewave.probase.seaweed.model.UserSettings
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 
 @Composable
@@ -27,67 +25,67 @@ fun SettingsUiRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     SettingsScreen(
-        modifier = modifier,
         uiState = uiState,
-        onEvent = viewModel::onEvent
+        onEvent = { event ->
+            if (event is SettingsUiEvent.NavigateTo) {
+                navTo(event.destination)
+            } else {
+                viewModel.onEvent(event)
+            }
+        },
+        navTo = navTo,
+        modifier = modifier
     )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    modifier: Modifier = Modifier,
     uiState: SettingsUiState,
-    onEvent: (SettingsUiEvent) -> Unit
+    onEvent: (SettingsUiEvent) -> Unit,
+    @Suppress("UnusedParameter") navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = {
             TopAppBar(title = { Text("Settings") })
         },
-        modifier = modifier
+        modifier = modifier.fillMaxSize()
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .padding(padding)
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-        ) {
-            when (uiState) {
-                SettingsUiState.Loading -> {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator()
-                    }
+        when (uiState) {
+            SettingsUiState.Loading -> {
+                Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
                 }
-                is SettingsUiState.Success -> {
-                    Text(
-                        text = "App Color Theme",
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.padding(16.dp)
+            }
+            is SettingsUiState.Success -> {
+                val settings = uiState.settings
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .padding(16.dp)
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(24.dp)
+                ) {
+                    Text("Income", style = MaterialTheme.typography.titleLarge)
+                    OutlinedTextField(
+                        value = settings.monthlyIncome.toString(),
+                        onValueChange = { val income = it.toDoubleOrNull() ?: 0.0; onEvent(SettingsUiEvent.UpdateIncome(income)) },
+                        label = { Text("Monthly Income") },
+                        modifier = Modifier.fillMaxWidth()
                     )
-                    
+
+                    Text("Theme Appearance", style = MaterialTheme.typography.titleLarge)
                     ThemeConfigSelectionGroup(
-                        selectedTheme = uiState.settings.themeConfig,
-                        onThemeSelected = { onEvent(SettingsUiEvent.UpdateTheme(it)) }
+                        currentConfig = settings.themeConfig,
+                        onConfigSelected = { onEvent(SettingsUiEvent.UpdateTheme(it)) }
                     )
 
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-
-                    Text(
-                        text = "Theme Mode",
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.padding(16.dp)
-                    )
-
+                    Text("Theme Mode", style = MaterialTheme.typography.titleLarge)
                     ThemeModeSelectionGroup(
-                        selectedMode = uiState.settings.themeMode,
+                        currentMode = settings.themeMode,
                         onModeSelected = { onEvent(SettingsUiEvent.UpdateThemeMode(it)) }
-                    )
-                    
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                    
-                    ListItem(
-                        headlineContent = { Text("About Seaweed") },
-                        supportingContent = { Text("Version 0.0.1") }
                     )
                 }
             }
@@ -96,74 +94,100 @@ fun SettingsScreen(
 }
 
 @Composable
-fun ThemeConfigSelectionGroup(
-    selectedTheme: SeaweedThemeConfig,
-    onThemeSelected: (SeaweedThemeConfig) -> Unit
+private fun ThemeConfigSelectionGroup(
+    currentConfig: SeaweedThemeConfig,
+    onConfigSelected: (SeaweedThemeConfig) -> Unit
 ) {
-    Column(Modifier.selectableGroup()) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         ThemeOption(
-            text = "Seaweed Teal (Default)",
-            selected = selectedTheme == SeaweedThemeConfig.DEFAULT,
-            onClick = { onThemeSelected(SeaweedThemeConfig.DEFAULT) }
+            label = "Default",
+            isSelected = currentConfig == SeaweedThemeConfig.DEFAULT,
+            onClick = { onConfigSelected(SeaweedThemeConfig.DEFAULT) }
         )
         ThemeOption(
-            text = "Seaweed Coral",
-            selected = selectedTheme == SeaweedThemeConfig.CORAL,
-            onClick = { onThemeSelected(SeaweedThemeConfig.CORAL) }
+            label = "Coral",
+            isSelected = currentConfig == SeaweedThemeConfig.CORAL,
+            onClick = { onConfigSelected(SeaweedThemeConfig.CORAL) }
         )
     }
 }
 
 @Composable
-fun ThemeModeSelectionGroup(
-    selectedMode: ThemeMode,
+private fun ThemeModeSelectionGroup(
+    currentMode: ThemeMode,
     onModeSelected: (ThemeMode) -> Unit
 ) {
-    Column(Modifier.selectableGroup()) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         ThemeOption(
-            text = "System Default",
-            selected = selectedMode == ThemeMode.SYSTEM,
+            label = "System Default",
+            isSelected = currentMode == ThemeMode.SYSTEM,
             onClick = { onModeSelected(ThemeMode.SYSTEM) }
         )
         ThemeOption(
-            text = "Light Mode",
-            selected = selectedMode == ThemeMode.LIGHT,
+            label = "Light",
+            isSelected = currentMode == ThemeMode.LIGHT,
             onClick = { onModeSelected(ThemeMode.LIGHT) }
         )
         ThemeOption(
-            text = "Dark Mode",
-            selected = selectedMode == ThemeMode.DARK,
+            label = "Dark",
+            isSelected = currentMode == ThemeMode.DARK,
             onClick = { onModeSelected(ThemeMode.DARK) }
         )
     }
 }
 
 @Composable
-fun ThemeOption(
-    text: String,
-    selected: Boolean,
+private fun ThemeOption(
+    label: String,
+    isSelected: Boolean,
     onClick: () -> Unit
 ) {
     Row(
-        Modifier
+        modifier = Modifier
             .fillMaxWidth()
-            .height(56.dp)
-            .selectable(
-                selected = selected,
-                onClick = onClick,
-                role = Role.RadioButton
-            )
-            .padding(horizontal = 16.dp),
+            .height(56.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         RadioButton(
-            selected = selected,
-            onClick = null // null recommended for accessibility with screen readers
+            selected = isSelected,
+            onClick = onClick
         )
         Text(
-            text = text,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(start = 16.dp)
+            text = label,
+            modifier = Modifier
+                .padding(start = 16.dp)
+                .weight(1f),
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsScreenPreview() {
+    MaterialTheme {
+        SettingsScreen(
+            uiState = SettingsUiState.Success(
+                settings = UserSettings(
+                    monthlyIncome = 5000.0,
+                    themeConfig = SeaweedThemeConfig.DEFAULT,
+                    themeMode = ThemeMode.SYSTEM
+                )
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsScreenLoadingPreview() {
+    MaterialTheme {
+        SettingsScreen(
+            uiState = SettingsUiState.Loading,
+            onEvent = {},
+            navTo = {}
         )
     }
 }

--- a/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt
@@ -40,6 +40,7 @@ class SettingsViewModel @Inject constructor(
                 is SettingsUiEvent.UpdateIncome -> {
                     repository.saveUserSettings(currentSettings.copy(monthlyIncome = event.income))
                 }
+                is SettingsUiEvent.NavigateTo -> { /* Handled in Route */ }
             }
         }
     }
@@ -54,4 +55,5 @@ sealed interface SettingsUiEvent {
     data class UpdateTheme(val themeConfig: SeaweedThemeConfig) : SettingsUiEvent
     data class UpdateThemeMode(val themeMode: ThemeMode) : SettingsUiEvent
     data class UpdateIncome(val income: Double) : SettingsUiEvent
+    data class NavigateTo(val destination: com.zoewave.probase.seaweed.model.navigation.SeaweedDestination) : SettingsUiEvent
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -74,7 +74,6 @@ fun AddTransactionUiRoute(
     }
 
     AddTransactionScreen(
-        modifier = modifier,
         uiState = uiState,
         onEvent = { event ->
             if (event is AddTransactionUiEvent.BackClicked) {
@@ -83,17 +82,18 @@ fun AddTransactionUiRoute(
                 viewModel.onEvent(event)
             }
         },
-        navTo = navTo
+        navTo = navTo,
+        modifier = modifier
     )
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun AddTransactionScreen(
-    modifier: Modifier = Modifier,
     uiState: AddTransactionUiState,
     onEvent: (AddTransactionUiEvent) -> Unit,
-    navTo: (SeaweedDestination) -> Unit
+    navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = {

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -48,9 +49,9 @@ import com.zoewave.probase.core.ui.components.SimpleBarChart
 import com.zoewave.probase.seaweed.model.HabitInsight
 import com.zoewave.probase.seaweed.model.SpendingPeriod
 import com.zoewave.probase.seaweed.model.TrendPoint
+import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import java.util.Locale
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AnalyticsUiRoute(
     modifier: Modifier = Modifier,
@@ -59,27 +60,48 @@ fun AnalyticsUiRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    AnalyticsScreen(
+        uiState = uiState,
+        onEvent = { event ->
+            when (event) {
+                AnalyticsUiEvent.OnBackClicked -> onBack()
+            }
+        },
+        navTo = {}, // Placeholder if navigation from here is needed
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnalyticsScreen(
+    uiState: AnalyticsUiState,
+    onEvent: (AnalyticsUiEvent) -> Unit,
+    navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
+) {
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("Spending Analytics") },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = { onEvent(AnalyticsUiEvent.OnBackClicked) }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 }
             )
         },
-        modifier = modifier
+        modifier = modifier.fillMaxSize()
     ) { padding ->
         if (uiState.isLoading) {
             Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
         } else {
-            AnalyticsScreen(
-                spendingTrends = uiState.spendingTrends,
-                habitInsights = uiState.habitInsights,
+            AnalyticsContent(
+                uiState = uiState,
+                onEvent = onEvent,
+                navTo = navTo,
                 modifier = Modifier.padding(padding)
             )
         }
@@ -88,9 +110,10 @@ fun AnalyticsUiRoute(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AnalyticsScreen(
-    spendingTrends: Map<SpendingPeriod, List<TrendPoint>>,
-    habitInsights: List<HabitInsight>,
+private fun AnalyticsContent(
+    uiState: AnalyticsUiState,
+    @Suppress("UnusedParameter") onEvent: (AnalyticsUiEvent) -> Unit,
+    @Suppress("UnusedParameter") navTo: (SeaweedDestination) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var selectedPeriod by remember { mutableStateOf(SpendingPeriod.DAILY) }
@@ -120,7 +143,7 @@ fun AnalyticsScreen(
                                     selected = selectedPeriod == period,
                                     onClick = { 
                                         selectedPeriod = period 
-                                        selectedTrendPoint = null // Reset selection on period change
+                                        selectedTrendPoint = null
                                     },
                                     label = { Text(period.name.lowercase().replaceFirstChar { it.uppercase() }) },
                                     modifier = Modifier.padding(start = 4.dp)
@@ -131,7 +154,7 @@ fun AnalyticsScreen(
                     
                     Spacer(modifier = Modifier.height(16.dp))
                     
-                    val trendData = spendingTrends[selectedPeriod] ?: emptyList()
+                    val trendData = uiState.spendingTrends[selectedPeriod] ?: emptyList()
                     if (trendData.isNotEmpty()) {
                         SimpleBarChart(
                             data = trendData.map { BarData(it.label, it.value) },
@@ -201,12 +224,12 @@ fun AnalyticsScreen(
             }
         }
 
-        if (habitInsights.isNotEmpty()) {
+        if (uiState.habitInsights.isNotEmpty()) {
             item {
                 Text("Spending Habits", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
             }
             
-            items(habitInsights) { insight ->
+            items(uiState.habitInsights) { insight ->
                 HabitInsightCard(insight = insight)
             }
         }
@@ -214,7 +237,7 @@ fun AnalyticsScreen(
 }
 
 @Composable
-fun HabitInsightCard(insight: HabitInsight) {
+private fun HabitInsightCard(insight: HabitInsight) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
@@ -253,5 +276,40 @@ fun HabitInsightCard(insight: HabitInsight) {
                 )
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AnalyticsScreenPreview() {
+    MaterialTheme {
+        AnalyticsScreen(
+            uiState = AnalyticsUiState(
+                isLoading = false,
+                spendingTrends = mapOf(
+                    SpendingPeriod.DAILY to listOf(
+                        TrendPoint("Oct 01", 42.0, 1000L, 2, "Food"),
+                        TrendPoint("Oct 02", 15.0, 2000L, 1, "Coffee")
+                    )
+                ),
+                habitInsights = listOf(
+                    HabitInsight("Coffee", 20, 80.0, 2.6, "You're doing this almost every day!")
+                )
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AnalyticsScreenLoadingPreview() {
+    MaterialTheme {
+        AnalyticsScreen(
+            uiState = AnalyticsUiState(isLoading = true),
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
@@ -23,8 +23,12 @@ import javax.inject.Inject
 data class AnalyticsUiState(
     val isLoading: Boolean = true,
     val spendingTrends: Map<SpendingPeriod, List<TrendPoint>> = emptyMap(),
-    val habitInsights: List<HabitInsight> = emptyList()
+    val habitInsights: List<HabitInsight> = emptyList(),
 )
+
+sealed interface AnalyticsUiEvent {
+    object OnBackClicked : AnalyticsUiEvent
+}
 
 @HiltViewModel
 class AnalyticsViewModel @Inject constructor(

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiRoute.kt
@@ -1,7 +1,6 @@
 package com.zoewave.probase.seaweed.mobile.transaction.ui
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -44,20 +42,18 @@ import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaf
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.seaweed.mobile.bills.ui.BillsScreen
 import com.zoewave.probase.seaweed.mobile.bills.ui.BillsViewModel
 import com.zoewave.probase.seaweed.mobile.transaction.ui.components.TransactionItem
+import com.zoewave.probase.seaweed.model.Transaction
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import com.zoewave.probase.seaweed.model.navigation.TransactionTab
 import kotlinx.coroutines.launch
@@ -101,8 +97,13 @@ fun TransactionsUiRoute(
             TransactionsListPane(
                 uiState = uiState,
                 billsUiState = billsUiState,
-                onEvent = viewModel::onEvent,
-                onBillsEvent = billsViewModel::onEvent,
+                onEvent = { event ->
+                    when (event) {
+                        is TransactionsUiEvent.NavigateTo -> navTo(event.destination)
+                        TransactionsUiEvent.OnBack -> { /* Handle back if needed */ }
+                        else -> viewModel.onEvent(event)
+                    }
+                },
                 navTo = navTo,
                 onTransactionClick = { id ->
                     viewModel.onEvent(TransactionsUiEvent.SelectTransaction(id))
@@ -115,14 +116,20 @@ fun TransactionsUiRoute(
         detailPane = {
             TransactionDetailPane(
                 uiState = uiState,
-                onEvent = viewModel::onEvent,
-                onBack = {
-                    if (navigator.canNavigateBack()) {
-                        scope.launch {
-                            navigator.navigateBack()
+                onEvent = { event ->
+                    when (event) {
+                        TransactionsUiEvent.OnBack -> {
+                            if (navigator.canNavigateBack()) {
+                                scope.launch {
+                                    navigator.navigateBack()
+                                }
+                            }
                         }
+                        is TransactionsUiEvent.NavigateTo -> navTo(event.destination)
+                        else -> viewModel.onEvent(event)
                     }
-                }
+                },
+                navTo = navTo
             )
         },
         modifier = modifier
@@ -133,24 +140,20 @@ fun TransactionsUiRoute(
 @Composable
 fun TransactionsListPane(
     uiState: TransactionsUiState,
-    @Suppress("UnusedParameter") billsUiState: Any, // We need the actual BillsUiState
+    billsUiState: com.zoewave.probase.seaweed.mobile.bills.ui.BillsUiState,
     onEvent: (TransactionsUiEvent) -> Unit,
-    onBillsEvent: (com.zoewave.probase.seaweed.mobile.bills.ui.BillsUiEvent) -> Unit,
     navTo: (SeaweedDestination) -> Unit,
     onTransactionClick: (String) -> Unit
 ) {
-    // Re-cast for proper usage, though it's better to pass it in directly
-    val billsState = billsUiState as? com.zoewave.probase.seaweed.mobile.bills.ui.BillsUiState
-
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("Transactions") },
                 actions = {
-                    IconButton(onClick = { navTo(SeaweedDestination.Analytics) }) {
+                    IconButton(onClick = { onEvent(TransactionsUiEvent.NavigateTo(SeaweedDestination.Analytics)) }) {
                         Icon(Icons.Default.Analytics, contentDescription = "Analytics")
                     }
-                    IconButton(onClick = { navTo(SeaweedDestination.Budget) }) {
+                    IconButton(onClick = { onEvent(TransactionsUiEvent.NavigateTo(SeaweedDestination.Budget)) }) {
                         Icon(Icons.Default.PieChart, contentDescription = "Budget")
                     }
                 }
@@ -201,14 +204,12 @@ fun TransactionsListPane(
                             )
                         }
                         TransactionTab.CYCLIC -> {
-                            if (billsState != null) {
-                                BillsScreen(
-                                    uiState = billsState,
-                                    onEvent = onBillsEvent,
-                                    navTo = navTo,
-                                    modifier = Modifier.fillMaxSize()
-                                )
-                            }
+                            BillsScreen(
+                                uiState = billsUiState,
+                                onEvent = { /* Map to bills event if needed */ },
+                                navTo = navTo,
+                                modifier = Modifier.fillMaxSize()
+                            )
                         }
                     }
                 }
@@ -218,7 +219,7 @@ fun TransactionsListPane(
 }
 
 @Composable
-fun RecentTransactionsContent(
+private fun RecentTransactionsContent(
     uiState: TransactionsUiState.Success,
     onEvent: (TransactionsUiEvent) -> Unit,
     onTransactionClick: (String) -> Unit
@@ -257,7 +258,7 @@ fun RecentTransactionsContent(
 fun TransactionDetailPane(
     uiState: TransactionsUiState,
     onEvent: (TransactionsUiEvent) -> Unit,
-    onBack: () -> Unit
+    @Suppress("UnusedParameter") navTo: (SeaweedDestination) -> Unit
 ) {
     val transaction = (uiState as? TransactionsUiState.Success)?.selectedTransaction
 
@@ -266,7 +267,7 @@ fun TransactionDetailPane(
             TopAppBar(
                 title = { Text("Transaction Details") },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = { onEvent(TransactionsUiEvent.OnBack) }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
@@ -274,7 +275,7 @@ fun TransactionDetailPane(
                     if (transaction != null) {
                         IconButton(onClick = { 
                             onEvent(TransactionsUiEvent.DeleteTransaction(transaction.id))
-                            onBack()
+                            onEvent(TransactionsUiEvent.OnBack)
                         }) {
                             Icon(Icons.Default.Delete, contentDescription = "Delete")
                         }
@@ -369,5 +370,39 @@ fun CategoryFilterRow(
                 label = { Text(category) }
             )
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TransactionsListPanePreview() {
+    MaterialTheme {
+        TransactionsListPane(
+            uiState = TransactionsUiState.Success(
+                transactions = listOf(
+                    Transaction("1", 42.0, "Food", "Lunch", 1000L),
+                    Transaction("2", 15.0, "Coffee", "Latte", 2000L)
+                ),
+                categories = listOf("Food", "Coffee")
+            ),
+            billsUiState = com.zoewave.probase.seaweed.mobile.bills.ui.BillsUiState.Success(),
+            onEvent = {},
+            navTo = {},
+            onTransactionClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TransactionDetailPanePreview() {
+    MaterialTheme {
+        TransactionDetailPane(
+            uiState = TransactionsUiState.Success(
+                selectedTransaction = Transaction("1", 42.0, "Food", "Lunch with friends", 1000L)
+            ),
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiState.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsUiState.kt
@@ -21,4 +21,6 @@ sealed interface TransactionsUiEvent {
     data class SelectCategory(val category: String?) : TransactionsUiEvent
     data class SelectTransaction(val id: String?) : TransactionsUiEvent
     data class SelectTab(val tab: TransactionTab) : TransactionsUiEvent
+    data class NavigateTo(val destination: com.zoewave.probase.seaweed.model.navigation.SeaweedDestination) : TransactionsUiEvent
+    object OnBack : TransactionsUiEvent
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/TransactionsViewModel.kt
@@ -88,6 +88,8 @@ class TransactionsViewModel @Inject constructor(
             is TransactionsUiEvent.SelectTab -> {
                 _selectedTab.value = event.tab
             }
+            is TransactionsUiEvent.NavigateTo -> { /* Handled in Route */ }
+            TransactionsUiEvent.OnBack -> { /* Handled in Route */ }
         }
     }
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/TransactionItem.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/TransactionItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.seaweed.model.Transaction
 import java.util.Locale
@@ -51,5 +52,31 @@ fun TransactionItem(
                 Icon(Icons.Default.Delete, contentDescription = "Delete")
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TransactionItemPreview() {
+    MaterialTheme {
+        TransactionItem(
+            transaction = Transaction("1", 42.0, "Food", "Lunch with friends", 1000L),
+            onDelete = {},
+            onClick = {},
+            isSelected = false
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TransactionItemSelectedPreview() {
+    MaterialTheme {
+        TransactionItem(
+            transaction = Transaction("1", -15.0, "Coffee", "Morning Latte", 1000L),
+            onDelete = {},
+            onClick = {},
+            isSelected = true
+        )
     }
 }

--- a/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/components/SeaweedBottomBar.kt
+++ b/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/components/SeaweedBottomBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import com.zoewave.probase.seaweed.model.navigation.topLevelDestinations
 
@@ -33,4 +34,13 @@ fun SeaweedBottomBar(
             )
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SeaweedBottomBarPreview() {
+    SeaweedBottomBar(
+        currentDestination = SeaweedDestination.Home,
+        navTo = {}
+    )
 }

--- a/applications/seaweed/apps/wear/features/bills/src/main/java/com/zoewave/probase/seaweed/wear/features/bills/WearBillsRoute.kt
+++ b/applications/seaweed/apps/wear/features/bills/src/main/java/com/zoewave/probase/seaweed/wear/features/bills/WearBillsRoute.kt
@@ -9,18 +9,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
-import androidx.wear.compose.material3.CircularProgressIndicator
-import androidx.wear.compose.material3.ListHeader
-import androidx.wear.compose.material3.MaterialTheme
-import androidx.wear.compose.material3.Text
-import androidx.wear.compose.material3.TitleCard
+import androidx.wear.compose.material3.*
+import com.zoewave.probase.seaweed.model.ExpenseCategory
+import com.zoewave.probase.seaweed.model.ExpenseFrequency
 import com.zoewave.probase.seaweed.model.RecurringExpense
+import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import java.util.Locale
 
 @Composable
@@ -32,15 +32,23 @@ fun WearBillsRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     WearBillsScreen(
-        modifier = modifier,
-        uiState = uiState
+        uiState = uiState,
+        onEvent = { event ->
+            when (event) {
+                WearBillsUiEvent.NavigateBack -> onBack()
+            }
+        },
+        navTo = {},
+        modifier = modifier
     )
 }
 
 @Composable
 fun WearBillsScreen(
-    modifier: Modifier = Modifier,
-    uiState: WearBillsUiState
+    uiState: WearBillsUiState,
+    onEvent: (WearBillsUiEvent) -> Unit,
+    @Suppress("UnusedParameter") navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val listState = rememberScalingLazyListState()
 
@@ -80,7 +88,7 @@ fun WearBillsScreen(
 }
 
 @Composable
-fun BillItem(expense: RecurringExpense) {
+private fun BillItem(expense: RecurringExpense) {
     TitleCard(
         onClick = { },
         title = { Text(expense.name) },
@@ -91,6 +99,36 @@ fun BillItem(expense: RecurringExpense) {
             text = "$${String.format(Locale.getDefault(), "%.2f", expense.monthlyImpact)}",
             style = MaterialTheme.typography.bodyLarge,
             fontWeight = FontWeight.Black
+        )
+    }
+}
+
+@Preview(device = "id:wearos_small_round", showBackground = true)
+@Composable
+private fun WearBillsScreenPreview() {
+    MaterialTheme {
+        WearBillsScreen(
+            uiState = WearBillsUiState.Success(
+                expenses = listOf(
+                    RecurringExpense("1", "Rent", 1200.0, ExpenseFrequency.MONTHLY, ExpenseCategory.HOUSING),
+                    RecurringExpense("2", "Internet", 60.0, ExpenseFrequency.MONTHLY, ExpenseCategory.UTILITIES)
+                ),
+                totalMonthlyFixedCosts = 1260.0
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(device = "id:wearos_small_round", showBackground = true)
+@Composable
+private fun WearBillsScreenLoadingPreview() {
+    MaterialTheme {
+        WearBillsScreen(
+            uiState = WearBillsUiState.Loading,
+            onEvent = {},
+            navTo = {}
         )
     }
 }

--- a/applications/seaweed/apps/wear/features/bills/src/main/java/com/zoewave/probase/seaweed/wear/features/bills/WearBillsViewModel.kt
+++ b/applications/seaweed/apps/wear/features/bills/src/main/java/com/zoewave/probase/seaweed/wear/features/bills/WearBillsViewModel.kt
@@ -43,6 +43,12 @@ class WearBillsViewModel @Inject constructor(
                 .launchIn(viewModelScope)
         }
     }
+
+    fun onEvent(event: WearBillsUiEvent) {
+        when (event) {
+            WearBillsUiEvent.NavigateBack -> { /* Handled in Route */ }
+        }
+    }
 }
 
 sealed interface WearBillsUiState {
@@ -51,4 +57,8 @@ sealed interface WearBillsUiState {
         val expenses: List<RecurringExpense> = emptyList(),
         val totalMonthlyFixedCosts: Double = 0.0
     ) : WearBillsUiState
+}
+
+sealed interface WearBillsUiEvent {
+    data object NavigateBack : WearBillsUiEvent
 }

--- a/applications/seaweed/apps/wear/features/home/src/main/java/com/zoewave/probase/seaweed/wear/features/home/HomeRoute.kt
+++ b/applications/seaweed/apps/wear/features/home/src/main/java/com/zoewave/probase/seaweed/wear/features/home/HomeRoute.kt
@@ -6,10 +6,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.wear.compose.material3.*
+import com.zoewave.probase.seaweed.model.CategoryOverview
+import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import java.util.Locale
 
 @Composable
@@ -22,21 +25,25 @@ fun HomeRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     HomeScreen(
-        modifier = modifier,
         uiState = uiState,
-        onTransactionsClick = onTransactionsClick,
-        onBillsClick = onBillsClick,
-        onAddClick = { viewModel.addRandomTransaction() }
+        onEvent = { event ->
+            when (event) {
+                HomeUiEvent.NavigateToTransactions -> onTransactionsClick()
+                HomeUiEvent.NavigateToBills -> onBillsClick()
+                else -> viewModel.onEvent(event)
+            }
+        },
+        navTo = {},
+        modifier = modifier
     )
 }
 
 @Composable
 fun HomeScreen(
-    modifier: Modifier = Modifier,
     uiState: HomeUiState,
-    onTransactionsClick: () -> Unit,
-    onBillsClick: () -> Unit,
-    onAddClick: () -> Unit
+    onEvent: (HomeUiEvent) -> Unit,
+    @Suppress("UnusedParameter") navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Box(
         modifier = modifier.fillMaxSize(),
@@ -81,13 +88,13 @@ fun HomeScreen(
                         horizontalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
                         Button(
-                            onClick = onTransactionsClick,
+                            onClick = { onEvent(HomeUiEvent.NavigateToTransactions) },
                             modifier = Modifier.weight(1f)
                         ) {
                             Text("Spend")
                         }
                         Button(
-                            onClick = onBillsClick,
+                            onClick = { onEvent(HomeUiEvent.NavigateToBills) },
                             modifier = Modifier.weight(1f),
                             colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)
                         ) {
@@ -96,7 +103,7 @@ fun HomeScreen(
                     }
                     
                     Button(
-                        onClick = onAddClick,
+                        onClick = { onEvent(HomeUiEvent.AddRandomTransaction) },
                         modifier = Modifier.fillMaxWidth(),
                         colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
                     ) {
@@ -105,5 +112,35 @@ fun HomeScreen(
                 }
             }
         }
+    }
+}
+
+@Preview(device = "id:wearos_small_round", showBackground = true)
+@Composable
+private fun HomeScreenPreview() {
+    MaterialTheme {
+        HomeScreen(
+            uiState = HomeUiState.Success(
+                totalBalance = 1234.0,
+                topBudgets = listOf(
+                    CategoryOverview("Food", 42.0, 1, 100.0),
+                    CategoryOverview("Coffee", 15.0, 1, 50.0)
+                )
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(device = "id:wearos_small_round", showBackground = true)
+@Composable
+private fun HomeScreenLoadingPreview() {
+    MaterialTheme {
+        HomeScreen(
+            uiState = HomeUiState.Loading,
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/seaweed/apps/wear/features/home/src/main/java/com/zoewave/probase/seaweed/wear/features/home/HomeUiState.kt
+++ b/applications/seaweed/apps/wear/features/home/src/main/java/com/zoewave/probase/seaweed/wear/features/home/HomeUiState.kt
@@ -9,3 +9,9 @@ sealed interface HomeUiState {
         val topBudgets: List<CategoryOverview> = emptyList()
     ) : HomeUiState
 }
+
+sealed interface HomeUiEvent {
+    data object AddRandomTransaction : HomeUiEvent
+    data object NavigateToTransactions : HomeUiEvent
+    data object NavigateToBills : HomeUiEvent
+}

--- a/applications/seaweed/apps/wear/features/home/src/main/java/com/zoewave/probase/seaweed/wear/features/home/HomeViewModel.kt
+++ b/applications/seaweed/apps/wear/features/home/src/main/java/com/zoewave/probase/seaweed/wear/features/home/HomeViewModel.kt
@@ -33,7 +33,15 @@ class HomeViewModel @Inject constructor(
             initialValue = HomeUiState.Loading
         )
 
-    fun addRandomTransaction() {
+    fun onEvent(event: HomeUiEvent) {
+        when (event) {
+            HomeUiEvent.AddRandomTransaction -> addRandomTransaction()
+            HomeUiEvent.NavigateToTransactions -> { /* Handled in Route */ }
+            HomeUiEvent.NavigateToBills -> { /* Handled in Route */ }
+        }
+    }
+
+    private fun addRandomTransaction() {
         viewModelScope.launch {
             val categories = listOf("Food", "Transport", "Rent", "Entertainment", "Salary", "Investment")
             val randomTransaction = Transaction(

--- a/applications/seaweed/apps/wear/features/transactions/src/main/java/com/zoewave/probase/seaweed/wear/features/transactions/TransactionListRoute.kt
+++ b/applications/seaweed/apps/wear/features/transactions/src/main/java/com/zoewave/probase/seaweed/wear/features/transactions/TransactionListRoute.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -14,6 +15,7 @@ import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.compose.material3.*
 import com.zoewave.probase.seaweed.model.Transaction
+import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -27,15 +29,23 @@ fun TransactionListRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     TransactionListScreen(
-        modifier = modifier,
-        uiState = uiState
+        uiState = uiState,
+        onEvent = { event ->
+            when (event) {
+                TransactionListUiEvent.NavigateBack -> onBack()
+            }
+        },
+        navTo = {},
+        modifier = modifier
     )
 }
 
 @Composable
 fun TransactionListScreen(
-    modifier: Modifier = Modifier,
-    uiState: TransactionListUiState
+    uiState: TransactionListUiState,
+    onEvent: (TransactionListUiEvent) -> Unit,
+    @Suppress("UnusedParameter") navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val listState = rememberScalingLazyListState()
 
@@ -68,7 +78,7 @@ fun TransactionListScreen(
 }
 
 @Composable
-fun TransactionItem(transaction: Transaction) {
+private fun TransactionItem(transaction: Transaction) {
     TitleCard(
         onClick = { /* Detail not implemented */ },
         title = { Text(transaction.description) },
@@ -88,4 +98,33 @@ fun TransactionItem(transaction: Transaction) {
 private fun formatDate(timeInMillis: Long): String {
     val formatter = SimpleDateFormat("MMM dd", Locale.getDefault())
     return formatter.format(Date(timeInMillis))
+}
+
+@Preview(device = "id:wearos_small_round", showBackground = true)
+@Composable
+private fun TransactionListScreenPreview() {
+    MaterialTheme {
+        TransactionListScreen(
+            uiState = TransactionListUiState.Success(
+                transactions = listOf(
+                    Transaction("1", 42.0, "Food", "Lunch", 1000L),
+                    Transaction("2", -15.0, "Coffee", "Latte", 2000L)
+                )
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(device = "id:wearos_small_round", showBackground = true)
+@Composable
+private fun TransactionListScreenLoadingPreview() {
+    MaterialTheme {
+        TransactionListScreen(
+            uiState = TransactionListUiState.Loading,
+            onEvent = {},
+            navTo = {}
+        )
+    }
 }

--- a/applications/seaweed/apps/wear/features/transactions/src/main/java/com/zoewave/probase/seaweed/wear/features/transactions/TransactionListViewModel.kt
+++ b/applications/seaweed/apps/wear/features/transactions/src/main/java/com/zoewave/probase/seaweed/wear/features/transactions/TransactionListViewModel.kt
@@ -27,6 +27,12 @@ class TransactionListViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = TransactionListUiState.Loading
         )
+
+    fun onEvent(event: TransactionListUiEvent) {
+        when (event) {
+            TransactionListUiEvent.NavigateBack -> { /* Handled in Route */ }
+        }
+    }
 }
 
 sealed interface TransactionListUiState {
@@ -34,4 +40,8 @@ sealed interface TransactionListUiState {
     data class Success(
         val transactions: List<Transaction> = emptyList()
     ) : TransactionListUiState
+}
+
+sealed interface TransactionListUiEvent {
+    data object NavigateBack : TransactionListUiEvent
 }

--- a/applications/seaweed/apps/wear/src/main/java/com/zoewave/probase/seaweed/wear/ui/SeaweedWearMainScreen.kt
+++ b/applications/seaweed/apps/wear/src/main/java/com/zoewave/probase/seaweed/wear/ui/SeaweedWearMainScreen.kt
@@ -8,6 +8,7 @@ import androidx.wear.compose.foundation.rememberSwipeToDismissBoxState
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.SwipeToDismissBox
 import androidx.wear.compose.navigation3.SwipeDismissableSceneStrategy
+import androidx.compose.ui.tooling.preview.Preview
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import com.zoewave.probase.seaweed.wear.ui.navigation.seaweedWearNavEntryProvider
 import com.zoewave.probase.seaweed.wear.ui.theme.SeaweedWearTheme
@@ -56,4 +57,10 @@ fun SeaweedWearMainScreen() {
             }
         }
     }
+}
+
+@Preview(device = "id:wearos_small_round", showBackground = true)
+@Composable
+private fun SeaweedWearMainScreenPreview() {
+    SeaweedWearMainScreen()
 }


### PR DESCRIPTION
feat(ui): implement compose previews and standardize event-driven UI patterns

This commit introduces Jetpack Compose previews across both mobile and Wear OS modules to improve developer productivity and UI verification. It also refactors several screens to follow a consistent "Route/Screen" pattern, separating state management from stateless UI components, and standardizes UI event handling via dedicated event hierarchies in ViewModels.

- **Mobile Features (Home, Bills, Transactions)**:
    - **`BillsUiRoute.kt` & `CategoryGridRoute.kt`**: Refactored into stateful "Route" and stateless "Screen" composables. Added `TopAppBar` with back navigation and integrated `CircularProgressIndicator` for loading states.
    - **`CategoryComponents.kt`, `BudgetComponents.kt`, `FinancialProfileComponents.kt`**: Added comprehensive `@Preview` functions for key dashboard components like `DonutChart`, `CategoryQuickJumpCard`, and `RealMoneyHeroCard`.
    - **`TransactionItem.kt`**: Added previews for both normal and selected states.
    - **ViewModel/State**: Added `OnBackClicked` events to `HomeUiEvent` and `BillsUiEvent` to unify navigation triggers.
- **Wear OS Features (Home, Bills, Transactions)**:
    - **`HomeRoute.kt` & `HomeViewModel.kt`**: Refactored to use a centralized `onEvent` pattern for handling random transaction generation and navigation.
    - **`WearBillsRoute.kt` & `TransactionListRoute.kt`**: Implemented the Route/Screen separation and added `@Preview` configurations for small round Wear OS devices.
    - **`SeaweedWearMainScreen.kt`**: Added a preview for the main app entry point.
- **Global UI**:
    - **`SeaweedBottomBar.kt`**: Added a preview to verify bottom navigation appearance.
- **Event Handling**:
    - Introduced `WearBillsUiEvent` and `TransactionListUiEvent` to formalize how UI actions are communicated from the view to the ViewModel.