### PR TITLE
feat(home): integrate AI task capture into home screen FAB

### DIFF
--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Checklist
 import androidx.compose.material.icons.filled.Close
@@ -118,6 +119,10 @@ fun HomeOverviewScreen(
                 onCameraClick = {
                     fabMenuExpanded = false
                     navTo(PhotoTodoRoute.Camera(projectId = null))
+                },
+                onSmartCaptureClick = {
+                    fabMenuExpanded = false
+                    navTo(PhotoTodoRoute.SmartCapture())
                 }
             )
         }
@@ -153,6 +158,7 @@ fun HomeOverviewFab(
     onAddCategoryClick: () -> Unit,
     onHomeProjectClick: () -> Unit, // Renamed
     onCameraClick: () -> Unit,
+    onSmartCaptureClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     FloatingActionButtonMenu(
@@ -190,6 +196,12 @@ fun HomeOverviewFab(
             onClick = onCameraClick,
             icon = { Icon(Icons.Default.CameraAlt, contentDescription = null) },
             text = { Text(stringResource(com.zoewave.photodo.model.R.string.applications_photodo_model_route_camera)) }
+        )
+
+        FloatingActionButtonMenuItem(
+            onClick = onSmartCaptureClick,
+            icon = { Icon(Icons.Default.AutoAwesome, contentDescription = null) },
+            text = { Text("AI Task") }
         )
     }
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
@@ -85,7 +85,11 @@ fun AdaptiveHomeScreen(
                     onCameraClick = {
                         fabMenuExpanded = false
                         navTo(PhotoTodoRoute.Camera(projectId = null))
-                    }
+                    },
+                    onSmartCaptureClick = {
+                        fabMenuExpanded = false
+                        navTo(PhotoTodoRoute.SmartCapture())
+                    },
                 )
             }
         ) { paddingValues ->

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
@@ -64,6 +64,10 @@ fun HomeScreen(
                 onCameraClick = {
                     fabMenuExpanded = false
                     navTo(PhotoTodoRoute.Camera(projectId = null))
+                },
+                onSmartCaptureClick = {
+                    fabMenuExpanded = false
+                    navTo(PhotoTodoRoute.SmartCapture())
                 }
             )
         }
@@ -161,7 +165,7 @@ fun HomeScreen(
         uiState = uiState,
         categoryToDelete = categoryToDelete,
         onDismissDeleteConfirmation = { categoryToDelete = null },
-        onEvent = onEvent
+        onEvent = onEvent,
     )
 }
 

--- a/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
+++ b/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
@@ -88,10 +88,10 @@ class SavePhotoViewModel @Inject constructor(
         initialValue = SavePhotoUiState("")
     )
 
