### PR TITLE
Photodo search

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -84,10 +84,10 @@
       </SelectionState>
       <SelectionState runConfigName="applications.photodo.apps.wear">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-11T22:11:43.543152Z">
+        <DropdownSelection timestamp="2026-04-16T19:07:28.063895Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_9a.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Wear_OS_XL_Round.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/zoewave/probase/di/AiConfigurationBridgeModule.kt
+++ b/app/src/main/java/com/zoewave/probase/di/AiConfigurationBridgeModule.kt
@@ -7,7 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
-@Module
+/*@Module
 @InstallIn(SingletonComponent::class)
 abstract class AiConfigurationBridgeModule {
 
@@ -16,4 +16,4 @@ abstract class AiConfigurationBridgeModule {
     abstract fun bindAiConfigurationSettings(
         impl: FakeSmartCaptureSettings
     ): AiConfigurationSettings
-}
+}*/

--- a/app/src/main/java/com/zoewave/probase/di/SmartCaptureBridgeModule.kt
+++ b/app/src/main/java/com/zoewave/probase/di/SmartCaptureBridgeModule.kt
@@ -7,7 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
-@Module
+/*@Module
 @InstallIn(SingletonComponent::class)
 abstract class SmartCaptureBridgeModule {
 
@@ -16,4 +16,4 @@ abstract class SmartCaptureBridgeModule {
     abstract fun bindSmartCaptureSettings(
         impl: FakeSmartCaptureSettings
     ): SmartCaptureSettings
-}
+}*/

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
@@ -307,7 +307,12 @@ fun HomeOverviewContent(
 
                 if (showSummaryHeader && !isSearchMode) {
                     item(span = { GridItemSpan(2) }) {
-                        OverviewSummaryCard(categories = uiState.categories)
+                        OverviewSummaryCard(
+                            categories = uiState.categories,
+                            isExpanded = uiState.isCategoriesSummaryExpanded,
+                            onToggleExpand = { onEvent(HomeEvent.OnToggleCategoriesSummary) },
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
                 }
 

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
@@ -128,7 +128,11 @@ fun AdaptiveHomeScreen(
                             }
                         } else {
                             item {
-                                OverviewSummaryCard(categories = uiState.categories)
+                                OverviewSummaryCard(
+                                    categories = uiState.categories,
+                                    isExpanded = uiState.isCategoriesSummaryExpanded,
+                                    onToggleExpand = { onEvent(HomeEvent.OnToggleCategoriesSummary) }
+                                )
                             }
 
                             item {

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
@@ -191,7 +191,7 @@ fun AdaptiveHomeScreen(
                         navTo = { route -> if (route != null) navTo(route) },
                         onDeleteClicked = { categoryToDelete = it },
                         modifier = Modifier.fillMaxSize().padding(paddingValues),
-                        showSummaryHeader = false // 🚀 Donut chart is already in the left pane!
+                        showSummaryHeader = false
                     )
                 },
                 modifier = Modifier.fillMaxSize()

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
@@ -114,43 +114,59 @@ fun AdaptiveHomeScreen(
                         verticalArrangement = Arrangement.spacedBy(24.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        if (uiState.isLoading) {
-                            item { CircularProgressIndicator() }
-                        } else if (uiState.isEmpty) {
+                        item {
+                            TaskSearchBar(
+                                query = uiState.searchQuery,
+                                onQueryChange = { onEvent(HomeEvent.OnSearchQueryChanged(it)) }
+                            )
+                        }
+
+                        if (uiState.searchQuery.isNotBlank()) {
                             item {
-                                Text(
-                                    stringResource(R.string.applications_photodo_apps_mobile_features_home_no_data_seed),
-                                    modifier = Modifier.padding(top = 16.dp)
+                                TaskSearchResultsList(
+                                    results = uiState.taskSearchResults,
+                                    navTo = navTo
                                 )
                             }
                         } else {
-                            item {
-                                OverviewSummaryCard(categories = uiState.categories)
-                            }
-
-                            item {
-                                Text(
-                                    stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
-                                    style = MaterialTheme.typography.titleLarge,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.padding(bottom = 8.dp)
-                                )
-                            }
-
-                            if (uiState.urgentProjects.isEmpty()) {
+                            if (uiState.isLoading) {
+                                item { CircularProgressIndicator() }
+                            } else if (uiState.isEmpty) {
                                 item {
                                     Text(
-                                        stringResource(R.string.applications_photodo_apps_mobile_features_home_no_urgent_projects),
+                                        stringResource(R.string.applications_photodo_apps_mobile_features_home_no_data_seed),
                                         modifier = Modifier.padding(top = 16.dp)
                                     )
                                 }
                             } else {
-                                items(items = uiState.urgentProjects, key = { it.projectId }) { project ->
-                                    HomeProjectRow(
-                                        project = project,
-                                        onEvent = onEvent,
-                                        navTo = navTo
+                                item {
+                                    OverviewSummaryCard(categories = uiState.categories)
+                                }
+
+                                item {
+                                    Text(
+                                        stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
+                                        style = MaterialTheme.typography.titleLarge,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.padding(bottom = 8.dp)
                                     )
+                                }
+
+                                if (uiState.urgentProjects.isEmpty()) {
+                                    item {
+                                        Text(
+                                            stringResource(R.string.applications_photodo_apps_mobile_features_home_no_urgent_projects),
+                                            modifier = Modifier.padding(top = 16.dp)
+                                        )
+                                    }
+                                } else {
+                                    items(items = uiState.urgentProjects, key = { it.projectId }) { project ->
+                                        HomeProjectRow(
+                                            project = project,
+                                            onEvent = onEvent,
+                                            navTo = navTo
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
@@ -2,8 +2,11 @@ package com.zoewave.probase.photodo.mobile.features.home.ui.components.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -114,44 +117,46 @@ fun AdaptiveHomeScreen(
                         verticalArrangement = Arrangement.spacedBy(24.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        item {
-                            TaskSearchBar(
-                                query = uiState.searchQuery,
-                                onQueryChange = { onEvent(HomeEvent.OnSearchQueryChanged(it)) }
-                            )
-                        }
-
-                        if (uiState.searchQuery.isNotBlank()) {
+                        if (uiState.isLoading) {
+                            item { CircularProgressIndicator() }
+                        } else if (uiState.isEmpty) {
                             item {
-                                TaskSearchResultsList(
-                                    results = uiState.taskSearchResults,
-                                    navTo = navTo
+                                Text(
+                                    stringResource(R.string.applications_photodo_apps_mobile_features_home_no_data_seed),
+                                    modifier = Modifier.padding(top = 16.dp)
                                 )
                             }
                         } else {
-                            if (uiState.isLoading) {
-                                item { CircularProgressIndicator() }
-                            } else if (uiState.isEmpty) {
+                            item {
+                                OverviewSummaryCard(categories = uiState.categories)
+                            }
+
+                            item {
+                                // --- 4. Jump Back In Section (Preserved Urgent/Fav List) ---
+                                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
+                                        Text(
+                                            stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
+                                            style = MaterialTheme.typography.titleLarge,
+                                            color = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
+
+                                    TaskSearchBar(
+                                        query = uiState.searchQuery,
+                                        onQueryChange = { onEvent(HomeEvent.OnSearchQueryChanged(it)) }
+                                    )
+                                }
+                            }
+
+                            if (uiState.searchQuery.isNotBlank()) {
                                 item {
-                                    Text(
-                                        stringResource(R.string.applications_photodo_apps_mobile_features_home_no_data_seed),
-                                        modifier = Modifier.padding(top = 16.dp)
+                                    TaskSearchResultsList(
+                                        results = uiState.taskSearchResults,
+                                        navTo = navTo
                                     )
                                 }
                             } else {
-                                item {
-                                    OverviewSummaryCard(categories = uiState.categories)
-                                }
-
-                                item {
-                                    Text(
-                                        stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
-                                        style = MaterialTheme.typography.titleLarge,
-                                        color = MaterialTheme.colorScheme.primary,
-                                        modifier = Modifier.padding(bottom = 8.dp)
-                                    )
-                                }
-
                                 if (uiState.urgentProjects.isEmpty()) {
                                     item {
                                         Text(

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
@@ -15,5 +15,6 @@ sealed interface HomeEvent {
 
     data class OnAddQuickProjectClicked(val overrideCategoryName: String? = null) : HomeEvent
     data class OnSearchQueryChanged(val query: String) : HomeEvent
+    data object OnToggleCategoriesSummary : HomeEvent
     data object OnDismissBottomSheet : HomeEvent
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
@@ -83,77 +83,92 @@ fun HomeScreen(
             verticalArrangement = Arrangement.spacedBy(24.dp), // 🚀 MAGIC: Replaces all your Spacers!
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            item {
+                TaskSearchBar(
+                    query = uiState.searchQuery,
+                    onQueryChange = { onEvent(HomeEvent.OnSearchQueryChanged(it)) }
+                )
+            }
 
-            // --- 🚀 NEW: Graphic/AI Overview Section (Derivative State) ---
-            if (!uiState.isLoading && !uiState.isEmpty) {
-                // Compute the models on recomposition
+            if (uiState.searchQuery.isNotBlank()) {
                 item {
-                    // 🚀 1. The main "High-Density Wheel" summary card
-                    OverviewSummaryCard(categories = uiState.categories) // ✅ Pass list directly
-                }
-
-                item {
-                    val importantCategories = remember(uiState.categories) {
-                        // Logic: Categories with most pending tasks
-                        uiState.categories
-                            .sortedByDescending { it.totalTasks - it.completedTasks }
-                            .take(5) // Show top 5
-                    }
-                    // 2. The horizontal quick-jump section (Preserved)
-                    CategoryQuickJumpRow(
-                        importantCategories = importantCategories,
-                        onEvent = onEvent,
+                    TaskSearchResultsList(
+                        results = uiState.taskSearchResults,
                         navTo = navTo
                     )
                 }
-            }
-            // --- End New Sections ---
-
-            item {            // --- 3. View All Categories Button (Preserved) ---
-                Button(
-                    onClick = { navTo(PhotoTodoRoute.CategoryGrid) },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_view_all_categories))
-                }
-            }
-
-            item {
-                // --- 4. Jump Back In Section (Preserved Urgent/Fav List) ---
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
-                    Text(
-                        stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
-                        style = MaterialTheme.typography.titleLarge,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-            }
-
-            if (uiState.isLoading) {
-                item { CircularProgressIndicator(modifier = Modifier.padding(top = 16.dp)) }
-            } else if (uiState.isEmpty) {
-                item {
-                    Text(
-                        stringResource(R.string.applications_photodo_apps_mobile_features_home_no_data_seed),
-                        modifier = Modifier.padding(top = 16.dp)
-                    )
-                }
             } else {
-                if (uiState.urgentProjects.isEmpty()) {
+                // --- 🚀 NEW: Graphic/AI Overview Section (Derivative State) ---
+                if (!uiState.isLoading && !uiState.isEmpty) {
+                    // Compute the models on recomposition
+                    item {
+                        // 🚀 1. The main "High-Density Wheel" summary card
+                        OverviewSummaryCard(categories = uiState.categories) // ✅ Pass list directly
+                    }
+
+                    item {
+                        val importantCategories = remember(uiState.categories) {
+                            // Logic: Categories with most pending tasks
+                            uiState.categories
+                                .sortedByDescending { it.totalTasks - it.completedTasks }
+                                .take(5) // Show top 5
+                        }
+                        // 2. The horizontal quick-jump section (Preserved)
+                        CategoryQuickJumpRow(
+                            importantCategories = importantCategories,
+                            onEvent = onEvent,
+                            navTo = navTo
+                        )
+                    }
+                }
+                // --- End New Sections ---
+
+                item {            // --- 3. View All Categories Button (Preserved) ---
+                    Button(
+                        onClick = { navTo(PhotoTodoRoute.CategoryGrid) },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_view_all_categories))
+                    }
+                }
+
+                item {
+                    // --- 4. Jump Back In Section (Preserved Urgent/Fav List) ---
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
+                        Text(
+                            stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+
+                if (uiState.isLoading) {
+                    item { CircularProgressIndicator(modifier = Modifier.padding(top = 16.dp)) }
+                } else if (uiState.isEmpty) {
                     item {
                         Text(
-                            stringResource(R.string.applications_photodo_apps_mobile_features_home_no_urgent_projects),
+                            stringResource(R.string.applications_photodo_apps_mobile_features_home_no_data_seed),
                             modifier = Modifier.padding(top = 16.dp)
                         )
                     }
                 } else {
-                    // Use `items` for the dynamic data! It scrolls seamlessly with the `item` blocks above.
-                    items(items = uiState.urgentProjects, key = { it.projectId }) { project ->
-                        HomeProjectRow(
-                            project = project,
-                            onEvent = onEvent, // Pass the channel down
-                            navTo = navTo      // Pass the channel down
-                        )
+                    if (uiState.urgentProjects.isEmpty()) {
+                        item {
+                            Text(
+                                stringResource(R.string.applications_photodo_apps_mobile_features_home_no_urgent_projects),
+                                modifier = Modifier.padding(top = 16.dp)
+                            )
+                        }
+                    } else {
+                        // Use `items` for the dynamic data! It scrolls seamlessly with the `item` blocks above.
+                        items(items = uiState.urgentProjects, key = { it.projectId }) { project ->
+                            HomeProjectRow(
+                                project = project,
+                                onEvent = onEvent, // Pass the channel down
+                                navTo = navTo      // Pass the channel down
+                            )
+                        }
                     }
                 }
             }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
@@ -89,7 +89,11 @@ fun HomeScreen(
                 // Compute the models on recomposition
                 item {
                     // 🚀 1. The main "High-Density Wheel" summary card
-                    OverviewSummaryCard(categories = uiState.categories) // ✅ Pass list directly
+                    OverviewSummaryCard(
+                        categories = uiState.categories,
+                        isExpanded = uiState.isCategoriesSummaryExpanded,
+                        onToggleExpand = { onEvent(HomeEvent.OnToggleCategoriesSummary) }
+                    )
                 }
 
                 item {

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.zoewave.probase.photodo.mobile.features.home.ui.components.home
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -83,11 +84,56 @@ fun HomeScreen(
             verticalArrangement = Arrangement.spacedBy(24.dp), // 🚀 MAGIC: Replaces all your Spacers!
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            // --- 🚀 NEW: Graphic/AI Overview Section (Derivative State) ---
+            if (!uiState.isLoading && !uiState.isEmpty) {
+                // Compute the models on recomposition
+                item {
+                    // 🚀 1. The main "High-Density Wheel" summary card
+                    OverviewSummaryCard(categories = uiState.categories) // ✅ Pass list directly
+                }
+
+                item {
+                    val importantCategories = remember(uiState.categories) {
+                        // Logic: Categories with most pending tasks
+                        uiState.categories
+                            .sortedByDescending { it.totalTasks - it.completedTasks }
+                            .take(5) // Show top 5
+                    }
+                    // 2. The horizontal quick-jump section (Preserved)
+                    CategoryQuickJumpRow(
+                        importantCategories = importantCategories,
+                        onEvent = onEvent,
+                        navTo = navTo
+                    )
+                }
+            }
+            // --- End New Sections ---
+
+            item {            // --- 3. View All Categories Button (Preserved) ---
+                Button(
+                    onClick = { navTo(PhotoTodoRoute.CategoryGrid) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_view_all_categories))
+                }
+            }
+
             item {
-                TaskSearchBar(
-                    query = uiState.searchQuery,
-                    onQueryChange = { onEvent(HomeEvent.OnSearchQueryChanged(it)) }
-                )
+                // --- 4. Jump Back In Section (Preserved Urgent/Fav List) ---
+                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
+                        Text(
+                            stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+
+                    TaskSearchBar(
+                        query = uiState.searchQuery,
+                        onQueryChange = { onEvent(HomeEvent.OnSearchQueryChanged(it)) }
+                    )
+                }
             }
 
             if (uiState.searchQuery.isNotBlank()) {
@@ -98,51 +144,6 @@ fun HomeScreen(
                     )
                 }
             } else {
-                // --- 🚀 NEW: Graphic/AI Overview Section (Derivative State) ---
-                if (!uiState.isLoading && !uiState.isEmpty) {
-                    // Compute the models on recomposition
-                    item {
-                        // 🚀 1. The main "High-Density Wheel" summary card
-                        OverviewSummaryCard(categories = uiState.categories) // ✅ Pass list directly
-                    }
-
-                    item {
-                        val importantCategories = remember(uiState.categories) {
-                            // Logic: Categories with most pending tasks
-                            uiState.categories
-                                .sortedByDescending { it.totalTasks - it.completedTasks }
-                                .take(5) // Show top 5
-                        }
-                        // 2. The horizontal quick-jump section (Preserved)
-                        CategoryQuickJumpRow(
-                            importantCategories = importantCategories,
-                            onEvent = onEvent,
-                            navTo = navTo
-                        )
-                    }
-                }
-                // --- End New Sections ---
-
-                item {            // --- 3. View All Categories Button (Preserved) ---
-                    Button(
-                        onClick = { navTo(PhotoTodoRoute.CategoryGrid) },
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_view_all_categories))
-                    }
-                }
-
-                item {
-                    // --- 4. Jump Back In Section (Preserved Urgent/Fav List) ---
-                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
-                        Text(
-                            stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
-                            style = MaterialTheme.typography.titleLarge,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                }
-
                 if (uiState.isLoading) {
                     item { CircularProgressIndicator(modifier = Modifier.padding(top = 16.dp)) }
                 } else if (uiState.isEmpty) {

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeSearchComponents.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeSearchComponents.kt
@@ -1,0 +1,145 @@
+package com.zoewave.probase.photodo.mobile.features.home.ui.components.home
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import com.zoewave.probase.photodo.model.navigation.PhotoTodoRoute
+
+@Composable
+fun TaskSearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        placeholder = { Text("Search tasks...") },
+        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+        trailingIcon = {
+            if (query.isNotBlank()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(Icons.Default.Close, contentDescription = "Clear search")
+                }
+            }
+        },
+        singleLine = true,
+        shape = RoundedCornerShape(16.dp),
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedBorderColor = MaterialTheme.colorScheme.primary,
+            unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+        )
+    )
+}
+
+@Composable
+fun TaskSearchResultsList(
+    results: List<TaskSearchResult>,
+    navTo: (PhotoTodoRoute) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        if (results.isEmpty()) {
+            Text(
+                text = "No matching tasks found.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(16.dp)
+            )
+        } else {
+            results.forEach { result ->
+                ProjectSearchResultGroup(
+                    result = result,
+                    navTo = navTo
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ProjectSearchResultGroup(
+    result: TaskSearchResult,
+    navTo: (PhotoTodoRoute) -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+        ),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { navTo(PhotoTodoRoute.TaskDetail(result.projectId, result.projectTitle)) }
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = result.projectTitle,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                    contentDescription = "Go to project",
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+            
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 8.dp),
+                color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+            )
+            
+            result.tasks.forEach { task ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { navTo(PhotoTodoRoute.TaskDetail(result.projectId, result.projectTitle)) }
+                        .padding(vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = if (task.isChecked) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = if (task.isChecked) Color(0xFF4CAF50) else MaterialTheme.colorScheme.outline
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = task.text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textDecoration = if (task.isChecked) TextDecoration.LineThrough else null,
+                        color = if (task.isChecked) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f) 
+                                else MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        }
+    }
+}

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeSearchComponents.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeSearchComponents.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -89,27 +88,13 @@ fun ProjectSearchResultGroup(
         shape = RoundedCornerShape(16.dp)
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { navTo(PhotoTodoRoute.TaskDetail(result.projectId, result.projectTitle)) }
-                    .padding(vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = result.projectTitle,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                    contentDescription = "Go to project",
-                    modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-            }
+            Text(
+                text = result.projectTitle,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(vertical = 4.dp)
+            )
             
             HorizontalDivider(
                 modifier = Modifier.padding(vertical = 8.dp),

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
@@ -21,7 +21,8 @@ data class HomeUiState(
     val quickProjectCategoryOverride: String? = null,
     val searchQuery: String = "",
     val taskSearchResults: List<TaskSearchResult> = emptyList(),
-    val isAiEnabled: Boolean = false
+    val isAiEnabled: Boolean = false,
+    val isCategoriesSummaryExpanded: Boolean = true
 ) {
     val isEmpty: Boolean = !isLoading && categories.isEmpty()
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
@@ -1,8 +1,16 @@
 package com.zoewave.probase.photodo.mobile.features.home.ui.components.home
 
 import androidx.compose.runtime.Immutable
+import com.zoewave.probase.applications.photodo.db.entity.TaskEntity
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.CategoryOverviewUiModel
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.state.ProjectListUiModel
+
+@Immutable
+data class TaskSearchResult(
+    val projectId: Long,
+    val projectTitle: String,
+    val tasks: List<TaskEntity>
+)
 
 @Immutable
 data class HomeUiState(
@@ -12,6 +20,7 @@ data class HomeUiState(
     val isQuickProjectSheetOpen: Boolean = false,
     val quickProjectCategoryOverride: String? = null,
     val searchQuery: String = "",
+    val taskSearchResults: List<TaskSearchResult> = emptyList(),
     val isAiEnabled: Boolean = false
 ) {
     val isEmpty: Boolean = !isLoading && categories.isEmpty()

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
@@ -11,13 +11,17 @@ import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.state.ProjectListUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -42,11 +46,30 @@ class HomeViewModel @Inject constructor(
     private val _uiFlags = MutableStateFlow(UiFlags())
 
     // 1. Directly map the relational database stream into our UI State
+    @OptIn(ExperimentalCoroutinesApi::class)
     val uiState: StateFlow<HomeUiState> = combine(
         photoDoRepo.getCategoriesWithProjectsAndTasks(),
+        _uiFlags.flatMapLatest { flags ->
+            if (flags.searchQuery.length >= 2) {
+                photoDoRepo.getProjectsWithMatchingTasks(flags.searchQuery)
+                    .map { projects ->
+                        projects.map { projectDetails ->
+                            TaskSearchResult(
+                                projectId = projectDetails.project.projectId,
+                                projectTitle = projectDetails.project.name,
+                                tasks = projectDetails.tasks.filter { 
+                                    it.text.contains(flags.searchQuery, ignoreCase = true) 
+                                }
+                            )
+                        }
+                    }
+            } else {
+                flowOf(emptyList<TaskSearchResult>())
+            }
+        },
         _uiFlags,
         appSettingsRepository.isAiEnabledFlow
-    ) { categoriesWithProjectsAndTasks, flags, isAiEnabled ->
+    ) { categoriesWithProjectsAndTasks, searchResults, flags, isAiEnabled ->
         val overviewModels = ArrayList<CategoryOverviewUiModel>(categoriesWithProjectsAndTasks.size)
         val urgentProjects = ArrayList<ProjectListUiModel>()
 
@@ -107,6 +130,7 @@ class HomeViewModel @Inject constructor(
                 isQuickProjectSheetOpen = flags.isQuickProjectSheetOpen,
                 quickProjectCategoryOverride = flags.quickProjectCategoryOverride,
                 searchQuery = flags.searchQuery,
+                taskSearchResults = searchResults,
                 isAiEnabled = isAiEnabled
             )
         }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
@@ -40,7 +40,8 @@ class HomeViewModel @Inject constructor(
     private data class UiFlags(
         val isQuickProjectSheetOpen: Boolean = false,
         val quickProjectCategoryOverride: String? = null,
-        val searchQuery: String = ""
+        val searchQuery: String = "",
+        val isCategoriesSummaryExpanded: Boolean = true
     )
 
     private val _uiFlags = MutableStateFlow(UiFlags())
@@ -131,7 +132,8 @@ class HomeViewModel @Inject constructor(
                 quickProjectCategoryOverride = flags.quickProjectCategoryOverride,
                 searchQuery = flags.searchQuery,
                 taskSearchResults = searchResults,
-                isAiEnabled = isAiEnabled
+                isAiEnabled = isAiEnabled,
+                isCategoriesSummaryExpanded = flags.isCategoriesSummaryExpanded
             )
         }
         .flowOn(Dispatchers.Default)
@@ -228,6 +230,12 @@ class HomeViewModel @Inject constructor(
             is HomeEvent.OnSearchQueryChanged -> {
                 _uiFlags.update { 
                     it.copy(searchQuery = event.query)
+                }
+            }
+
+            is HomeEvent.OnToggleCategoriesSummary -> {
+                _uiFlags.update { 
+                    it.copy(isCategoriesSummaryExpanded = !it.isCategoriesSummaryExpanded)
                 }
             }
         }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/OverviewSummaryCard.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/OverviewSummaryCard.kt
@@ -1,7 +1,11 @@
 package com.zoewave.probase.photodo.mobile.features.home.ui.components.home
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,8 +18,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -40,128 +49,164 @@ import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories
 @Composable
 fun OverviewSummaryCard(
     categories: List<CategoryOverviewUiModel>,
+    isExpanded: Boolean,
+    onToggleExpand: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     // Transform the categories into colored slices
     val slices = mapCategoriesToWheelSlices(categories)
     val totalCategories = categories.size
 
-    // Expressive, compact card (Height reduced to 160dp)
+    // Expressive, compact card
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .height(160.dp), // Compact height
+            .clickable { onToggleExpand() },
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant, // Using neutral color
             contentColor = MaterialTheme.colorScheme.onSurfaceVariant
         ),
         shape = RoundedCornerShape(20.dp) // express round corners
     ) {
-        // Zero internal padding inside the card!
-        Row(
-            modifier = Modifier.fillMaxSize(),
-            horizontalArrangement = Arrangement.Start, // Legend pushed to the left
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-
-            // --- 🚀 1. The Compact Legend (Left Side) ---
-            Column(
+        Column {
+            // --- HEADER ---
+            Row(
                 modifier = Modifier
-                    .weight(1f) // Legends get space
-                    .fillMaxHeight()
-                    // Minimum padding to group the text nicely
-                    .padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
-                verticalArrangement = Arrangement.Center
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                // Main Header (Bold, Primary Color)
                 Text(
                     text = stringResource(R.string.applications_photodo_apps_mobile_features_home_total_categories),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.primary
                 )
-
-                // Bold Category Count
-                Text(
-                    text = "$totalCategories",
-                    style = MaterialTheme.typography.displayMedium, // Compact but Display font
-                    fontWeight = FontWeight.Black
-                )
-
-                // Tiny Legend Items (Derivative from slices)
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    // Show top 3 in compact legend
-                    slices.take(3).forEach { slice ->
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            // Tiny Color Dot
-                            Box(modifier = Modifier.size(8.dp).clip(RoundedCornerShape(4.dp)).size(8.dp).background(slice.color))
-                            Spacer(modifier = Modifier.size(6.dp))
-                            Text(
-                                text = "${slice.name} (${slice.value})", // I'll keep this as is for now as it's a mix of dynamic data and symbols, or I could use a template
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
-                                maxLines = 1
-                            )
-                        }
+                
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (!isExpanded) {
+                        Text(
+                            text = "$totalCategories Categories",
+                            style = MaterialTheme.typography.labelMedium,
+                            modifier = Modifier.padding(end = 8.dp)
+                        )
                     }
+                    Icon(
+                        imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = if (isExpanded) "Collapse" else "Expand",
+                        modifier = Modifier.size(24.dp)
+                    )
                 }
             }
 
-            // --- 🚀 2. The Color Wheel Donut Chart (Right Side) ---
-            Box(
-                modifier = Modifier
-                    .size(140.dp) // Large wheel, packed into compact container
-                    .padding(end = 16.dp), // Standard side padding
-                contentAlignment = Alignment.Center
+            AnimatedVisibility(
+                visible = isExpanded,
+                enter = expandVertically(),
+                exit = shrinkVertically()
             ) {
+                // Zero internal padding inside the card!
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(140.dp) // Reduced height as header is separate
+                        .padding(bottom = 12.dp),
+                    horizontalArrangement = Arrangement.Start, // Legend pushed to the left
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
 
-                // --- Part A: The Drawing Canvas ---
-                Canvas(modifier = Modifier.fillMaxSize()) {
-                    var currentStartAngle = -90f // Start from the top
-                    val strokeWidth = 24.dp.toPx() // Expressive, thick stroke
-
-                    if (slices.isEmpty()) {
-                        // Empty state placeholder arc
-                        drawArc(
-                            color = Color.LightGray.copy(alpha = 0.3f),
-                            startAngle = 0f,
-                            sweepAngle = 360f,
-                            useCenter = false,
-                            style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+                    // --- 🚀 1. The Compact Legend (Left Side) ---
+                    Column(
+                        modifier = Modifier
+                            .weight(1f) // Legends get space
+                            .fillMaxHeight()
+                            // Minimum padding to group the text nicely
+                            .padding(start = 16.dp),
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        // Bold Category Count
+                        Text(
+                            text = "$totalCategories",
+                            style = MaterialTheme.typography.displayMedium, // Compact but Display font
+                            fontWeight = FontWeight.Black
                         )
-                    } else {
-                        slices.forEach { slice ->
-                            // Draw the colored segment
-                            drawArc(
-                                color = slice.color,
-                                startAngle = currentStartAngle,
-                                sweepAngle = slice.sweepAngle,
-                                useCenter = false,
-                                style = Stroke(width = strokeWidth, cap = StrokeCap.Round) // Rounded expressive ends
-                            )
-                            currentStartAngle += slice.sweepAngle // Increment the angle
+
+                        // Tiny Legend Items (Derivative from slices)
+                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            // Show top 3 in compact legend
+                            slices.take(3).forEach { slice ->
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    // Tiny Color Dot
+                                    Box(modifier = Modifier.size(8.dp).clip(RoundedCornerShape(4.dp)).size(8.dp).background(slice.color))
+                                    Spacer(modifier = Modifier.size(6.dp))
+                                    Text(
+                                        text = "${slice.name} (${slice.value})", // I'll keep this as is for now as it's a mix of dynamic data and symbols, or I could use a template
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
+                                        maxLines = 1
+                                    )
+                                }
+                            }
                         }
                     }
-                }
 
-                // --- Part B: The Center Label (Derivative State) ---
-                // Shows overall progress percentage
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    val totalTasks = slices.sumOf { it.value }
-                    val totalCompleted = categories.sumOf { it.completedTasks }
-                    val progressPercentage = if (totalTasks > 0) (totalCompleted.toFloat() / totalTasks * 100).toInt() else 0
+                    // --- 🚀 2. The Color Wheel Donut Chart (Right Side) ---
+                    Box(
+                        modifier = Modifier
+                            .size(130.dp) // Large wheel, packed into compact container
+                            .padding(end = 16.dp), // Standard side padding
+                        contentAlignment = Alignment.Center
+                    ) {
 
-                    Text(
-                        text = "$progressPercentage%",
-                        style = MaterialTheme.typography.titleLarge, // Big bold center number
-                        fontWeight = FontWeight.Black,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    Text(
-                        text = stringResource(R.string.applications_photodo_apps_mobile_features_home_done),
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Bold
-                    )
+                        // --- Part A: The Drawing Canvas ---
+                        Canvas(modifier = Modifier.fillMaxSize()) {
+                            var currentStartAngle = -90f // Start from the top
+                            val strokeWidth = 20.dp.toPx() // Expressive, thick stroke
+
+                            if (slices.isEmpty()) {
+                                // Empty state placeholder arc
+                                drawArc(
+                                    color = Color.LightGray.copy(alpha = 0.3f),
+                                    startAngle = 0f,
+                                    sweepAngle = 360f,
+                                    useCenter = false,
+                                    style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+                                )
+                            } else {
+                                slices.forEach { slice ->
+                                    // Draw the colored segment
+                                    drawArc(
+                                        color = slice.color,
+                                        startAngle = currentStartAngle,
+                                        sweepAngle = slice.sweepAngle,
+                                        useCenter = false,
+                                        style = Stroke(width = strokeWidth, cap = StrokeCap.Round) // Rounded expressive ends
+                                    )
+                                    currentStartAngle += slice.sweepAngle // Increment the angle
+                                }
+                            }
+                        }
+
+                        // --- Part B: The Center Label (Derivative State) ---
+                        // Shows overall progress percentage
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            val totalTasks = slices.sumOf { it.value }
+                            val totalCompleted = categories.sumOf { it.completedTasks }
+                            val progressPercentage = if (totalTasks > 0) (totalCompleted.toFloat() / totalTasks * 100).toInt() else 0
+
+                            Text(
+                                text = "$progressPercentage%",
+                                style = MaterialTheme.typography.titleLarge, // Big bold center number
+                                fontWeight = FontWeight.Black,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Text(
+                                text = stringResource(R.string.applications_photodo_apps_mobile_features_home_done),
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -211,6 +256,8 @@ private fun OverviewSummaryCardPreview() {
     PhotoDoTheme {
         OverviewSummaryCard(
             categories = mockData,
+            isExpanded = true,
+            onToggleExpand = {},
             modifier = Modifier.padding(16.dp)
         )
     }

--- a/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/PhotoDoDao.kt
+++ b/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/PhotoDoDao.kt
@@ -120,6 +120,14 @@ interface PhotoDoDao {
     @Query("SELECT * FROM projects WHERE name LIKE '%' || :searchQuery || '%' OR notes LIKE '%' || :searchQuery || '%'")
     fun searchProjects(searchQuery: String): Flow<List<ProjectEntity>>
 
+    @Transaction
+    @Query("SELECT * FROM projects WHERE name LIKE '%' || :searchQuery || '%' OR notes LIKE '%' || :searchQuery || '%'")
+    fun searchProjectsWithDetails(searchQuery: String): Flow<List<ProjectDetails>>
+
+    @Transaction
+    @Query("SELECT * FROM projects WHERE projectId IN (SELECT DISTINCT projectId FROM tasks WHERE text LIKE '%' || :searchQuery || '%')")
+    fun getProjectsWithMatchingTasks(searchQuery: String): Flow<List<ProjectDetails>>
+
     // --- Task Operations (Checklist) ---
 
     @Upsert

--- a/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/repo/PhotoDoRepo.kt
+++ b/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/repo/PhotoDoRepo.kt
@@ -38,6 +38,8 @@ interface PhotoDoRepo {
     suspend fun updateProjectUrgency(projectId: Long, isUrgent: Boolean)
     suspend fun updateProjectFavorite(projectId: Long, isFavorite: Boolean)
     fun searchProjects(searchQuery: String): Flow<List<ProjectEntity>>
+    fun searchProjectsWithDetails(searchQuery: String): Flow<List<ProjectDetails>>
+    fun getProjectsWithMatchingTasks(searchQuery: String): Flow<List<ProjectDetails>>
 
     // --- Task Operations (Checklist) ---
     suspend fun upsertTask(task: TaskEntity): Long

--- a/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/repo/PhotoDoRepoImpl.kt
+++ b/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/repo/PhotoDoRepoImpl.kt
@@ -108,6 +108,14 @@ class PhotoDoRepoImpl @Inject constructor(
         return photoDoDao.searchProjects(searchQuery)
     }
 
+    override fun searchProjectsWithDetails(searchQuery: String): Flow<List<ProjectDetails>> {
+        return photoDoDao.searchProjectsWithDetails(searchQuery)
+    }
+
+    override fun getProjectsWithMatchingTasks(searchQuery: String): Flow<List<ProjectDetails>> {
+        return photoDoDao.getProjectsWithMatchingTasks(searchQuery)
+    }
+
     // --- Task Operations ---
     override suspend fun upsertTask(task: TaskEntity): Long = withContext(Dispatchers.IO) {
         val id = photoDoDao.upsertTask(task)


### PR DESCRIPTION
feat(home): implement expandable overview summary card

This commit introduces the ability to expand and collapse the category overview summary card on the home screen. It also simplifies the search result items by removing redundant navigation icons.

- **`HomeViewModel.kt`, `HomeUiState.kt` & `HomeEvent.kt`**:
    - Added `isCategoriesSummaryExpanded` to the UI state and flags to track the card's visibility state.
    - Implemented the `OnToggleCategoriesSummary` event to handle user interaction.
- **`OverviewSummaryCard.kt`**:
    - Refactored the card to include a header with a title and an expand/collapse icon.
    - Wrapped the donut chart and legend in `AnimatedVisibility` for smooth vertical expansion and shrinking.
    - Added a `clickable` modifier to the card to toggle the expanded state.
    - Adjusted the donut chart stroke width and size for better visual balance in the new layout.
- **`HomeSearchComponents.kt`**:
    - Simplified `SearchResultItem` by removing the `clickable` modifier and the forward arrow icon from the project title row.
- **`HomeScreen.kt` & `AdaptiveHomeScreen.kt`**:
    - Updated the `OverviewSummaryCard` implementation to pass the expansion state and toggle callback.