### PR TITLE
Photodo age

### DIFF
--- a/applications/photodo/docs/GenAI/AgeTest/implementation_plan.md
+++ b/applications/photodo/docs/GenAI/AgeTest/implementation_plan.md
@@ -1,0 +1,52 @@
+# Integrate Compliance Handshake into PhotoDo
+
+This plan outlines the integration of the `:features:compliance` module into the PhotoDo mobile app. It implements a "Verifiable Handshake" before Cloud AI operations and adds a compliance status indicator in the Settings screen.
+
+## User Review Required
+
+> [!IMPORTANT]
+> Cloud AI operations will now perform a real-time age verification check. If the check fails (e.g., user is under 13 or SDK is outdated), Cloud AI will be blocked or degraded to Local AI.
+
+## Proposed Changes
+
+### [features:ai:capture]
+
+#### [SmartCaptureOrchestrator.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/data/SmartCaptureOrchestrator.kt)
+
+- Inject `AgeSignalsManager`.
+- In `processImage`, perform a `getAgeSignal()` handshake before calling `cloudEngine`.
+- **Logic**:
+    - If `getAgeSignal()` fails with `SdkVersionOutdated`, block Cloud AI and log the error.
+    - If `AgeRange` is `AGE_0_12`, block Cloud AI (13+ Policy).
+    - If successful, proceed with Cloud AI.
+
+---
+
+### [applications:photodo:apps:mobile:features:settings]
+
+#### [SettingsUiState.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/settings/ui/SettingsUiState.kt)
+
+- Add `ageVerificationStatus: String` and `isAgeVerified: Boolean`.
+
+#### [SettingsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/mobile/features/settings/ui/SettingsViewModel.kt)
+
+- Inject `AgeSignalsManager`.
+- Fetch `AgeSignal` in `init` (or via a specific event) and update `uiState`.
+- **Zero-Footprint**: The signal is kept in memory only for the duration of the ViewModel's lifecycle.
+
+#### [AboutSettingsCard.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/settings/ui/components/AboutSettingsCard.kt)
+
+- Update the UI to display the "Regulatory Compliance" status under the "About" or a new "Legal & Compliance" section.
+- Show `ageVerificationStatus` and a "Verified" badge if applicable.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+- `SmartCaptureOrchestratorTest`: Mock `AgeSignalsManager` to return different `Result` types (Success with various age ranges, Failure with `SdkVersionOutdated`) and verify that `cloudEngine` is called or skipped correctly.
+- Command: `./gradlew :features:ai:capture:testDebugUnitTest`
+
+### Manual Verification
+- Open Settings in the PhotoDo app and verify that the "Regulatory Compliance" status is displayed.
+- Trigger a Smart Capture and verify in the logs that the "Compliance Handshake" is performed before Cloud AI initialization.

--- a/features/ai/capture/build.gradle.kts
+++ b/features/ai/capture/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     // --- Feature Dependencies ---
     implementation(project(":features:camera"))
+    implementation(project(":features:compliance"))
 
     // --- Third Party ---
     implementation(libs.androidx.compose.material.icons.extended)

--- a/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/SmartCaptureOrchestrator.kt
+++ b/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/SmartCaptureOrchestrator.kt
@@ -5,6 +5,10 @@ import android.util.Log
 import com.zoewave.probase.core.model.tasks.SmartTaskDraft
 import com.zoewave.probase.features.ai.capture.domain.DiagnosticResult
 import com.zoewave.probase.features.ai.capture.domain.SmartCaptureEngine
