### PR TITLE
Seaweed test

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -93,28 +93,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="resources/com/zoewave/probase/photodo/mobile/main_flow.journey.xml">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-05T23:12:46.371808Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_10_Pro_Fold.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
-      <SelectionState runConfigName="resources/com/zoewave/probase/photodo/wear/wear_main_flow.journey.xml">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-02T00:24:34.319858Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Wear_OS_XL_Round.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
       <SelectionState runConfigName="applications.goswift.apps.wear">
         <option name="selectionMode" value="DROPDOWN" />
         <DropdownSelection timestamp="2026-04-09T19:02:11.170646Z">

--- a/applications/seaweed/apps/mobile/features/transaction/build.gradle.kts
+++ b/applications/seaweed/apps/mobile/features/transaction/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(project(":applications:seaweed:apps:mobile:features:bills"))
     implementation(project(":features:ai:vision"))
     implementation(project(":features:ai:capture"))
+    implementation(project(":features:ai:configuration"))
 
     implementation(libs.coil.compose)
     implementation(libs.mlkit.text.recognition)

--- a/applications/seaweed/apps/mobile/features/transaction/build.gradle.kts
+++ b/applications/seaweed/apps/mobile/features/transaction/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(project(":applications:seaweed:features:main"))
     implementation(project(":applications:seaweed:apps:mobile:features:bills"))
     implementation(project(":features:ai:vision"))
+    implementation(project(":features:ai:capture"))
 
     implementation(libs.coil.compose)
     implementation(libs.mlkit.text.recognition)

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -1,12 +1,17 @@
 package com.zoewave.probase.seaweed.mobile.transaction.ui
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -30,6 +35,7 @@ import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.ShoppingBag
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -113,201 +119,219 @@ fun AddTransactionScreen(
         },
         modifier = modifier
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .padding(padding)
-                .padding(16.dp)
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            uiState.receiptUri?.let { uri ->
-                AsyncImage(
-                    model = uri,
-                    contentDescription = "Receipt",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(200.dp),
-                    contentScale = ContentScale.Crop
-                )
-            }
-            OutlinedTextField(
-                value = uiState.description,
-                onValueChange = { onEvent(AddTransactionUiEvent.DescriptionChanged(it)) },
-                label = { Text("Description") },
-                modifier = Modifier.fillMaxWidth()
-            )
-            OutlinedTextField(
-                value = uiState.amount,
-                onValueChange = { onEvent(AddTransactionUiEvent.AmountChanged(it)) },
-                label = { Text("Amount") },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            QuickExpenseBar(
-                onAdjustAmount = { delta -> onEvent(AddTransactionUiEvent.AdjustAmount(delta)) }
-            )
-
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                uiState.receiptUri?.let { uri ->
+                    AsyncImage(
+                        model = uri,
+                        contentDescription = "Receipt",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(200.dp),
+                        contentScale = ContentScale.Crop
+                    )
+                }
                 OutlinedTextField(
-                    value = uiState.category,
-                    onValueChange = { onEvent(AddTransactionUiEvent.CategoryChanged(it)) },
-                    label = { Text("Category") },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .onFocusChanged { focusState ->
-                            onEvent(AddTransactionUiEvent.SetCategorySuggestionsVisible(focusState.isFocused))
-                        },
-                    trailingIcon = { Icon(Icons.Default.Category, contentDescription = null) }
+                    value = uiState.description,
+                    onValueChange = { onEvent(AddTransactionUiEvent.DescriptionChanged(it)) },
+                    label = { Text("Description") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = uiState.amount,
+                    onValueChange = { onEvent(AddTransactionUiEvent.AmountChanged(it)) },
+                    label = { Text("Amount") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.fillMaxWidth()
                 )
 
-                AnimatedVisibility(visible = uiState.isCategorySuggestionsVisible) {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        if (uiState.recentCategories.isNotEmpty()) {
-                            Text("Recent", style = MaterialTheme.typography.labelMedium)
-                            LazyRow(
+                QuickExpenseBar(
+                    onAdjustAmount = { delta -> onEvent(AddTransactionUiEvent.AdjustAmount(delta)) }
+                )
+
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = uiState.category,
+                        onValueChange = { onEvent(AddTransactionUiEvent.CategoryChanged(it)) },
+                        label = { Text("Category") },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .onFocusChanged { focusState ->
+                                onEvent(AddTransactionUiEvent.SetCategorySuggestionsVisible(focusState.isFocused))
+                            },
+                        trailingIcon = { Icon(Icons.Default.Category, contentDescription = null) }
+                    )
+
+                    AnimatedVisibility(visible = uiState.isCategorySuggestionsVisible) {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            if (uiState.recentCategories.isNotEmpty()) {
+                                Text("Recent", style = MaterialTheme.typography.labelMedium)
+                                LazyRow(
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    contentPadding = PaddingValues(bottom = 8.dp)
+                                ) {
+                                    items(uiState.recentCategories) { category ->
+                                        AssistChip(
+                                            onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(category)) },
+                                            label = { Text(category) }
+                                        )
+                                    }
+                                }
+                            }
+
+                            Text("Suggestions", style = MaterialTheme.typography.labelMedium)
+                            FlowRow(
+                                modifier = Modifier.fillMaxWidth(),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                contentPadding = PaddingValues(bottom = 8.dp)
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
-                                items(uiState.recentCategories) { category ->
-                                    AssistChip(
-                                        onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(category)) },
-                                        label = { Text(category) }
+                                val suggestions = listOf(
+                                    "Food" to Icons.Default.Fastfood,
+                                    "Coffee" to Icons.Default.Coffee,
+                                    "Transport" to Icons.Default.DirectionsBus,
+                                    "Shopping" to Icons.Default.ShoppingBag,
+                                    "Housing" to Icons.Default.Home,
+                                    "Health" to Icons.Default.LocalHospital
+                                )
+                                suggestions.forEach { (name, icon) ->
+                                    val isSelected = uiState.category.equals(name, ignoreCase = true)
+                                    FilterChip(
+                                        selected = isSelected,
+                                        onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(name)) },
+                                        label = { Text(name) },
+                                        leadingIcon = {
+                                            Icon(
+                                                icon,
+                                                contentDescription = null,
+                                                modifier = Modifier.size(18.dp)
+                                            )
+                                        }
                                     )
                                 }
                             }
                         }
+                    }
+                }
 