-    fun setInitialData(uri: String, draft: SmartTaskDraft? = null) {
+    fun setInitialData(uri: String?, draft: SmartTaskDraft? = null) {
         if (_photoUri.value == uri && draft == null) return
         
-        _photoUri.value = uri
+        _photoUri.value = uri ?: ""
         if (draft != null) {
             _isFromAi.value = true
             _categoryName.value = draft.category ?: ""

--- a/applications/photodo/model/src/main/java/com/zoewave/probase/photodo/model/navigation/PhotoTodoRoute.kt
+++ b/applications/photodo/model/src/main/java/com/zoewave/probase/photodo/model/navigation/PhotoTodoRoute.kt
@@ -62,12 +62,12 @@ sealed class PhotoTodoRoute(
 
     @Serializable
     data class SavePhoto(
-        val photoUri: String,
+        val photoUri: String? = null,
         val prefilledAiDraft: SmartTaskDraft? = null
     ) : PhotoTodoRoute(icon = Icons.Default.CameraAlt)
 
     @Serializable
-    data class SmartCapture(val photoUri: String) : PhotoTodoRoute(icon = Icons.Default.CameraAlt)
+    data class SmartCapture(val photoUri: String? = null) : PhotoTodoRoute(icon = Icons.Default.CameraAlt)
 
     @Serializable
     data class SmartAdvice(val projectId: Long) : PhotoTodoRoute(icon = Icons.Default.CheckCircle)

--- a/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/CloudCaptureEngineImpl.kt
+++ b/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/CloudCaptureEngineImpl.kt
@@ -76,7 +76,7 @@ class CloudCaptureEngineImpl @Inject constructor() : SmartCaptureEngine {
         apiKey: String?,
         modelName: String?,
         userContext: String?,
-        onLog: (String) -> Unit
+        onLog: (String) -> Unit,
     ): DiagnosticResult<SmartTaskDraft> {
         val logs = mutableListOf("Cloud AI Engine initialized")
         onLog("Cloud Engine: Warming up...")

--- a/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/SmartCaptureOrchestrator.kt
+++ b/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/SmartCaptureOrchestrator.kt
@@ -11,10 +11,10 @@ import javax.inject.Singleton
 
 @Singleton
 class SmartCaptureOrchestrator @Inject constructor(
-    @Named("Cloud") private val cloudEngine: SmartCaptureEngine,
-    @Named("Local") private val localEngine: SmartCaptureEngine
+    @param:Named("Cloud") private val cloudEngine: SmartCaptureEngine,
+    @param:Named("Local") private val localEngine: SmartCaptureEngine,
 ) {
-    private val TAG = "SmartCaptureOrchestrator"
+    private val tag = "SmartCaptureOrchestrator"
 
     suspend fun validateApiKey(apiKey: String): Pair<String, List<String>> {
         val models = cloudEngine.getAvailableModels(apiKey)
@@ -45,7 +45,7 @@ class SmartCaptureOrchestrator @Inject constructor(
         }
 
         if (!apiKey.isNullOrBlank()) {
-            Log.d(TAG, "Attempting Tier 1 (Cloud) capture with $modelName...")
+            Log.d(tag, "Attempting Tier 1 (Cloud) capture with $modelName...")
             onLog("Tier 1: Cloud AI requested...")
             totalLogs.add("Orchestrator: Cloud API Key present")
             
@@ -56,7 +56,7 @@ class SmartCaptureOrchestrator @Inject constructor(
                     // No fallback for text-only
                     return result.copy(logs = totalLogs + result.logs)
                 }
-                Log.w(TAG, "Cloud failed: ${result.error}. Falling back to Local.")
+                Log.w(tag, "Cloud failed: ${result.error}. Falling back to Local.")
                 onLog("Cloud AI failed (${result.error.take(30)}...). Falling back to Local...")
                 val fallbackLogs = listOf("Orchestrator: Cloud failed (${result.error})", "Triggering Local AI Fallback")
                 val fallbackResult = localEngine.processImage(bitmap, null, userContext = userContext, onLog = onLog)
@@ -67,12 +67,12 @@ class SmartCaptureOrchestrator @Inject constructor(
             } else {
                 return result.copy(logs = totalLogs + result.logs)
             }
-        } else {
-            Log.d(TAG, "No API key provided. Skipping Tier 1.")
-            onLog("Using Tier 2 (Local) AI...")
-            totalLogs.add("Orchestrator: No Cloud Key, using Local AI")
-            val result = localEngine.processImage(bitmap!!, null, userContext = userContext, onLog = onLog)
-            return result.copy(logs = totalLogs + result.logs)
-        }
+            } else {
+                Log.d(tag, "No API key provided. Skipping Tier 1.")
+                onLog("Using Tier 2 (Local) AI...")
+                totalLogs.add("Orchestrator: No Cloud Key, using Local AI")
+                val result = localEngine.processImage(bitmap!!, null, userContext = userContext, onLog = onLog)
+                return result.copy(logs = totalLogs + result.logs)
+            }
     }
 }

--- a/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt
+++ b/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt
@@ -58,13 +58,13 @@ fun SmartCaptureUiRoute(
     initialPhotoUri: String? = null,
     onCaptureComplete: (SmartTaskDraft) -> Unit,
     onRetakeRequest: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
     // 🚀 Update: Instead of auto-triggering analysis, set the URI so user can add context
     LaunchedEffect(initialPhotoUri) {
-        if (initialPhotoUri != null && uiState is SmartCaptureUiState.Idle && (uiState as SmartCaptureUiState.Idle).capturedUri == null) {
+        if ((initialPhotoUri != null) && uiState is SmartCaptureUiState.Idle && (uiState as SmartCaptureUiState.Idle).capturedUri == null) {
             viewModel.setCapturedUri(initialPhotoUri)
         }
     }
@@ -90,9 +90,9 @@ internal fun SmartCaptureScreen(
     onConfirmTask: (SmartTaskDraft) -> Unit,
     onRetake: () -> Unit,
     onReset: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
-    var showDiagnostics by remember { mutableStateOf(false) }
+    var showDiagnostics by remember { mutableStateOf(value = false) }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),

--- a/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureViewModel.kt
+++ b/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureViewModel.kt
@@ -3,7 +3,6 @@ package com.zoewave.probase.features.ai.capture.ui
 import android.graphics.Bitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.zoewave.probase.core.model.tasks.SmartTaskDraft
 import com.zoewave.probase.core.util.network.NetworkStatsProvider
 import com.zoewave.probase.features.ai.capture.data.ImageLoader
 import com.zoewave.probase.features.ai.capture.data.SmartCaptureOrchestrator
@@ -14,9 +13,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -25,7 +24,7 @@ class SmartCaptureViewModel @Inject constructor(
     private val orchestrator: SmartCaptureOrchestrator,
     private val settings: SmartCaptureSettings,
     private val imageLoader: ImageLoader,
-    private val networkStatsProvider: NetworkStatsProvider
+    private val networkStatsProvider: NetworkStatsProvider,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SmartCaptureUiState>(SmartCaptureUiState.Idle())


### PR DESCRIPTION
This commit adds a new "AI Task" option to the Floating Action Button (FAB) across the home screen variants, allowing users to navigate directly to the Smart Capture flow. It also updates navigation routes and view models to support optional image URIs, facilitating entry into AI flows without a pre-captured image.

- **`PhotoTodoRoute.kt`**:
    - Updated `SavePhoto` and `SmartCapture` routes to make `photoUri` an optional parameter.
- **`HomeOverviewScreen.kt`**, **`HomeScreen.kt`**, & **`AdaptiveHomeScreen.kt`**:
    - Expanded the `FloatingActionButtonMenu` to include a "AI Task" item using the `AutoAwesome` icon.
    - Implemented navigation logic to `SmartCapture` when the new menu item is selected.
- **`SavePhotoViewModel.kt`**:
    - Updated `setInitialData` to accept a nullable URI, providing a default empty string to the internal state.
- **`SmartCaptureOrchestrator.kt`**:
    - Refined Dagger/Hilt constructor injection using `@param:Named`.
    - Renamed internal `TAG` to `tag` and cleaned up logging logic.
- **`SmartCaptureScreen.kt` & `SmartCaptureViewModel.kt`**:
    - Performed minor code cleanup, including removing unused imports and adding trailing commas for better formatting.
    - Adjusted `LaunchedEffect` logic in the capture screen for better readability.