+import com.zoewave.probase.features.compliance.AgeSignalsManager
+import com.zoewave.probase.features.compliance.model.AgeRange
+import com.zoewave.probase.features.compliance.model.AgeVerificationStatus
+import com.zoewave.probase.features.compliance.model.ComplianceError
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -13,6 +17,7 @@ import javax.inject.Singleton
 class SmartCaptureOrchestrator @Inject constructor(
     @param:Named("Cloud") private val cloudEngine: SmartCaptureEngine,
     @param:Named("Local") private val localEngine: SmartCaptureEngine,
+    private val ageSignalsManager: AgeSignalsManager
 ) {
     private val tag = "SmartCaptureOrchestrator"
 
@@ -45,6 +50,52 @@ class SmartCaptureOrchestrator @Inject constructor(
         }
 
         if (!apiKey.isNullOrBlank()) {
+            Log.d(tag, "Performing Compliance Handshake...")
+            onLog("Compliance: Verifying age signal...")
+            val ageSignalResult = ageSignalsManager.getAgeSignal()
+            
+            val isAllowed = ageSignalResult.fold(
+                onSuccess = { signal ->
+                    if (signal.isAuthorizedForCloudAI) {
+                        Log.d(tag, "Compliance: Handshake successful (Status: ${signal.verificationStatus}).")
+                        onLog("Compliance: Handshake successful.")
+                        true
+                    } else {
+                        Log.w(tag, "Compliance: Access restricted (Status: ${signal.verificationStatus}).")
+                        if (signal.verificationStatus == AgeVerificationStatus.SUPERVISED_APPROVAL_PENDING) {
+                            onLog("Compliance: Parental approval required.")
+                        } else {
+                            onLog("Compliance: 13+ Policy check failed.")
+                        }
+                        false
+                    }
+                },
+                onFailure = { error ->
+                    if (error is ComplianceError.SdkVersionOutdated) {
+                        Log.e(tag, "Compliance: SDK version outdated. Blocking Cloud AI.")
+                        onLog("Compliance: SDK Version Outdated. Please update the app.")
+                    } else {
+                        Log.e(tag, "Compliance: Error retrieving signal: ${error.message}")
+                        onLog("Compliance: Verification error.")
+                    }
+                    false
+                }
+            )
+
+            if (!isAllowed) {
+                if (bitmap == null) {
+                    return DiagnosticResult(SmartTaskDraft(), totalLogs, error = "Compliance: Cloud AI access restricted.")
+                }
+                Log.w(tag, "Compliance restricted. Falling back to Local.")
+                onLog("Compliance restricted. Falling back to Local AI...")
+                val fallbackLogs = listOf("Orchestrator: Compliance Check Restricted", "Triggering Local AI Fallback")
+                val fallbackResult = localEngine.processImage(bitmap, null, userContext = userContext, onLog = onLog)
+                return fallbackResult.copy(
+                    logs = totalLogs + fallbackLogs + fallbackResult.logs,
+                    warnings = listOf("Cloud analysis restricted for compliance. Using local extraction.")
+                )
+            }
+
             Log.d(tag, "Attempting Tier 1 (Cloud) capture with $modelName...")
             onLog("Tier 1: Cloud AI requested...")
             totalLogs.add("Orchestrator: Cloud API Key present")

--- a/features/ai/vision/build.gradle.kts
+++ b/features/ai/vision/build.gradle.kts
@@ -12,6 +12,7 @@ android {
 dependencies {
     implementation(project(":core:data"))
     implementation(project(":features:ai:capture"))
+    implementation(project(":features:compliance"))
 
     // Compose
     implementation(libs.androidx.compose.material3)

--- a/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/ReceiptOrchestrator.kt
+++ b/features/ai/vision/src/main/java/com/zoewave/probase/features/ai/vision/receipt/ReceiptOrchestrator.kt
@@ -1,8 +1,12 @@
 package com.zoewave.probase.features.ai.vision.receipt
 
 import android.graphics.Bitmap
+import android.util.Log
 import com.zoewave.probase.features.ai.vision.receipt.data.CloudReceiptEngine
 import com.zoewave.probase.features.ai.vision.receipt.data.LocalReceiptEngine
+import com.zoewave.probase.features.compliance.AgeSignalsManager
+import com.zoewave.probase.features.compliance.model.AgeRange
+import com.zoewave.probase.features.compliance.model.ComplianceError
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -10,8 +14,11 @@ import javax.inject.Singleton
 @Singleton
 class ReceiptOrchestrator @Inject constructor(
     @Named("CloudReceipt") private val cloudEngine: ReceiptEngine,
-    @Named("LocalReceipt") private val localEngine: ReceiptEngine
+    @Named("LocalReceipt") private val localEngine: ReceiptEngine,
+    private val ageSignalsManager: AgeSignalsManager
 ) {
+    private val tag = "ReceiptOrchestrator"
+
     suspend fun processReceipt(
         bitmap: Bitmap,
         apiKey: String?,
@@ -21,6 +28,29 @@ class ReceiptOrchestrator @Inject constructor(
         val totalLogs = mutableListOf<String>()
         return try {
             if (!apiKey.isNullOrBlank()) {
+                Log.d(tag, "Performing Compliance Handshake...")
+                totalLogs.add("Orchestrator: Compliance check...")
+                
+                val ageSignalResult = ageSignalsManager.getAgeSignal()
+                val isAllowed = ageSignalResult.fold(
+                    onSuccess = { signal ->
+                        signal.isAuthorizedForCloudAI
+                    },
+                    onFailure = { error ->
+                        Log.e(tag, "Compliance error: ${error.message}")
+                        false
+                    }
+                )
+
+                if (!isAllowed) {
+                    totalLogs.add("Orchestrator: Compliance restricted. Using Local AI.")
+                    val result = localEngine.processReceipt(bitmap, null, userContext = userContext)
+                    return result.copy(
+                        logs = totalLogs + result.logs,
+                        warnings = listOf("Cloud analysis restricted for compliance. Using local extraction.")
+                    )
+                }
+
                 totalLogs.add("Orchestrator: Attempting Cloud Receipt AI")
                 val result = cloudEngine.processReceipt(bitmap, apiKey, modelName, userContext)
                 result.copy(logs = totalLogs + result.logs)

--- a/features/compliance/Docs/walkthrough_simple.md
+++ b/features/compliance/Docs/walkthrough_simple.md
@@ -1,0 +1,43 @@
+# Play Age Signals Integration for Compliance (Refined)
+
+I have implemented the `:features:compliance` module and integrated it across the ProBase project to satisfy the 2026 App Store Accountability Acts (ASAA). This implementation follows a **"Clean-Slate"** approach for our initial launch, focusing on authoritative real-time signals.
+
+## Changes Made
+
+### 1. Refined Data Model
+- **[AgeSignal.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/compliance/model/AgeSignal.kt)**: Implements the authoritative **"Clean-Slate"** 2026 logic via the `isAuthorizedForCloudAI` property.
+    - **VERIFIED (18+)**: Full Access.
+    - **DECLARED (13-17)**: Full Access (subject to strict filters downstream).
+    - **SUPERVISED**: Access only if `mostRecentApprovalDate` is present (proving parental consent for this app version).
+
+### 2. Graceful Error Handling
+- **[ComplianceError.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/compliance/model/ComplianceError.kt)**: Custom exceptions for `SdkVersionOutdated` and `NetworkError`.
+- **[AgeSignalsManager.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/compliance/AgeSignalsManager.kt)**: API returns `Result<AgeSignal>` to ensure apps handle SDK and network failures gracefully.
+
+### 3. Authoritative Implementation
+- **[AgeSignalsManagerImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/compliance/AgeSignalsManagerImpl.kt)**:
+    - Performs the secure `checkAgeSignals` handshake with the Play Store.
+    - Maps SDK error codes (e.g., `-10` for `SDK_VERSION_OUTDATED`) to internal `ComplianceError` types.
+    - **Zero-Footprint**: Signals are transient and never cached locally.
+
+### 4. App Integration (PhotoDo & Seaweed)
+I have hooked the simplified compliance handshake into core AI orchestrators and the Settings UI.
+
+- **[SmartCaptureOrchestrator.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/data/SmartCaptureOrchestrator.kt)**: Enforces the `isAuthorizedForCloudAI` gate before Cloud AI extraction. Handles the "Ask Parent" trigger log for pending approvals.
+- **[ReceiptOrchestrator.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/vision/receipt/ReceiptOrchestrator.kt)**: Enforces the same authorization gate for receipt processing.
+- **PhotoDo Settings UI**:
+    - **[SettingsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/settings/ui/SettingsViewModel.kt)**: Fetches authoritative age signals upon initialization.
+    - **[AboutSettingsCard.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/settings/ui/components/AboutSettingsCard.kt)**: Displays the "Regulatory Compliance" status to the user.
+
+## Verification Summary
+
+### Automated Tests
+- Ran unit tests for the compliance module:
+  `./gradlew :features:compliance:testDebugUnitTest`
+  **Result**: 8 passed, 0 failed. Covers all authorization branches (Verified, Declared, Supervised w/ date, Supervised w/o date, Restricted).
+
+### Build Verification
+- Verified the build of the compliance module and the PhotoTodo app:
+  `./gradlew :features:compliance:assembleDebug`
+  `./gradlew :applications:photodo:apps:mobile:assembleDebug`
+  **Result**: Both builds finished successfully, confirming correct wiring of Hilt dependencies.

--- a/features/compliance/src/main/java/com/zoewave/probase/features/compliance/model/AgeSignal.kt
+++ b/features/compliance/src/main/java/com/zoewave/probase/features/compliance/model/AgeSignal.kt
@@ -9,7 +9,18 @@ data class AgeSignal(
     val ageRange: AgeRange?,
     val verificationStatus: AgeVerificationStatus,
     val mostRecentApprovalDate: Date?
-)
+) {
+    /**
+     * Authoritative "Clean-Slate" 2026 logic for Cloud AI authorization.
+     */
+    val isAuthorizedForCloudAI: Boolean
+        get() = when (verificationStatus) {
+            AgeVerificationStatus.VERIFIED -> true
+            AgeVerificationStatus.DECLARED -> true
+            AgeVerificationStatus.SUPERVISED -> mostRecentApprovalDate != null
+            else -> false
+        }
+}
 
 enum class AgeRange(val description: String) {
     AGE_0_12("0-12"),

--- a/features/compliance/src/test/java/com/zoewave/probase/features/compliance/AgeSignalsManagerTest.kt
+++ b/features/compliance/src/test/java/com/zoewave/probase/features/compliance/AgeSignalsManagerTest.kt
@@ -5,14 +5,14 @@ import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.Status
 import com.google.android.gms.tasks.Tasks
-import com.google.android.play.agesignals.model.AgeSignalsErrorCode
 import com.google.android.play.agesignals.AgeSignalsException
 import com.google.android.play.agesignals.AgeSignalsManager
 import com.google.android.play.agesignals.AgeSignalsManagerFactory
-import com.google.android.play.agesignals.AgeSignalsRequest
 import com.google.android.play.agesignals.AgeSignalsResult
+import com.google.android.play.agesignals.model.AgeSignalsErrorCode
 import com.google.android.play.agesignals.model.AgeSignalsVerificationStatus
 import com.zoewave.probase.features.compliance.model.AgeRange
+import com.zoewave.probase.features.compliance.model.AgeSignal
 import com.zoewave.probase.features.compliance.model.AgeVerificationStatus
 import com.zoewave.probase.features.compliance.model.ComplianceError
 import io.mockk.every
@@ -66,6 +66,37 @@ class AgeSignalsManagerTest {
         assertEquals(AgeRange.AGE_18_PLUS, ageSignal.ageRange)
         assertEquals(AgeVerificationStatus.VERIFIED, ageSignal.verificationStatus)
         assertEquals(now, ageSignal.mostRecentApprovalDate)
+        assertTrue(ageSignal.isAuthorizedForCloudAI)
+    }
+
+    @Test
+    fun `isAuthorizedForCloudAI returns true for Verified and Declared statuses`() {
+        val verifiedSignal = AgeSignal(null, AgeVerificationStatus.VERIFIED, null)
+        val declaredSignal = AgeSignal(null, AgeVerificationStatus.DECLARED, null)
+        
+        assertTrue(verifiedSignal.isAuthorizedForCloudAI)
+        assertTrue(declaredSignal.isAuthorizedForCloudAI)
+    }
+
+    @Test
+    fun `isAuthorizedForCloudAI returns true for Supervised with approval date`() {
+        val supervisedSignal = AgeSignal(null, AgeVerificationStatus.SUPERVISED, Date())
+        assertTrue(supervisedSignal.isAuthorizedForCloudAI)
+    }
+
+    @Test
+    fun `isAuthorizedForCloudAI returns false for Supervised without approval date`() {
+        val supervisedSignal = AgeSignal(null, AgeVerificationStatus.SUPERVISED, null)
+        assertTrue(!supervisedSignal.isAuthorizedForCloudAI)
+    }
+
+    @Test
+    fun `isAuthorizedForCloudAI returns false for Unknown or Restricted statuses`() {
+        val unknownSignal = AgeSignal(null, AgeVerificationStatus.UNKNOWN, null)
+        val pendingSignal = AgeSignal(null, AgeVerificationStatus.SUPERVISED_APPROVAL_PENDING, null)
+        
+        assertTrue(!unknownSignal.isAuthorizedForCloudAI)
+        assertTrue(!pendingSignal.isAuthorizedForCloudAI)
     }
 
     @Test


### PR DESCRIPTION
feat(ai): integrate age-based compliance checks for cloud AI access

This commit introduces a mandatory compliance handshake before triggering Cloud AI processing within the orchestration layer. By integrating `AgeSignalsManager`, the system now verifies user eligibility (e.g., 13+ policy, parental approval) before sending data to cloud engines, falling back to local AI processing when access is restricted.

- **`SmartCaptureOrchestrator.kt`**:
    - Injected `AgeSignalsManager` to perform a compliance check prior to cloud analysis.
    - Implemented a fallback mechanism that redirects the request to `localEngine` if `isAuthorizedForCloudAI` is false.
    - Added comprehensive logging and status updates for various compliance states, including outdated SDK versions and pending parental approvals.
- **`ReceiptOrchestrator.kt`**:
    - Integrated age signal verification into the receipt processing workflow.
    - Added a fallback to `localEngine.processReceipt` with a warning notification when cloud processing is restricted.
- **Build Configuration**:
    - Added the `:features:compliance` module dependency to both `features/ai/capture` and `features/ai/vision` to support the new validation logic.