-                        Text("Suggestions", style = MaterialTheme.typography.labelMedium)
-                        FlowRow(
+                Button(
+                    onClick = { onEvent(AddTransactionUiEvent.SaveTransaction) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    val base = uiState.amount.toDoubleOrNull() ?: 0.0
+                    val tip = uiState.customTipAmount.toDoubleOrNull() ?: 0.0
+                    val total = base + tip
+                    if (total > 0 && tip > 0) {
+                        Text("Save (Total: $${String.format(Locale.getDefault(), "%.2f", total)})")
+                    } else {
+                        Text("Save")
+                    }
+                }
+
+                TextButton(
+                    onClick = { onEvent(AddTransactionUiEvent.ToggleTipWidget) },
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                ) {
+                    Text(if (uiState.isTipWidgetVisible) "Hide Tip Options" else "Add Tip")
+                }
+
+                AnimatedVisibility(visible = uiState.isTipWidgetVisible) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text("Standard Tips", style = MaterialTheme.typography.labelMedium)
+                        Row(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
-                            val suggestions = listOf(
-                                "Food" to Icons.Default.Fastfood,
-                                "Coffee" to Icons.Default.Coffee,
-                                "Transport" to Icons.Default.DirectionsBus,
-                                "Shopping" to Icons.Default.ShoppingBag,
-                                "Housing" to Icons.Default.Home,
-                                "Health" to Icons.Default.LocalHospital
-                            )
-                            suggestions.forEach { (name, icon) ->
-                                val isSelected = uiState.category.equals(name, ignoreCase = true)
+                            listOf(10, 15, 18, 20).forEach { percentage ->
                                 FilterChip(
-                                    selected = isSelected,
-                                    onClick = { onEvent(AddTransactionUiEvent.CategoryChanged(name)) },
-                                    label = { Text(name) },
-                                    leadingIcon = {
-                                        Icon(
-                                            icon,
-                                            contentDescription = null,
-                                            modifier = Modifier.size(18.dp)
-                                        )
-                                    }
+                                    selected = uiState.tipPercentage == percentage,
+                                    onClick = { onEvent(AddTransactionUiEvent.SelectTipPercentage(percentage)) },
+                                    label = { Text("$percentage%") }
                                 )
                             }
-                        }
-                    }
-                }
-            }
-
-            Button(
-                onClick = { onEvent(AddTransactionUiEvent.SaveTransaction) },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                val base = uiState.amount.toDoubleOrNull() ?: 0.0
-                val tip = uiState.customTipAmount.toDoubleOrNull() ?: 0.0
-                val total = base + tip
-                if (total > 0 && tip > 0) {
-                    Text("Save (Total: $${String.format(Locale.getDefault(), "%.2f", total)})")
-                } else {
-                    Text("Save")
-                }
-            }
-
-            TextButton(
-                onClick = { onEvent(AddTransactionUiEvent.ToggleTipWidget) },
-                modifier = Modifier.align(Alignment.CenterHorizontally)
-            ) {
-                Text(if (uiState.isTipWidgetVisible) "Hide Tip Options" else "Add Tip")
-            }
-
-            AnimatedVisibility(visible = uiState.isTipWidgetVisible) {
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text("Standard Tips", style = MaterialTheme.typography.labelMedium)
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        listOf(10, 15, 18, 20).forEach { percentage ->
                             FilterChip(
-                                selected = uiState.tipPercentage == percentage,
-                                onClick = { onEvent(AddTransactionUiEvent.SelectTipPercentage(percentage)) },
-                                label = { Text("$percentage%") }
+                                selected = uiState.tipPercentage == null && uiState.customTipAmount.isNotEmpty(),
+                                onClick = { onEvent(AddTransactionUiEvent.SelectTipPercentage(null)) },
+                                label = { Text("None") }
                             )
                         }
-                        FilterChip(
-                            selected = uiState.tipPercentage == null && uiState.customTipAmount.isNotEmpty(),
-                            onClick = { onEvent(AddTransactionUiEvent.SelectTipPercentage(null)) },
-                            label = { Text("None") }
+                        OutlinedTextField(
+                            value = uiState.customTipAmount,
+                            onValueChange = { onEvent(AddTransactionUiEvent.CustomTipAmountChanged(it)) },
+                            label = { Text("Tip Amount") },
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                            modifier = Modifier.fillMaxWidth()
                         )
                     }
-                    OutlinedTextField(
-                        value = uiState.customTipAmount,
-                        onValueChange = { onEvent(AddTransactionUiEvent.CustomTipAmountChanged(it)) },
-                        label = { Text("Tip Amount") },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                }
+
+                TextButton(
+                    onClick = { onEvent(AddTransactionUiEvent.ToggleSplitWidget) },
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                ) {
+                    Text(if (uiState.isSplitWidgetVisible) "Hide Split Bill" else "Split Bill")
+                }
+
+                AnimatedVisibility(visible = uiState.isSplitWidgetVisible) {
+                    val base = uiState.amount.toDoubleOrNull() ?: 0.0
+                    val tip = uiState.customTipAmount.toDoubleOrNull() ?: 0.0
+                    val total = base + tip
+                    val perPerson = if (uiState.splitCount > 0) total / uiState.splitCount else total
+
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text("Split among", style = MaterialTheme.typography.labelMedium)
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            IconButton(onClick = { onEvent(AddTransactionUiEvent.SplitCountChanged(uiState.splitCount - 1)) }) {
+                                Icon(Icons.Default.Remove, contentDescription = "Remove person")
+                            }
+                            Text(
+                                text = "${uiState.splitCount} people",
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Bold
+                            )
+                            IconButton(onClick = { onEvent(AddTransactionUiEvent.SplitCountChanged(uiState.splitCount + 1)) }) {
+                                Icon(Icons.Default.Add, contentDescription = "Add person")
+                            }
+                        }
+                        if (uiState.splitCount > 1) {
+                            Text(
+                                text = "Each person pays: $${String.format(Locale.getDefault(), "%.2f", perPerson)}",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
                 }
             }
 
-            TextButton(
-                onClick = { onEvent(AddTransactionUiEvent.ToggleSplitWidget) },
-                modifier = Modifier.align(Alignment.CenterHorizontally)
-            ) {
-                Text(if (uiState.isSplitWidgetVisible) "Hide Split Bill" else "Split Bill")
-            }
-
-            AnimatedVisibility(visible = uiState.isSplitWidgetVisible) {
-                val base = uiState.amount.toDoubleOrNull() ?: 0.0
-                val tip = uiState.customTipAmount.toDoubleOrNull() ?: 0.0
-                val total = base + tip
-                val perPerson = if (uiState.splitCount > 0) total / uiState.splitCount else total
-
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+            if (uiState.isLoading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.7f))
+                        .clickable(enabled = false) {},
+                    contentAlignment = Alignment.Center
                 ) {
-                    Text("Split among", style = MaterialTheme.typography.labelMedium)
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        IconButton(onClick = { onEvent(AddTransactionUiEvent.SplitCountChanged(uiState.splitCount - 1)) }) {
-                            Icon(Icons.Default.Remove, contentDescription = "Remove person")
-                        }
-                        Text(
-                            text = "${uiState.splitCount} people",
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Bold
-                        )
-                        IconButton(onClick = { onEvent(AddTransactionUiEvent.SplitCountChanged(uiState.splitCount + 1)) }) {
-                            Icon(Icons.Default.Add, contentDescription = "Add person")
-                        }
-                    }
-                    if (uiState.splitCount > 1) {
-                        Text(
-                            text = "Each person pays: $${String.format(Locale.getDefault(), "%.2f", perPerson)}",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.primary
-                        )
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        CircularProgressIndicator()
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text("AI is analyzing receipt...", style = MaterialTheme.typography.bodyMedium)
                     }
                 }
             }
@@ -317,7 +341,7 @@ fun AddTransactionScreen(
 
 @Preview(showBackground = true)
 @Composable
-private fun AddTransactionScreenPreview() {
+fun AddTransactionScreenPreview() {
     MaterialTheme {
         AddTransactionScreen(
             uiState = AddTransactionUiState(
@@ -339,7 +363,7 @@ private fun AddTransactionScreenPreview() {
 
 @Preview(showBackground = true, name = "Empty State")
 @Composable
-private fun AddTransactionScreenEmptyPreview() {
+fun AddTransactionScreenEmptyPreview() {
     MaterialTheme {
         AddTransactionScreen(
             uiState = AddTransactionUiState(),

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Coffee
@@ -86,10 +87,20 @@ fun AddTransactionUiRoute(
     AddTransactionScreen(
         uiState = uiState,
         onEvent = { event ->
-            if (event is AddTransactionUiEvent.BackClicked) {
-                onBack()
-            } else {
-                viewModel.onEvent(event)
+            when (event) {
+                is AddTransactionUiEvent.BackClicked -> onBack()
+                AddTransactionUiEvent.DebugAiClicked -> {
+                    uiState.lastAiDebugInfo?.let { debug ->
+                        navTo(
+                            SeaweedDestination.SmartReceiptDebug(
+                                rawResponse = debug.rawResponse,
+                                logs = debug.logs,
+                                engineUsed = debug.engineUsed
+                            )
+                        )
+                    }
+                }
+                else -> viewModel.onEvent(event)
             }
         },
         navTo = navTo,
@@ -115,6 +126,11 @@ fun AddTransactionScreen(
                     }
                 },
                 actions = {
+                    if (uiState.lastAiDebugInfo != null) {
+                        IconButton(onClick = { onEvent(AddTransactionUiEvent.DebugAiClicked) }) {
+                            Icon(Icons.Default.BugReport, contentDescription = "View AI Debug Info", tint = MaterialTheme.colorScheme.primary)
+                        }
+                    }
                     IconButton(onClick = { navTo(SeaweedDestination.Camera) }) {
                         Icon(Icons.Default.CameraAlt, contentDescription = "Take Receipt Photo")
                     }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -35,17 +35,21 @@ import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.ShoppingBag
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -320,6 +324,16 @@ fun AddTransactionScreen(
                 }
             }
 
+            if (uiState.showCaptureTypeSelection) {
+                CaptureTypeSelectionSheet(
+                    comment = uiState.userContextComment,
+                    onCommentChanged = { onEvent(AddTransactionUiEvent.UserCommentChanged(it)) },
+                    onReceiptSelected = { onEvent(AddTransactionUiEvent.SelectReceiptMode) },
+                    onPurchaseSelected = { onEvent(AddTransactionUiEvent.SelectPurchaseMode(uiState.userContextComment)) },
+                    onDismiss = { onEvent(AddTransactionUiEvent.CancelCaptureSelection) }
+                )
+            }
+
             if (uiState.isLoading) {
                 Box(
                     modifier = Modifier
@@ -370,5 +384,87 @@ fun AddTransactionScreenEmptyPreview() {
             onEvent = {},
             navTo = {}
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CaptureTypeSelectionSheet(
+    comment: String,
+    onCommentChanged: (String) -> Unit,
+    onReceiptSelected: () -> Unit,
+    onPurchaseSelected: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Analyze Photo with AI",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = "Choose how you want the AI to process this image.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            HorizontalDivider()
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Button(
+                    onClick = onReceiptSelected,
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer, contentColor = MaterialTheme.colorScheme.onSecondaryContainer)
+                ) {
+                    Text("Receipt")
+                }
+                Button(
+                    onClick = onPurchaseSelected,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Purchase")
+                }
+            }
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Add context for Purchase (Optional)",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                OutlinedTextField(
+                    value = comment,
+                    onValueChange = onCommentChanged,
+                    placeholder = { Text("e.g. Buying a new monitor for work...") },
+                    modifier = Modifier.fillMaxWidth(),
+                    maxLines = 3
+                )
+                Text(
+                    text = "Providing details helps the AI better categorize and describe the purchase.",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            
+            Spacer(modifier = Modifier.height(16.dp))
+        }
     }
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -5,7 +5,8 @@ import androidx.lifecycle.viewModelScope
 import android.graphics.Bitmap
 import android.util.Log
 import com.zoewave.probase.features.ai.capture.data.ImageLoader
-import com.zoewave.probase.features.ai.vision.receipt.SmartReceiptScanner
+import com.zoewave.probase.features.ai.configuration.domain.AiConfigurationSettings
+import com.zoewave.probase.features.ai.vision.receipt.ReceiptOrchestrator
 import com.zoewave.probase.seaweed.data.TransactionRepository
 import com.zoewave.probase.seaweed.model.Transaction
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,10 +14,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
@@ -37,7 +40,15 @@ data class AddTransactionUiState(
     val recentCategories: List<String> = emptyList(),
     val isCategorySuggestionsVisible: Boolean = false,
     val showCaptureTypeSelection: Boolean = false,
-    val userContextComment: String = ""
+    val userContextComment: String = "",
+    val lastAiDebugInfo: AiDebugInfo? = null
+)
+
+@Serializable
+data class AiDebugInfo(
+    val rawResponse: String,
+    val logs: List<String>,
+    val engineUsed: String
 )
 
 sealed interface AddTransactionUiEvent {
@@ -60,15 +71,17 @@ sealed interface AddTransactionUiEvent {
     data class SelectPurchaseMode(val comment: String) : AddTransactionUiEvent
     data class UserCommentChanged(val comment: String) : AddTransactionUiEvent
     object CancelCaptureSelection : AddTransactionUiEvent
+    object DebugAiClicked : AddTransactionUiEvent
 }
 
 @HiltViewModel
 class AddTransactionViewModel @Inject constructor(
     private val repository: TransactionRepository,
-    private val imageLoader: ImageLoader
+    private val imageLoader: ImageLoader,
+    private val orchestrator: ReceiptOrchestrator,
+    private val aiSettings: AiConfigurationSettings
 ) : ViewModel() {
 
-    private val scanner = SmartReceiptScanner()
     private val _uiState = MutableStateFlow(AddTransactionUiState())
     
     val uiState: StateFlow<AddTransactionUiState> = combine(
@@ -108,6 +121,7 @@ class AddTransactionViewModel @Inject constructor(
             AddTransactionUiEvent.CancelCaptureSelection -> {
                 _uiState.update { it.copy(showCaptureTypeSelection = false, receiptUri = null) }
             }
+            AddTransactionUiEvent.DebugAiClicked -> { /* Handled in Route */ }
             AddTransactionUiEvent.SaveTransaction -> saveTransaction()
             AddTransactionUiEvent.BackClicked -> { /* Handled in Route */ }
             AddTransactionUiEvent.SuccessConsumed -> _uiState.update { it.copy(isSuccess = false) }
@@ -147,15 +161,25 @@ class AddTransactionViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             try {
-                val result = scanner.scanReceipt(bitmap, userComment)
+                val apiKey = aiSettings.getGeminiApiKey()
+                val modelName = aiSettings.aiModelFlow.firstOrNull()
+                
+                Log.d("AddTransactionVM", "Sending to Orchestrator (multimodal)...")
+                val result = orchestrator.processReceipt(bitmap, apiKey, modelName, userComment)
+                
                 Log.d("AddTransactionVM", "AI Result: $result")
                 _uiState.update { 
                     val updated = it.copy(
-                        amount = if (result.totalAmount > 0) String.format(Locale.getDefault(), "%.2f", result.totalAmount) else it.amount,
+                        amount = if ((result.total ?: 0.0) > 0) String.format(Locale.getDefault(), "%.2f", result.total) else it.amount,
                         category = result.category ?: it.category,
                         description = result.merchant ?: it.description,
                         isLoading = false,
-                        errorMessage = null
+                        errorMessage = null,
+                        lastAiDebugInfo = AiDebugInfo(
+                            rawResponse = result.rawResponse ?: "No raw data from engine",
+                            logs = result.logs,
+                            engineUsed = result.engineUsed
+                        )
                     )
                     Log.d("AddTransactionVM", "Updating UI State: description=${updated.description}, amount=${updated.amount}, category=${updated.category}")
                     updated

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -34,7 +34,9 @@ data class AddTransactionUiState(
     val isSplitWidgetVisible: Boolean = false,
     val splitCount: Int = 1,
     val recentCategories: List<String> = emptyList(),
-    val isCategorySuggestionsVisible: Boolean = false
+    val isCategorySuggestionsVisible: Boolean = false,
+    val showCaptureTypeSelection: Boolean = false,
+    val userContextComment: String = ""
 )
 
 sealed interface AddTransactionUiEvent {
@@ -53,6 +55,10 @@ sealed interface AddTransactionUiEvent {
     data class SetCategorySuggestionsVisible(val visible: Boolean) : AddTransactionUiEvent
     data class AdjustAmount(val delta: Double) : AddTransactionUiEvent
     data class ReceiptImageCaptured(val bitmap: Bitmap) : AddTransactionUiEvent
+    object SelectReceiptMode : AddTransactionUiEvent
+    data class SelectPurchaseMode(val comment: String) : AddTransactionUiEvent
+    data class UserCommentChanged(val comment: String) : AddTransactionUiEvent
+    object CancelCaptureSelection : AddTransactionUiEvent
 }
 
 @HiltViewModel
@@ -83,8 +89,23 @@ class AddTransactionViewModel @Inject constructor(
             is AddTransactionUiEvent.CategoryChanged -> _uiState.update { it.copy(category = event.value, errorMessage = null) }
             is AddTransactionUiEvent.DescriptionChanged -> _uiState.update { it.copy(description = event.value, errorMessage = null) }
             is AddTransactionUiEvent.ReceiptAttached -> {
-                _uiState.update { it.copy(receiptUri = event.uri, errorMessage = null) }
-                processReceiptUri(event.uri)
+                _uiState.update { it.copy(receiptUri = event.uri, showCaptureTypeSelection = true, errorMessage = null) }
+            }
+            AddTransactionUiEvent.SelectReceiptMode -> {
+                val uri = _uiState.value.receiptUri
+                _uiState.update { it.copy(showCaptureTypeSelection = false) }
+                if (uri != null) processReceiptUri(uri, null)
+            }
+            is AddTransactionUiEvent.SelectPurchaseMode -> {
+                val uri = _uiState.value.receiptUri
+                _uiState.update { it.copy(showCaptureTypeSelection = false) }
+                if (uri != null) processReceiptUri(uri, event.comment)
+            }
+            is AddTransactionUiEvent.UserCommentChanged -> {
+                _uiState.update { it.copy(userContextComment = event.comment) }
+            }
+            AddTransactionUiEvent.CancelCaptureSelection -> {
+                _uiState.update { it.copy(showCaptureTypeSelection = false, receiptUri = null) }
             }
             AddTransactionUiEvent.SaveTransaction -> saveTransaction()
             AddTransactionUiEvent.BackClicked -> { /* Handled in Route */ }
@@ -121,11 +142,11 @@ class AddTransactionViewModel @Inject constructor(
         }
     }
 
-    private fun processReceiptImage(bitmap: Bitmap) {
+    private fun processReceiptImage(bitmap: Bitmap, userComment: String? = null) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             try {
-                val result = scanner.scanReceipt(bitmap)
+                val result = scanner.scanReceipt(bitmap, userComment)
                 _uiState.update { 
                     it.copy(
                         amount = if (result.totalAmount > 0) String.format(Locale.getDefault(), "%.2f", result.totalAmount) else it.amount,
@@ -140,12 +161,12 @@ class AddTransactionViewModel @Inject constructor(
         }
     }
 
-    private fun processReceiptUri(uri: String) {
+    private fun processReceiptUri(uri: String, userComment: String? = null) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             val bitmap = imageLoader.loadBitmap(uri)
             if (bitmap != null) {
-                processReceiptImage(bitmap)
+                processReceiptImage(bitmap, userComment)
             } else {
                 _uiState.update { it.copy(isLoading = false, errorMessage = "Failed to load image for AI analysis") }
             }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -152,11 +152,12 @@ class AddTransactionViewModel @Inject constructor(
                         amount = if (result.totalAmount > 0) String.format(Locale.getDefault(), "%.2f", result.totalAmount) else it.amount,
                         category = result.category ?: it.category,
                         description = result.merchant ?: it.description,
-                        isLoading = false
+                        isLoading = false,
+                        errorMessage = null
                     )
                 }
-            } catch (_: Exception) {
-                _uiState.update { it.copy(isLoading = false, errorMessage = "Failed to parse receipt") }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(isLoading = false, errorMessage = "Failed to parse receipt: ${e.message}") }
             }
         }
     }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -3,6 +3,7 @@ package com.zoewave.probase.seaweed.mobile.transaction.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import android.graphics.Bitmap
+import com.zoewave.probase.features.ai.capture.data.ImageLoader
 import com.zoewave.probase.features.ai.vision.receipt.SmartReceiptScanner
 import com.zoewave.probase.seaweed.data.TransactionRepository
 import com.zoewave.probase.seaweed.model.Transaction
@@ -56,7 +57,8 @@ sealed interface AddTransactionUiEvent {
 
 @HiltViewModel
 class AddTransactionViewModel @Inject constructor(
-    private val repository: TransactionRepository
+    private val repository: TransactionRepository,
+    private val imageLoader: ImageLoader
 ) : ViewModel() {
 
     private val scanner = SmartReceiptScanner()
@@ -80,7 +82,10 @@ class AddTransactionViewModel @Inject constructor(
             is AddTransactionUiEvent.AmountChanged -> _uiState.update { it.copy(amount = event.value, errorMessage = null) }
             is AddTransactionUiEvent.CategoryChanged -> _uiState.update { it.copy(category = event.value, errorMessage = null) }
             is AddTransactionUiEvent.DescriptionChanged -> _uiState.update { it.copy(description = event.value, errorMessage = null) }
-            is AddTransactionUiEvent.ReceiptAttached -> _uiState.update { it.copy(receiptUri = event.uri, errorMessage = null) }
+            is AddTransactionUiEvent.ReceiptAttached -> {
+                _uiState.update { it.copy(receiptUri = event.uri, errorMessage = null) }
+                processReceiptUri(event.uri)
+            }
             AddTransactionUiEvent.SaveTransaction -> saveTransaction()
             AddTransactionUiEvent.BackClicked -> { /* Handled in Route */ }
             AddTransactionUiEvent.SuccessConsumed -> _uiState.update { it.copy(isSuccess = false) }
@@ -131,6 +136,18 @@ class AddTransactionViewModel @Inject constructor(
                 }
             } catch (_: Exception) {
                 _uiState.update { it.copy(isLoading = false, errorMessage = "Failed to parse receipt") }
+            }
+        }
+    }
+
+    private fun processReceiptUri(uri: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val bitmap = imageLoader.loadBitmap(uri)
+            if (bitmap != null) {
+                processReceiptImage(bitmap)
+            } else {
+                _uiState.update { it.copy(isLoading = false, errorMessage = "Failed to load image for AI analysis") }
             }
         }
     }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -48,7 +48,8 @@ data class AddTransactionUiState(
 data class AiDebugInfo(
     val rawResponse: String,
     val logs: List<String>,
-    val engineUsed: String
+    val engineUsed: String,
+    val whatIsThis: String? = null
 )
 
 sealed interface AddTransactionUiEvent {
@@ -178,7 +179,8 @@ class AddTransactionViewModel @Inject constructor(
                         lastAiDebugInfo = AiDebugInfo(
                             rawResponse = result.rawResponse ?: "No raw data from engine",
                             logs = result.logs,
-                            engineUsed = result.engineUsed
+                            engineUsed = result.engineUsed,
+                            whatIsThis = result.whatIsThis
                         )
                     )
                     Log.d("AddTransactionVM", "Updating UI State: description=${updated.description}, amount=${updated.amount}, category=${updated.category}")

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -3,6 +3,7 @@ package com.zoewave.probase.seaweed.mobile.transaction.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import android.graphics.Bitmap
+import android.util.Log
 import com.zoewave.probase.features.ai.capture.data.ImageLoader
 import com.zoewave.probase.features.ai.vision.receipt.SmartReceiptScanner
 import com.zoewave.probase.seaweed.data.TransactionRepository
@@ -147,16 +148,20 @@ class AddTransactionViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true) }
             try {
                 val result = scanner.scanReceipt(bitmap, userComment)
+                Log.d("AddTransactionVM", "AI Result: $result")
                 _uiState.update { 
-                    it.copy(
+                    val updated = it.copy(
                         amount = if (result.totalAmount > 0) String.format(Locale.getDefault(), "%.2f", result.totalAmount) else it.amount,
                         category = result.category ?: it.category,
                         description = result.merchant ?: it.description,
                         isLoading = false,
                         errorMessage = null
                     )
+                    Log.d("AddTransactionVM", "Updating UI State: description=${updated.description}, amount=${updated.amount}, category=${updated.category}")
+                    updated
                 }
             } catch (e: Exception) {
+                Log.e("AddTransactionVM", "AI Analysis failed", e)
                 _uiState.update { it.copy(isLoading = false, errorMessage = "Failed to parse receipt: ${e.message}") }
             }
         }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AiDebugScreen.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AiDebugScreen.kt
@@ -1,0 +1,123 @@
+package com.zoewave.probase.seaweed.mobile.transaction.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AiDebugScreen(
+    rawResponse: String,
+    logs: List<String>,
+    engineUsed: String,
+    onBack: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("AI Debug Info") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.BugReport, contentDescription = null)
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column {
+                            Text("Engine Used", style = MaterialTheme.typography.labelSmall)
+                            Text(engineUsed, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                        }
+                    }
+                }
+            }
+
+            item {
+                Text("Process Logs", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary)
+            }
+
+            items(logs) { log ->
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                ) {
+                    Text(
+                        text = "> $log",
+                        modifier = Modifier.padding(8.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace
+                    )
+                }
+            }
+
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Default.Code, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Raw AI JSON Response", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary)
+                }
+            }
+
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.Black, RoundedCornerShape(12.dp))
+                        .padding(16.dp)
+                ) {
+                    Text(
+                        text = if (rawResponse.isBlank()) "No response data available" else rawResponse,
+                        color = Color(0xFF00FF00), // Matrix Green
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 12.sp,
+                        lineHeight = 18.sp
+                    )
+                }
+            }
+            
+            item {
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+        }
+    }
+}

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AiDebugScreen.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AiDebugScreen.kt
@@ -25,6 +25,7 @@ fun AiDebugScreen(
     rawResponse: String,
     logs: List<String>,
     engineUsed: String,
+    whatIsThis: String? = null,
     onBack: () -> Unit
 ) {
     Scaffold(
@@ -64,6 +65,22 @@ fun AiDebugScreen(
                             Text("Engine Used", style = MaterialTheme.typography.labelSmall)
                             Text(engineUsed, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
                         }
+                    }
+                }
+            }
+
+            whatIsThis?.let {
+                item {
+                    Text("AI Description (whatIsThis)", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.secondary)
+                    Card(
+                        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.3f))
+                    ) {
+                        Text(
+                            text = it,
+                            modifier = Modifier.padding(16.dp),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
                     }
                 }
             }

--- a/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/navigation/seaweedNavEntryProvider.kt
+++ b/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/navigation/seaweedNavEntryProvider.kt
@@ -121,6 +121,7 @@ fun seaweedNavEntryProvider(
                     rawResponse = key.rawResponse,
                     logs = key.logs,
                     engineUsed = key.engineUsed,
+                    whatIsThis = key.whatIsThis,
                     onBack = onBack
                 )
             }

--- a/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/navigation/seaweedNavEntryProvider.kt
+++ b/applications/seaweed/apps/mobile/src/main/java/com/zoewave/probase/seaweed/mobile/ui/navigation/seaweedNavEntryProvider.kt
@@ -14,6 +14,7 @@ import com.zoewave.probase.seaweed.mobile.settings.ui.SettingsUiRoute
 import com.zoewave.probase.seaweed.mobile.transaction.ui.AddTransactionUiEvent
 import com.zoewave.probase.seaweed.mobile.transaction.ui.AddTransactionUiRoute
 import com.zoewave.probase.seaweed.mobile.transaction.ui.AddTransactionViewModel
+import com.zoewave.probase.seaweed.mobile.transaction.ui.AiDebugScreen
 import com.zoewave.probase.seaweed.mobile.transaction.ui.AnalyticsUiRoute
 import com.zoewave.probase.seaweed.mobile.transaction.ui.TransactionsUiRoute
 import com.zoewave.probase.seaweed.mobile.ui.components.AdaptiveSeaweedScreen
@@ -113,6 +114,14 @@ fun seaweedNavEntryProvider(
                     initialPhotoUri = key.photoUri,
                     onComplete = onBack,
                     onDismiss = onBack
+                )
+            }
+            is SeaweedDestination.SmartReceiptDebug -> {
+                AiDebugScreen(
+                    rawResponse = key.rawResponse,
+                    logs = key.logs,
+                    engineUsed = key.engineUsed,
+                    onBack = onBack
                 )
             }
         }

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
@@ -93,7 +93,8 @@ sealed class SeaweedDestination(
     data class SmartReceiptDebug(
         val rawResponse: String,
         val logs: List<String>,
-        val engineUsed: String
+        val engineUsed: String,
+        val whatIsThis: String? = null
     ) : SeaweedDestination(
         title = "AI Debug Info",
         icon = Icons.Default.Settings

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/navigation/SeaweedDestination.kt
@@ -88,6 +88,16 @@ sealed class SeaweedDestination(
         title = "Smart Receipt",
         icon = Icons.Default.Home
     )
+
+    @Serializable
+    data class SmartReceiptDebug(
+        val rawResponse: String,
+        val logs: List<String>,
+        val engineUsed: String
+    ) : SeaweedDestination(
+        title = "AI Debug Info",
+        icon = Icons.Default.Settings
+    )
 }
 
 val topLevelDestinations = listOf(

--- a/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt
+++ b/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt
@@ -1,9 +1,6 @@
 package com.zoewave.probase.features.ai.capture.ui
 
-import android.graphics.ImageDecoder
 import android.net.Uri
-import android.os.Build
-import android.provider.MediaStore
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -47,10 +44,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.zoewave.probase.core.model.tasks.SmartTaskDraft
+import com.zoewave.probase.core.ui.theme.AshBikeTheme
 import com.zoewave.probase.features.ai.capture.ui.state.SmartCaptureUiState
 
 @Composable
@@ -414,5 +413,90 @@ private fun TaskField(label: String, value: String) {
     Column(modifier = Modifier.padding(vertical = 4.dp)) {
         Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.tertiary)
         Text(value, style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+@Preview(showBackground = true, name = "Empty State")
+@Composable
+fun SmartCaptureScreenEmptyPreview() {
+    AshBikeTheme {
+        SmartCaptureScreen(
+            uiState = SmartCaptureUiState.Idle(
+                capturedUri = null,
+                userComment = ""
+            ),
+            onUploadClick = {},
+            onCommentChanged = {},
+            onAnalyzeClick = { _, _ -> },
+            onConfirmTask = {},
+            onReset = {},
+            onDismiss = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Context Input State")
+@Composable
+fun SmartCaptureScreenContextInputPreview() {
+    AshBikeTheme {
+        SmartCaptureScreen(
+            uiState = SmartCaptureUiState.Idle(
+                capturedUri = "https://example.com/photo.jpg",
+                userComment = "Fixing the kitchen sink"
+            ),
+            onUploadClick = {},
+            onCommentChanged = {},
+            onAnalyzeClick = { _, _ -> },
+            onConfirmTask = {},
+            onReset = {},
+            onDismiss = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Loading State")
+@Composable
+fun SmartCaptureScreenLoadingPreview() {
+    AshBikeTheme {
+        SmartCaptureScreen(
+            uiState = SmartCaptureUiState.Loading(
+                logs = listOf("Analyzing image...", "OCR successful"),
+                isUsingCloud = true,
+                networkSpeed = "1.2 MB/s"
+            ),
+            onUploadClick = {},
+            onCommentChanged = {},
+            onAnalyzeClick = { _, _ -> },
+            onConfirmTask = {},
+            onReset = {},
+            onDismiss = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Success State")
+@Composable
+fun SmartCaptureScreenSuccessPreview() {
+    AshBikeTheme {
+        SmartCaptureScreen(
+            uiState = SmartCaptureUiState.Success(
+                draft = SmartTaskDraft(
+                    taskName = "Replace Sink Faucet",
+                    category = "Plumbing",
+                    projectName = "Kitchen Renovation",
+                    duration = "2 hours",
+                    dueDate = "2023-12-31",
+                    budget = 150.0,
+                    subTasks = listOf("Buy new faucet", "Remove old faucet", "Install new faucet")
+                ),
+                engineUsed = "Cloud AI (Gemini)"
+            ),
+            onUploadClick = {},
+            onCommentChanged = {},
+            onAnalyzeClick = { _, _ -> },
+            onConfirmTask = {},
+            onReset = {},
+            onDismiss = {}
+        )
     }
 }

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/ReceiptEngine.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/ReceiptEngine.kt
@@ -25,5 +25,6 @@ data class ReceiptDiagnosticResult(
     val logs: List<String> = emptyList(),
     val engineUsed: String = "Unknown",
     val error: String? = null,
-    val warnings: List<String> = emptyList()
+    val warnings: List<String> = emptyList(),
+    val rawResponse: String? = null
 )

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/ReceiptEngine.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/ReceiptEngine.kt
@@ -26,5 +26,6 @@ data class ReceiptDiagnosticResult(
     val engineUsed: String = "Unknown",
     val error: String? = null,
     val warnings: List<String> = emptyList(),
-    val rawResponse: String? = null
+    val rawResponse: String? = null,
+    val whatIsThis: String? = null
 )

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/ReceiptResult.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/ReceiptResult.kt
@@ -7,5 +7,6 @@ data class ReceiptResult(
     val totalAmount: Double = 0.0,
     val date: String = "",
     val merchant: String? = null,
-    val category: String? = null
+    val category: String? = null,
+    val whatIsThis: String? = null
 )

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
@@ -3,6 +3,7 @@ package com.zoewave.probase.features.ai.vision.receipt
 import android.graphics.Bitmap
 import android.util.Log
 import com.google.ai.client.generativeai.GenerativeModel
+import com.google.ai.client.generativeai.type.content
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
@@ -41,16 +42,21 @@ class SmartReceiptScanner {
             // For this implementation, we attempt and catch availability/unsupported errors as a fallback mechanism.
             val contextPrompt = userContext?.let { "\nUser provided context: $it" } ?: ""
             val prompt = """
-                Please take your best guess and try to extract the merchant name, total amount, and date from the following receipt text or image context. 
+                You are a smart financial assistant. From this image and user context, extract the merchant name, total amount, and date.
                 Suggest a category. 
                 $contextPrompt
                 Return ONLY a valid JSON object with keys: merchant, totalAmount, date, category.
-                Text: $visionText
+                Text from image: $visionText
             """.trimIndent()
 
             Log.d("SmartReceiptScanner", "AI Prompt: $prompt")
 
-            val response = generativeModel.generateContent(prompt)
+            val inputContent = content {
+                image(bitmap)
+                text(prompt)
+            }
+
+            val response = generativeModel.generateContent(inputContent)
             val jsonText = response.text ?: throw Exception("Empty response")
             
             Log.d("SmartReceiptScanner", "AI Response: $jsonText")

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
@@ -1,6 +1,7 @@
 package com.zoewave.probase.features.ai.vision.receipt
 
 import android.graphics.Bitmap
+import android.util.Log
 import com.google.ai.client.generativeai.GenerativeModel
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
@@ -40,15 +41,19 @@ class SmartReceiptScanner {
             // For this implementation, we attempt and catch availability/unsupported errors as a fallback mechanism.
             val contextPrompt = userContext?.let { "\nUser provided context: $it" } ?: ""
             val prompt = """
-                Extract the merchant name, total amount, and date from the following receipt text or image context. 
+                Please take your best guess and try to extract the merchant name, total amount, and date from the following receipt text or image context. 
                 Suggest a category. 
                 $contextPrompt
                 Return ONLY a valid JSON object with keys: merchant, totalAmount, date, category.
                 Text: $visionText
             """.trimIndent()
 
+            Log.d("SmartReceiptScanner", "AI Prompt: $prompt")
+
             val response = generativeModel.generateContent(prompt)
             val jsonText = response.text ?: throw Exception("Empty response")
+            
+            Log.d("SmartReceiptScanner", "AI Response: $jsonText")
             
             // Clean JSON string in case AI adds markdown wrappers
             val cleanedJson = jsonText.substringAfter("{").substringBeforeLast("}")

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
@@ -22,7 +22,7 @@ class SmartReceiptScanner {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    suspend fun scanReceipt(bitmap: Bitmap): ReceiptResult = withContext(Dispatchers.Default) {
+    suspend fun scanReceipt(bitmap: Bitmap, userContext: String? = null): ReceiptResult = withContext(Dispatchers.Default) {
         val image = InputImage.fromBitmap(bitmap, 0)
         
         // 1. ML Kit Text Extraction
@@ -32,15 +32,17 @@ class SmartReceiptScanner {
             ""
         }
 
-        if (visionText.isBlank()) return@withContext ReceiptResult()
+        if (visionText.isBlank() && userContext == null) return@withContext ReceiptResult()
 
         // 2. Try Gemini Nano
         try {
             // In a real production app, you'd check availability via AICore first.
             // For this implementation, we attempt and catch availability/unsupported errors as a fallback mechanism.
+            val contextPrompt = userContext?.let { "\nUser provided context: $it" } ?: ""
             val prompt = """
-                Extract the merchant name, total amount, and date from the following receipt text. 
+                Extract the merchant name, total amount, and date from the following receipt text or image context. 
                 Suggest a category. 
+                $contextPrompt
                 Return ONLY a valid JSON object with keys: merchant, total, date, category.
                 Text: $visionText
             """.trimIndent()

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
@@ -43,7 +43,7 @@ class SmartReceiptScanner {
                 Extract the merchant name, total amount, and date from the following receipt text or image context. 
                 Suggest a category. 
                 $contextPrompt
-                Return ONLY a valid JSON object with keys: merchant, total, date, category.
+                Return ONLY a valid JSON object with keys: merchant, totalAmount, date, category.
                 Text: $visionText
             """.trimIndent()
 

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/SmartReceiptScanner.kt
@@ -42,10 +42,10 @@ class SmartReceiptScanner {
             // For this implementation, we attempt and catch availability/unsupported errors as a fallback mechanism.
             val contextPrompt = userContext?.let { "\nUser provided context: $it" } ?: ""
             val prompt = """
-                You are a smart financial assistant. From this image and user context, extract the merchant name, total amount, and date.
-                Suggest a category. 
+                what is this a picture of?
                 $contextPrompt
-                Return ONLY a valid JSON object with keys: merchant, totalAmount, date, category.
+                Return ONLY a valid JSON object with keys: merchant, totalAmount, date, category, whatIsThis.
+                Field 'whatIsThis' should contain a detailed description of what you see in the image.
                 Text from image: $visionText
             """.trimIndent()
 

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/data/CloudReceiptEngine.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/data/CloudReceiptEngine.kt
@@ -83,7 +83,8 @@ class CloudReceiptEngine @Inject constructor() : ReceiptEngine {
                 date = draft.date,
                 category = draft.category,
                 logs = logs,
-                engineUsed = "Cloud AI (Gemini)"
+                engineUsed = "Cloud AI (Gemini)",
+                rawResponse = jsonText
             )
         } catch (e: Exception) {
             logs.add("Cloud API failed: ${e.localizedMessage}")

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/data/CloudReceiptEngine.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/data/CloudReceiptEngine.kt
@@ -15,7 +15,8 @@ private data class GeminiReceiptDraft(
     val merchant: String? = null,
     val total: Double? = null,
     val date: String? = null,
-    val category: String? = null
+    val category: String? = null,
+    val whatIsThis: String? = null
 )
 
 class CloudReceiptEngine @Inject constructor() : ReceiptEngine {
@@ -50,7 +51,7 @@ class CloudReceiptEngine @Inject constructor() : ReceiptEngine {
         val prompt = content {
             image(bitmap)
             text("""
-                Extract financial information from this receipt image. 
+                what is this a picture of?
                 ${if (!userContext.isNullOrBlank()) "Context: '$userContext'" else ""}
                 
                 Fields:
@@ -58,13 +59,15 @@ class CloudReceiptEngine @Inject constructor() : ReceiptEngine {
                 - total: The final amount paid. Return strictly as a number (e.g. 15.50).
                 - date: The transaction date. Convert to MM/DD/YYYY format.
                 - category: Suggest a broad category (e.g. Food, Travel, Office, Shopping).
+                - whatIsThis: A detailed description of what this is a picture of.
                 
                 Respond ONLY with valid JSON matching this schema:
                 {
                   "merchant": string or null,
                   "total": number or null,
                   "date": string or null,
-                  "category": string or null
+                  "category": string or null,
+                  "whatIsThis": string or null
                 }
             """.trimIndent())
         }
@@ -84,7 +87,8 @@ class CloudReceiptEngine @Inject constructor() : ReceiptEngine {
                 category = draft.category,
                 logs = logs,
                 engineUsed = "Cloud AI (Gemini)",
-                rawResponse = jsonText
+                rawResponse = jsonText,
+                whatIsThis = draft.whatIsThis
             )
         } catch (e: Exception) {
             logs.add("Cloud API failed: ${e.localizedMessage}")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ android-minSdk = "34"
 android-targetSdk = "35"
 
 # -- Build Tools --
-agp = "9.1.0"
+agp = "9.1.1"
 kotlin = "2.3.0"
 # KSP version must match Kotlin version exactly
 ksp = "2.3.4"


### PR DESCRIPTION
feat(transaction): show category suggestions on field focus

This commit enhances the user experience of the transaction creation screen by conditionally displaying category suggestions only when the category input field is focused. This declutters the interface and provides a smoother interaction through animated transitions.

- **`AddTransactionUiRoute.kt`**:
    - Added an `onFocusChanged` modifier to the Category `OutlinedTextField` to update the visibility state of suggestions.
    - Wrapped the "Recent" and "Suggestions" UI blocks in `AnimatedVisibility` to animate their appearance based on field focus.
    - Refined the `FilterChip` selection logic to perform case-insensitive comparisons between the current input and suggested categories.
- **`AddTransactionViewModel.kt`**:
    - Expanded `AddTransactionUiState` to include `isCategorySuggestionsVisible` for tracking the focus state of the category input.
    - Added a new `SetCategorySuggestionsVisible` event to the `AddTransactionUiEvent` sealed interface.
    - Updated the ViewModel's `onEvent` handler to manage the visibility state based on UI focus events.