### PR TITLE
Photodo cleanup

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -37,10 +37,10 @@
       </SelectionState>
       <SelectionState runConfigName="applications.photodo.apps.mobile">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-12T20:16:44.019375Z">
+        <DropdownSelection timestamp="2026-04-17T00:35:23.841834Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_10_Pro_Fold.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_9a.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
@@ -92,37 +92,29 @@ fun HomeOverviewScreen(
     uiState: HomeUiState,
     onEvent: (HomeEvent) -> Unit,
     navTo: (PhotoTodoRoute?) -> Unit, // ✅ Standardized Navigation Channel
-    modifier: Modifier = Modifier
 ) {
-
-    // Add these state variables at the top of your composable
-    var showAddCategorySheet by rememberSaveable { mutableStateOf(false) }
-    var categoryToDelete by remember { mutableStateOf<CategoryOverviewUiModel?>(null) }
-    var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
-    var isSearchMode by rememberSaveable { mutableStateOf(false) }
-
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
         // 2. Replace the Scaffold's floatingActionButton block with this:
         floatingActionButton = {
             HomeOverviewFab(
-                fabMenuExpanded = fabMenuExpanded,
-                onFabToggle = { fabMenuExpanded = it },
+                fabMenuExpanded = uiState.fabMenuExpanded,
+                onFabToggle = { onEvent(HomeEvent.OnFabMenuToggle(it)) },
                 onAddCategoryClick = {
-                    fabMenuExpanded = false
-                    showAddCategorySheet = true
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
+                    onEvent(HomeEvent.OnShowAddCategoryDialog(true))
                 },
                 onHomeProjectClick = { // Updated parameter name
-                    fabMenuExpanded = false
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
                     // Map to the common Quick Project logic with "Home" override!
                     onEvent(HomeEvent.OnAddQuickProjectClicked("Home"))
                 },
                 onCameraClick = {
-                    fabMenuExpanded = false
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
                     navTo(PhotoTodoRoute.Camera(projectId = null))
                 },
                 onSmartCaptureClick = {
-                    fabMenuExpanded = false
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
                     navTo(PhotoTodoRoute.SmartCapture())
                 },
                 isAiEnabled = uiState.isAiEnabled
@@ -131,11 +123,8 @@ fun HomeOverviewScreen(
     ) { innerPadding ->
         HomeOverviewContent(
             uiState = uiState,
-            isSearchMode = isSearchMode,
-            onSearchModeChange = { isSearchMode = it },
             onEvent = onEvent,
             navTo = navTo,
-            onDeleteClicked = { categoryToDelete = it },
             modifier = Modifier.padding(innerPadding)
         )
     }
@@ -143,11 +132,11 @@ fun HomeOverviewScreen(
     // ... inside HomeOverviewScreen, just below the Scaffold closing brace ...
 
     HomeOverviewDialogs(
-        showAddCategorySheet = showAddCategorySheet,
-        onDismissAddCategory = { showAddCategorySheet = false },
+        showAddCategorySheet = uiState.showAddCategoryDialog,
+        onDismissAddCategory = { onEvent(HomeEvent.OnShowAddCategoryDialog(false)) },
         uiState = uiState, // Pass the UI State!
-        categoryToDelete = categoryToDelete,
-        onDismissDeleteConfirmation = { categoryToDelete = null },
+        categoryToDelete = uiState.categoryToDelete,
+        onDismissDeleteConfirmation = { onEvent(HomeEvent.OnCategoryToDeleteChanged(null)) },
         onEvent = onEvent
     )
 } // <-- End of HomeOverviewScreen
@@ -214,19 +203,16 @@ fun HomeOverviewFab(
 @Composable
 fun HomeOverviewContent(
     uiState: HomeUiState,
-    isSearchMode: Boolean,
-    onSearchModeChange: (Boolean) -> Unit,
     onEvent: (HomeEvent) -> Unit,
     navTo: (PhotoTodoRoute?) -> Unit,
-    onDeleteClicked: (CategoryOverviewUiModel) -> Unit,
     modifier: Modifier = Modifier,
     showSummaryHeader: Boolean = true
 ) {
-    val filteredCategories = remember(uiState.categories, uiState.searchQuery) {
-        if (uiState.searchQuery.isBlank()) {
+    val filteredCategories = remember(uiState.categories, uiState.categorySearchQuery) {
+        if (uiState.categorySearchQuery.isBlank()) {
             uiState.categories
         } else {
-            uiState.categories.filter { it.name.contains(uiState.searchQuery, ignoreCase = true) }
+            uiState.categories.filter { it.name.contains(uiState.categorySearchQuery, ignoreCase = true) }
         }
     }
 
@@ -252,13 +238,13 @@ fun HomeOverviewContent(
                 // --- 🚀 NEW: Header Row (Shortcuts) ---
                 item(span = { GridItemSpan(2) }) {
                     AnimatedVisibility(
-                        visible = isSearchMode,
+                        visible = uiState.isSearchMode,
                         enter = fadeIn(),
                         exit = fadeOut()
                     ) {
                         OutlinedTextField(
-                            value = uiState.searchQuery,
-                            onValueChange = { onEvent(HomeEvent.OnSearchQueryChanged(it)) },
+                            value = uiState.categorySearchQuery,
+                            onValueChange = { onEvent(HomeEvent.OnCategorySearchQueryChanged(it)) },
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(bottom = 8.dp),
@@ -266,8 +252,8 @@ fun HomeOverviewContent(
                             leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                             trailingIcon = {
                                 IconButton(onClick = {
-                                    onEvent(HomeEvent.OnSearchQueryChanged(""))
-                                    onSearchModeChange(false)
+                                    onEvent(HomeEvent.OnCategorySearchQueryChanged(""))
+                                    onEvent(HomeEvent.OnSearchModeToggle(false))
                                 }) {
                                     Icon(Icons.Default.Close, contentDescription = "Close search")
                                 }
@@ -278,7 +264,7 @@ fun HomeOverviewContent(
                     }
 
                     AnimatedVisibility(
-                        visible = !isSearchMode,
+                        visible = !uiState.isSearchMode,
                         enter = fadeIn(),
                         exit = fadeOut()
                     ) {
@@ -296,7 +282,7 @@ fun HomeOverviewContent(
                                 color = MaterialTheme.colorScheme.primary
                             )
                             IconButton(
-                                onClick = { onSearchModeChange(true) },
+                                onClick = { onEvent(HomeEvent.OnSearchModeToggle(true)) },
                                 modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
                             ) {
                                 Icon(Icons.Default.Search, contentDescription = "Search")
@@ -305,7 +291,7 @@ fun HomeOverviewContent(
                     }
                 }
 
-                if (showSummaryHeader && !isSearchMode) {
+                if (showSummaryHeader && !uiState.isSearchMode) {
                     item(span = { GridItemSpan(2) }) {
                         OverviewSummaryCard(
                             categories = uiState.categories,
@@ -324,7 +310,7 @@ fun HomeOverviewContent(
                         category = category,
                         index = index,
                         onEvent = onEvent,
-                        onDeleteClicked = onDeleteClicked,
+                        onDeleteClicked = { onEvent(HomeEvent.OnCategoryToDeleteChanged(it)) },
                         navTo = navTo
                     )
                 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/AdaptiveHomeScreen.kt
@@ -49,164 +49,142 @@ import com.zoewave.probase.photodo.model.navigation.PhotoTodoRoute
 fun AdaptiveHomeScreen(
     uiState: HomeUiState,
     onEvent: (HomeEvent) -> Unit,
-    navTo: (PhotoTodoRoute) -> Unit,
-    windowSizeClass: WindowSizeClass,
-    modifier: Modifier = Modifier
+    navTo: (PhotoTodoRoute?) -> Unit,
 ) {
-    val isExpanded = windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact
+    val navigator = rememberListDetailPaneScaffoldNavigator<Nothing>()
 
-    if (!isExpanded) {
-        HomeScreen(
-            uiState = uiState,
-            onEvent = onEvent,
-            navTo = navTo,
-            modifier = modifier
-        )
-    } else {
-        val navigator = rememberListDetailPaneScaffoldNavigator<Nothing>()
-
-        // Shared dialog/fab states for the adaptive view
-        var showAddCategoryDialog by rememberSaveable { mutableStateOf(false) }
-        var categoryToDelete by remember { mutableStateOf<CategoryOverviewUiModel?>(null) }
-        var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
-        var isSearchMode by rememberSaveable { mutableStateOf(false) }
-
-        Scaffold(
-            modifier = modifier.fillMaxSize(),
-            floatingActionButton = {
-                HomeOverviewFab(
-                    fabMenuExpanded = fabMenuExpanded,
-                    onFabToggle = { fabMenuExpanded = it },
-                    onAddCategoryClick = {
-                        fabMenuExpanded = false
-                        showAddCategoryDialog = true
-                    },
-                    onHomeProjectClick = {
-                        fabMenuExpanded = false
-                        onEvent(HomeEvent.OnAddQuickProjectClicked("Home"))
-                    },
-                    onCameraClick = {
-                        fabMenuExpanded = false
-                        navTo(PhotoTodoRoute.Camera(projectId = null))
-                    },
-                    onSmartCaptureClick = {
-                        fabMenuExpanded = false
-                        navTo(PhotoTodoRoute.SmartCapture())
-                    },
-                    isAiEnabled = uiState.isAiEnabled
-                )
-            }
-        ) { paddingValues ->
-            val paneContrast = LocalPaneContrast.current
-            
-            ListDetailPaneScaffold(
-                directive = navigator.scaffoldDirective,
-                value = navigator.scaffoldValue,
-                listPane = {
-                    // LEFT PANE: The Dashboard (Summary + Jump Back In)
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(
-                                if (paneContrast == "TINTED") MaterialTheme.colorScheme.surfaceContainerLow
-                                else MaterialTheme.colorScheme.surface
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        floatingActionButton = {
+            HomeOverviewFab(
+                fabMenuExpanded = uiState.fabMenuExpanded,
+                onFabToggle = { onEvent(HomeEvent.OnFabMenuToggle(it)) },
+                onAddCategoryClick = {
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
+                    onEvent(HomeEvent.OnShowAddCategoryDialog(true))
+                },
+                onHomeProjectClick = {
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
+                    onEvent(HomeEvent.OnAddQuickProjectClicked("Home"))
+                },
+                onCameraClick = {
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
+                    navTo(PhotoTodoRoute.Camera(projectId = null))
+                },
+                onSmartCaptureClick = {
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
+                    navTo(PhotoTodoRoute.SmartCapture())
+                },
+                isAiEnabled = uiState.isAiEnabled
+            )
+        }
+    ) { paddingValues ->
+        val paneContrast = LocalPaneContrast.current
+        
+        ListDetailPaneScaffold(
+            directive = navigator.scaffoldDirective,
+            value = navigator.scaffoldValue,
+            listPane = {
+                // LEFT PANE: The Dashboard (Summary + Jump Back In)
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            if (paneContrast == "TINTED") MaterialTheme.colorScheme.surfaceContainerLow
+                            else MaterialTheme.colorScheme.surface
+                        )
+                        .padding(paddingValues)
+                        .padding(horizontal = 16.dp),
+                    contentPadding = PaddingValues(top = 16.dp, bottom = 80.dp),
+                    verticalArrangement = Arrangement.spacedBy(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    if (uiState.isLoading) {
+                        item { CircularProgressIndicator() }
+                    } else if (uiState.isEmpty) {
+                        item {
+                            Text(
+                                stringResource(R.string.applications_photodo_apps_mobile_features_home_no_data_seed),
+                                modifier = Modifier.padding(top = 16.dp)
                             )
-                            .padding(paddingValues)
-                            .padding(horizontal = 16.dp),
-                        contentPadding = PaddingValues(top = 16.dp, bottom = 80.dp),
-                        verticalArrangement = Arrangement.spacedBy(24.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        if (uiState.isLoading) {
-                            item { CircularProgressIndicator() }
-                        } else if (uiState.isEmpty) {
+                        }
+                    } else {
+                        item {
+                            OverviewSummaryCard(
+                                categories = uiState.categories,
+                                isExpanded = uiState.isCategoriesSummaryExpanded,
+                                onToggleExpand = { onEvent(HomeEvent.OnToggleCategoriesSummary) }
+                            )
+                        }
+
+                        item {
+                            // --- 4. Jump Back In Section (Preserved Urgent/Fav List) ---
+                            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
+                                    Text(
+                                        stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
+                                        style = MaterialTheme.typography.titleLarge,
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+
+                                TaskSearchBar(
+                                    query = uiState.taskSearchQuery,
+                                    onQueryChange = { onEvent(HomeEvent.OnTaskSearchQueryChanged(it)) }
+                                )
+                            }
+                        }
+
+                        if (uiState.taskSearchQuery.isNotBlank()) {
                             item {
-                                Text(
-                                    stringResource(R.string.applications_photodo_apps_mobile_features_home_no_data_seed),
-                                    modifier = Modifier.padding(top = 16.dp)
+                                TaskSearchResultsList(
+                                    results = uiState.taskSearchResults,
+                                    navTo = navTo
                                 )
                             }
                         } else {
-                            item {
-                                OverviewSummaryCard(
-                                    categories = uiState.categories,
-                                    isExpanded = uiState.isCategoriesSummaryExpanded,
-                                    onToggleExpand = { onEvent(HomeEvent.OnToggleCategoriesSummary) }
-                                )
-                            }
-
-                            item {
-                                // --- 4. Jump Back In Section (Preserved Urgent/Fav List) ---
-                                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
-                                        Text(
-                                            stringResource(R.string.applications_photodo_apps_mobile_features_home_jump_back_in),
-                                            style = MaterialTheme.typography.titleLarge,
-                                            color = MaterialTheme.colorScheme.primary
-                                        )
-                                    }
-
-                                    TaskSearchBar(
-                                        query = uiState.searchQuery,
-                                        onQueryChange = { onEvent(HomeEvent.OnSearchQueryChanged(it)) }
-                                    )
-                                }
-                            }
-
-                            if (uiState.searchQuery.isNotBlank()) {
+                            if (uiState.urgentProjects.isEmpty()) {
                                 item {
-                                    TaskSearchResultsList(
-                                        results = uiState.taskSearchResults,
-                                        navTo = navTo
+                                    Text(
+                                        stringResource(R.string.applications_photodo_apps_mobile_features_home_no_urgent_projects),
+                                        modifier = Modifier.padding(top = 16.dp)
                                     )
                                 }
                             } else {
-                                if (uiState.urgentProjects.isEmpty()) {
-                                    item {
-                                        Text(
-                                            stringResource(R.string.applications_photodo_apps_mobile_features_home_no_urgent_projects),
-                                            modifier = Modifier.padding(top = 16.dp)
-                                        )
-                                    }
-                                } else {
-                                    items(items = uiState.urgentProjects, key = { it.projectId }) { project ->
-                                        HomeProjectRow(
-                                            project = project,
-                                            onEvent = onEvent,
-                                            navTo = navTo
-                                        )
-                                    }
+                                items(items = uiState.urgentProjects, key = { it.projectId }) { project ->
+                                    HomeProjectRow(
+                                        project = project,
+                                        onEvent = onEvent,
+                                        navTo = navTo
+                                    )
                                 }
                             }
                         }
                     }
-                },
-                detailPane = {
-                    // RIGHT PANE: The Directory (Full Category Grid)
-                    HomeOverviewContent(
-                        uiState = uiState,
-                        isSearchMode = isSearchMode,
-                        onSearchModeChange = { isSearchMode = it },
-                        onEvent = onEvent,
-                        navTo = { route -> if (route != null) navTo(route) },
-                        onDeleteClicked = { categoryToDelete = it },
-                        modifier = Modifier.fillMaxSize().padding(paddingValues),
-                        showSummaryHeader = false
-                    )
-                },
-                modifier = Modifier.fillMaxSize()
-            )
-        }
-
-        HomeOverviewDialogs(
-            showAddCategorySheet = showAddCategoryDialog,
-            onDismissAddCategory = { showAddCategoryDialog = false },
-            uiState = uiState,
-            categoryToDelete = categoryToDelete,
-            onDismissDeleteConfirmation = { categoryToDelete = null },
-            onEvent = onEvent
+                }
+            },
+            detailPane = {
+                // RIGHT PANE: The Directory (Full Category Grid)
+                HomeOverviewContent(
+                    uiState = uiState,
+                    onEvent = onEvent,
+                    navTo = { route -> if (route != null) navTo(route) },
+                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    showSummaryHeader = false
+                )
+            },
+            modifier = Modifier.fillMaxSize()
         )
     }
+
+    HomeOverviewDialogs(
+        showAddCategorySheet = uiState.showAddCategoryDialog,
+        onDismissAddCategory = { onEvent(HomeEvent.OnShowAddCategoryDialog(false)) },
+        uiState = uiState,
+        categoryToDelete = uiState.categoryToDelete,
+        onDismissDeleteConfirmation = { onEvent(HomeEvent.OnCategoryToDeleteChanged(null)) },
+        onEvent = onEvent
+    )
 }
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
@@ -226,8 +204,7 @@ fun AdaptiveHomeScreenPreviewCompact() {
                 )
             ),
             onEvent = {},
-            navTo = {},
-            windowSizeClass = calculateFromSize(DpSize(400.dp, 800.dp))
+            navTo = {}
         )
     }
 }
@@ -249,8 +226,7 @@ fun AdaptiveHomeScreenPreviewExpanded() {
                 )
             ),
             onEvent = {},
-            navTo = {},
-            windowSizeClass = calculateFromSize(DpSize(1000.dp, 800.dp))
+            navTo = {}
         )
     }
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
@@ -1,6 +1,7 @@
 package com.zoewave.probase.photodo.mobile.features.home.ui.components.home
 
 import com.zoewave.probase.applications.photodo.db.model.ProjectTemplate
+import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.CategoryOverviewUiModel
 
 sealed interface HomeEvent {
     data object OnRefresh : HomeEvent
@@ -14,7 +15,14 @@ sealed interface HomeEvent {
     data class OnDeleteCategory(val categoryId: Long) : HomeEvent
 
     data class OnAddQuickProjectClicked(val overrideCategoryName: String? = null) : HomeEvent
-    data class OnSearchQueryChanged(val query: String) : HomeEvent
+    data class OnCategorySearchQueryChanged(val query: String) : HomeEvent
+    data class OnTaskSearchQueryChanged(val query: String) : HomeEvent
     data object OnToggleCategoriesSummary : HomeEvent
     data object OnDismissBottomSheet : HomeEvent
+
+    // UI State Toggles
+    data class OnShowAddCategoryDialog(val show: Boolean) : HomeEvent
+    data class OnCategoryToDeleteChanged(val category: CategoryOverviewUiModel?) : HomeEvent
+    data class OnFabMenuToggle(val expanded: Boolean) : HomeEvent
+    data class OnSearchModeToggle(val enabled: Boolean) : HomeEvent
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt
@@ -40,34 +40,29 @@ import components.home.CategoryQuickJumpRow
 fun HomeScreen(
     uiState: HomeUiState,
     onEvent: (HomeEvent) -> Unit,
-    navTo: (PhotoTodoRoute) -> Unit, // ✅ Restrictive navigation channel enforced
-    modifier: Modifier = Modifier
+    navTo: (PhotoTodoRoute?) -> Unit, // ✅ Restrictive navigation channel enforced
 ) {
-    var showAddCategoryDialog by rememberSaveable { mutableStateOf(false) }
-    var categoryToDelete by remember { mutableStateOf<CategoryOverviewUiModel?>(null) }
-    var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
-
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
         // 🚀 Upgrade: HomeOverviewFab for consistent FAB actions
         floatingActionButton = {
             HomeOverviewFab(
-                fabMenuExpanded = fabMenuExpanded,
-                onFabToggle = { fabMenuExpanded = it },
+                fabMenuExpanded = uiState.fabMenuExpanded,
+                onFabToggle = { onEvent(HomeEvent.OnFabMenuToggle(it)) },
                 onAddCategoryClick = {
-                    fabMenuExpanded = false
-                    showAddCategoryDialog = true
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
+                    onEvent(HomeEvent.OnShowAddCategoryDialog(true))
                 },
                 onHomeProjectClick = {
-                    fabMenuExpanded = false
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
                     onEvent(HomeEvent.OnAddQuickProjectClicked("Home"))
                 },
                 onCameraClick = {
-                    fabMenuExpanded = false
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
                     navTo(PhotoTodoRoute.Camera(projectId = null))
                 },
                 onSmartCaptureClick = {
-                    fabMenuExpanded = false
+                    onEvent(HomeEvent.OnFabMenuToggle(false))
                     navTo(PhotoTodoRoute.SmartCapture())
                 },
                 isAiEnabled = uiState.isAiEnabled
@@ -181,11 +176,11 @@ fun HomeScreen(
     }
 
     HomeOverviewDialogs(
-        showAddCategorySheet = showAddCategoryDialog,
-        onDismissAddCategory = { showAddCategoryDialog = false },
+        showAddCategorySheet = uiState.showAddCategoryDialog,
+        onDismissAddCategory = { onEvent(HomeEvent.OnShowAddCategoryDialog(false)) },
         uiState = uiState,
-        categoryToDelete = categoryToDelete,
-        onDismissDeleteConfirmation = { categoryToDelete = null },
+        categoryToDelete = uiState.categoryToDelete,
+        onDismissDeleteConfirmation = { onEvent(HomeEvent.OnCategoryToDeleteChanged(null)) },
         onEvent = onEvent,
     )
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
@@ -19,10 +19,15 @@ data class HomeUiState(
     val urgentProjects: List<ProjectListUiModel> = emptyList(),
     val isQuickProjectSheetOpen: Boolean = false,
     val quickProjectCategoryOverride: String? = null,
-    val searchQuery: String = "",
+    val categorySearchQuery: String = "",
+    val taskSearchQuery: String = "",
     val taskSearchResults: List<TaskSearchResult> = emptyList(),
     val isAiEnabled: Boolean = false,
-    val isCategoriesSummaryExpanded: Boolean = true
+    val isCategoriesSummaryExpanded: Boolean = true,
+    val showAddCategoryDialog: Boolean = false,
+    val categoryToDelete: CategoryOverviewUiModel? = null,
+    val fabMenuExpanded: Boolean = false,
+    val isSearchMode: Boolean = false
 ) {
     val isEmpty: Boolean = !isLoading && categories.isEmpty()
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
@@ -40,8 +40,13 @@ class HomeViewModel @Inject constructor(
     private data class UiFlags(
         val isQuickProjectSheetOpen: Boolean = false,
         val quickProjectCategoryOverride: String? = null,
-        val searchQuery: String = "",
-        val isCategoriesSummaryExpanded: Boolean = true
+        val categorySearchQuery: String = "",
+        val taskSearchQuery: String = "",
+        val isCategoriesSummaryExpanded: Boolean = true,
+        val showAddCategoryDialog: Boolean = false,
+        val categoryToDelete: CategoryOverviewUiModel? = null,
+        val fabMenuExpanded: Boolean = false,
+        val isSearchMode: Boolean = false
     )
 
     private val _uiFlags = MutableStateFlow(UiFlags())
@@ -51,15 +56,15 @@ class HomeViewModel @Inject constructor(
     val uiState: StateFlow<HomeUiState> = combine(
         photoDoRepo.getCategoriesWithProjectsAndTasks(),
         _uiFlags.flatMapLatest { flags ->
-            if (flags.searchQuery.length >= 2) {
-                photoDoRepo.getProjectsWithMatchingTasks(flags.searchQuery)
+            if (flags.taskSearchQuery.length >= 2) {
+                photoDoRepo.getProjectsWithMatchingTasks(flags.taskSearchQuery)
                     .map { projects ->
                         projects.map { projectDetails ->
                             TaskSearchResult(
                                 projectId = projectDetails.project.projectId,
                                 projectTitle = projectDetails.project.name,
                                 tasks = projectDetails.tasks.filter { 
-                                    it.text.contains(flags.searchQuery, ignoreCase = true) 
+                                    it.text.contains(flags.taskSearchQuery, ignoreCase = true) 
                                 }
                             )
                         }
@@ -130,10 +135,15 @@ class HomeViewModel @Inject constructor(
                 urgentProjects = urgentProjects,
                 isQuickProjectSheetOpen = flags.isQuickProjectSheetOpen,
                 quickProjectCategoryOverride = flags.quickProjectCategoryOverride,
-                searchQuery = flags.searchQuery,
+                categorySearchQuery = flags.categorySearchQuery,
+                taskSearchQuery = flags.taskSearchQuery,
                 taskSearchResults = searchResults,
                 isAiEnabled = isAiEnabled,
-                isCategoriesSummaryExpanded = flags.isCategoriesSummaryExpanded
+                isCategoriesSummaryExpanded = flags.isCategoriesSummaryExpanded,
+                showAddCategoryDialog = flags.showAddCategoryDialog,
+                categoryToDelete = flags.categoryToDelete,
+                fabMenuExpanded = flags.fabMenuExpanded,
+                isSearchMode = flags.isSearchMode
             )
         }
         .flowOn(Dispatchers.Default)
@@ -227,9 +237,15 @@ class HomeViewModel @Inject constructor(
                 }
             }
 
-            is HomeEvent.OnSearchQueryChanged -> {
+            is HomeEvent.OnCategorySearchQueryChanged -> {
                 _uiFlags.update { 
-                    it.copy(searchQuery = event.query)
+                    it.copy(categorySearchQuery = event.query)
+                }
+            }
+
+            is HomeEvent.OnTaskSearchQueryChanged -> {
+                _uiFlags.update { 
+                    it.copy(taskSearchQuery = event.query)
                 }
             }
 
@@ -237,6 +253,22 @@ class HomeViewModel @Inject constructor(
                 _uiFlags.update { 
                     it.copy(isCategoriesSummaryExpanded = !it.isCategoriesSummaryExpanded)
                 }
+            }
+
+            is HomeEvent.OnShowAddCategoryDialog -> {
+                _uiFlags.update { it.copy(showAddCategoryDialog = event.show) }
+            }
+
+            is HomeEvent.OnCategoryToDeleteChanged -> {
+                _uiFlags.update { it.copy(categoryToDelete = event.category) }
+            }
+
+            is HomeEvent.OnFabMenuToggle -> {
+                _uiFlags.update { it.copy(fabMenuExpanded = event.expanded) }
+            }
+
+            is HomeEvent.OnSearchModeToggle -> {
+                _uiFlags.update { it.copy(isSearchMode = event.enabled) }
             }
         }
     }

--- a/applications/photodo/apps/mobile/features/settings/build.gradle.kts
+++ b/applications/photodo/apps/mobile/features/settings/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(project(":applications:photodo:apps:mobile:core"))
     implementation(project(":features:ai:capture"))
     implementation(project(":features:ai:configuration"))
+    implementation(project(":features:compliance"))
 
     // --- Serialization (The backbone of Nav3) ---
     implementation(libs.kotlinx.serialization.json)

--- a/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/SettingsEvent.kt
+++ b/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/SettingsEvent.kt
@@ -6,4 +6,9 @@ sealed interface SettingsEvent {
     data class OnPaneContrastSelected(val paneContrastIdentifier: String) : SettingsEvent
     data class OnGeminiApiKeyChanged(val apiKey: String?) : SettingsEvent
     data class OnAiEnabledToggled(val enabled: Boolean) : SettingsEvent
+
+    // UI State Toggles
+    data class OnThemeExpandedToggled(val expanded: Boolean) : SettingsEvent
+    data class OnAiExpandedToggled(val expanded: Boolean) : SettingsEvent
+    data class OnAboutExpandedToggled(val expanded: Boolean) : SettingsEvent
 }

--- a/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/SettingsUiRoute.kt
+++ b/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/SettingsUiRoute.kt
@@ -1,11 +1,8 @@
 package com.zoewave.probase.photodo.mobile.features.settings.ui
 
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.zoewave.probase.photodo.model.navigation.PhotoTodoRoute
 import com.zoewave.probase.photodo.mobile.features.settings.ui.components.SettingsScreen
@@ -13,22 +10,14 @@ import com.zoewave.probase.photodo.mobile.features.settings.ui.components.Settin
 
 @Composable
 fun SettingsUiRoute(
-    initialCardKeyToExpand: String?,
     navTo: (PhotoTodoRoute?) -> Unit,
-    modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    // Pass the deep-link argument into the ViewModel on first load
-    LaunchedEffect(initialCardKeyToExpand) {
-        viewModel.setInitialExpandedKey(initialCardKeyToExpand)
-    }
-
     SettingsScreen(
         uiState = uiState,
         onEvent = viewModel::onEvent,
-        navTo = navTo,
-        modifier = modifier.fillMaxSize()
+        navTo = navTo
     )
 }

--- a/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/SettingsUiState.kt
+++ b/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/SettingsUiState.kt
@@ -8,5 +8,10 @@ data class SettingsUiState(
     val isAiEnabled: Boolean = false,
     val initialCardKeyToExpand: String? = null,
     val appVersion: String = "",
-    val firebaseDeviceId: String = ""
+    val firebaseDeviceId: String = "",
+    val ageVerificationStatus: String = "Checking...",
+    val isAgeVerified: Boolean = false,
+    val isThemeExpanded: Boolean = false,
+    val isAiExpanded: Boolean = false,
+    val isAboutExpanded: Boolean = false
 )

--- a/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/SettingsViewModel.kt
+++ b/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/SettingsViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.installations.FirebaseInstallations
 import com.zoewave.probase.applications.photodo.db.repo.AppSettingsRepository
 import com.zoewave.probase.features.ai.capture.data.SmartCaptureOrchestrator
+import com.zoewave.probase.features.compliance.AgeSignalsManager
+import com.zoewave.probase.features.compliance.model.AgeVerificationStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +18,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
@@ -23,14 +26,25 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val appSettingsRepository: AppSettingsRepository,
+    private val ageSignalsManager: AgeSignalsManager,
     @param:ApplicationContext private val context: Context
 ) : ViewModel() {
 
-    // Holds the deep-link argument passed from the navigation graph
-    private val _initialExpandedKey = MutableStateFlow<String?>(null)
+    private data class UiFlags(
+        val initialExpandedKey: String? = null,
+        val isThemeExpanded: Boolean = false,
+        val isAiExpanded: Boolean = false,
+        val isAboutExpanded: Boolean = false
+    )
+
+    private val _uiFlags = MutableStateFlow(UiFlags())
 
     // NEW: Firebase Device ID state
     private val _firebaseDeviceId = MutableStateFlow<String>("Loading...")
+
+    // NEW: Compliance status state
+    private val _ageVerificationStatus = MutableStateFlow<String>("Checking...")
+    private val _isAgeVerified = MutableStateFlow<Boolean>(false)
 
     // Combines the DB theme preference with the navigation argument into a single UI State
 @Suppress("UNCHECKED_CAST")
@@ -40,18 +54,32 @@ class SettingsViewModel @Inject constructor(
         appSettingsRepository.paneContrastFlow,
         appSettingsRepository.isGeminiApiKeySetFlow,
         appSettingsRepository.isAiEnabledFlow,
-        _initialExpandedKey,
-        _firebaseDeviceId
+        _firebaseDeviceId,
+        _ageVerificationStatus,
+        _isAgeVerified,
+        _uiFlags
     ) { args: Array<Any?> ->
+        val flags = args[8] as UiFlags
+        
+        // Auto-expand logic (only once on init)
+        val finalThemeExpanded = flags.isThemeExpanded || (flags.initialExpandedKey == "SYSTEM")
+        val finalAiExpanded = flags.isAiExpanded || (flags.initialExpandedKey == "AI")
+        val finalAboutExpanded = flags.isAboutExpanded || (flags.initialExpandedKey == "ABOUT")
+
         SettingsUiState(
             currentTheme = args[0] as String,
             currentPalette = args[1] as String,
             currentPaneContrast = args[2] as String,
             isApiKeySet = args[3] as Boolean,
             isAiEnabled = args[4] as Boolean,
-            initialCardKeyToExpand = args[5] as String?,
+            initialCardKeyToExpand = flags.initialExpandedKey,
             appVersion = getAppVersion(),
-            firebaseDeviceId = args[6] as String
+            firebaseDeviceId = args[5] as String,
+            ageVerificationStatus = args[6] as String,
+            isAgeVerified = args[7] as Boolean,
+            isThemeExpanded = finalThemeExpanded,
+            isAiExpanded = finalAiExpanded,
+            isAboutExpanded = finalAboutExpanded
         )
     }.stateIn(
         scope = viewModelScope,
@@ -61,6 +89,7 @@ class SettingsViewModel @Inject constructor(
 
     init {
         fetchFirebaseDeviceId()
+        fetchComplianceStatus()
     }
 
     private fun getAppVersion(): String {
@@ -84,6 +113,24 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    private fun fetchComplianceStatus() {
+        viewModelScope.launch {
+            val result = ageSignalsManager.getAgeSignal()
+            result.fold(
+                onSuccess = { signal ->
+                    val rangeText = signal.ageRange?.description ?: "Unknown"
+                    val statusText = signal.verificationStatus.name
+                    _ageVerificationStatus.value = "$rangeText ($statusText)"
+                    _isAgeVerified.value = signal.verificationStatus == AgeVerificationStatus.VERIFIED
+                },
+                onFailure = { error ->
+                    _ageVerificationStatus.value = "Error: ${error.message}"
+                    _isAgeVerified.value = false
+                }
+            )
+        }
+    }
+
     fun onEvent(event: SettingsEvent) {
         when (event) {
             is SettingsEvent.OnThemeSelected -> {
@@ -103,13 +150,23 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.OnAiEnabledToggled -> {
                 viewModelScope.launch { appSettingsRepository.saveAiEnabled(event.enabled) }
             }
+
+            is SettingsEvent.OnThemeExpandedToggled -> {
+                _uiFlags.update { it.copy(isThemeExpanded = event.expanded) }
+            }
+            is SettingsEvent.OnAiExpandedToggled -> {
+                _uiFlags.update { it.copy(isAiExpanded = event.expanded) }
+            }
+            is SettingsEvent.OnAboutExpandedToggled -> {
+                _uiFlags.update { it.copy(isAboutExpanded = event.expanded) }
+            }
         }
     }
 
     // Called once when the Route initializes
     fun setInitialExpandedKey(key: String?) {
-        if (_initialExpandedKey.value == null && key != null) {
-            _initialExpandedKey.value = key
+        if (_uiFlags.value.initialExpandedKey == null && key != null) {
+            _uiFlags.update { it.copy(initialExpandedKey = key) }
         }
     }
 }

--- a/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/components/AboutSettingsCard.kt
+++ b/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/components/AboutSettingsCard.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -27,6 +29,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
@@ -40,6 +43,8 @@ fun AboutSettingsCard(
     onExpandToggle: () -> Unit,
     appVersion: String,
     firebaseDeviceId: String,
+    ageVerificationStatus: String,
+    isAgeVerified: Boolean,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -117,6 +122,42 @@ fun AboutSettingsCard(
                     ) {
                         Text(stringResource(R.string.applications_photodo_apps_mobile_features_settings_about_copy_id))
                     }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // NEW: Regulatory Compliance Section
+                    Text(
+                        text = "Regulatory Compliance",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(top = 4.dp)
+                    ) {
+                        Icon(
+                            imageVector = if (isAgeVerified) Icons.Default.CheckCircle else Icons.Default.Shield,
+                            contentDescription = null,
+                            tint = if (isAgeVerified) Color(0xFF4CAF50) else MaterialTheme.colorScheme.secondary,
+                            modifier = Modifier.padding(end = 8.dp)
+                        )
+                        Column {
+                            Text(
+                                text = "Age Verification Status",
+                                style = MaterialTheme.typography.labelMedium
+                            )
+                            Text(
+                                text = ageVerificationStatus,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                    Text(
+                        text = "Authoritative age signals are retrieved in real-time from the Play Store to ensure age-appropriate experiences.",
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
 
                     Spacer(modifier = Modifier.height(16.dp))
 

--- a/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/components/SettingsScreen.kt
+++ b/applications/photodo/apps/mobile/features/settings/src/main/java/com/zoewave/probase/photodo/mobile/features/settings/ui/components/SettingsScreen.kt
@@ -16,10 +16,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -40,21 +36,7 @@ fun SettingsScreen(
     uiState: SettingsUiState,
     onEvent: (SettingsEvent) -> Unit,
     navTo: (PhotoTodoRoute?) -> Unit,
-    modifier: Modifier = Modifier
 ) {
-    // Determine if we should open this card automatically based on the UiState deep-link
-    var isThemeExpanded by rememberSaveable(uiState.initialCardKeyToExpand) {
-        mutableStateOf(uiState.initialCardKeyToExpand == ThemeIdentifiers.SYSTEM)
-    }
-
-    var isAiExpanded by rememberSaveable(uiState.initialCardKeyToExpand) {
-        mutableStateOf(uiState.initialCardKeyToExpand == "AI")
-    }
-
-    var isAboutExpanded by rememberSaveable(uiState.initialCardKeyToExpand) {
-        mutableStateOf(uiState.initialCardKeyToExpand == "ABOUT")
-    }
-
     Scaffold(
         topBar = {
             TopAppBar(
@@ -70,7 +52,7 @@ fun SettingsScreen(
                 }
             )
         },
-        modifier = modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize()
     ) { paddingValues ->
         Box(
             modifier = Modifier
@@ -86,8 +68,8 @@ fun SettingsScreen(
             ) {
                 ThemeSettingsCard(
                     title = stringResource(R.string.applications_photodo_apps_mobile_features_settings_app_theme_title),
-                    expanded = isThemeExpanded,
-                    onExpandToggle = { isThemeExpanded = !isThemeExpanded },
+                    expanded = uiState.isThemeExpanded,
+                    onExpandToggle = { onEvent(SettingsEvent.OnThemeExpandedToggled(!uiState.isThemeExpanded)) },
                     currentTheme = uiState.currentTheme,
                     onThemeSelected = { newTheme ->
                         onEvent(SettingsEvent.OnThemeSelected(newTheme))
@@ -95,8 +77,8 @@ fun SettingsScreen(
                 )
 
                 AiConfigurationCard(
-                    expanded = isAiExpanded,
-                    onExpandToggle = { isAiExpanded = !isAiExpanded },
+                    expanded = uiState.isAiExpanded,
+                    onExpandToggle = { onEvent(SettingsEvent.OnAiExpandedToggled(!uiState.isAiExpanded)) },
                     title = "Smart Capture AI",
                     description = "Use Gemini to automatically fill details from images."
                 )
@@ -113,19 +95,13 @@ fun SettingsScreen(
                 )
 
                 AboutSettingsCard(
-                    expanded = isAboutExpanded,
-                    onExpandToggle = { isAboutExpanded = !isAboutExpanded },
+                    expanded = uiState.isAboutExpanded,
+                    onExpandToggle = { onEvent(SettingsEvent.OnAboutExpandedToggled(!uiState.isAboutExpanded)) },
                     appVersion = uiState.appVersion,
-                    firebaseDeviceId = uiState.firebaseDeviceId
+                    firebaseDeviceId = uiState.firebaseDeviceId,
+                    ageVerificationStatus = uiState.ageVerificationStatus,
+                    isAgeVerified = uiState.isAgeVerified
                 )
-
-                // Additional settings cards can be added here following the same pattern
-                /*
-                NotificationSettingsCard(
-                    uiState = uiState,
-                    onEvent = onEvent
-                )
-                */
             }
         }
     }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksEvent.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksEvent.kt
@@ -2,6 +2,7 @@ package com.zoewave.probase.photodo.mobile.features.tasks.ui
 
 import com.zoewave.probase.applications.photodo.db.model.ProjectTemplate
 import com.zoewave.probase.core.model.tasks.SmartTaskDraft
+import com.zoewave.probase.photodo.mobile.features.tasks.ui.state.ProjectListUiModel
 
 
 sealed interface TasksEvent {
@@ -50,4 +51,9 @@ sealed interface TasksEvent {
 
     // ✅ Sheet Dismissal
     data object OnDismissBottomSheet : TasksEvent
+
+    // UI State Toggles
+    data class OnFabMenuToggle(val expanded: Boolean) : TasksEvent
+    data class OnShowDeleteCategoryConfirmation(val show: Boolean) : TasksEvent
+    data class OnProjectToDeleteChanged(val project: ProjectListUiModel?) : TasksEvent
 }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksViewModel.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksViewModel.kt
@@ -78,7 +78,10 @@ class TasksViewModel @Inject constructor(
         val isAddTaskItemSheetOpen: Boolean = false,
         val isAddPhotoSheetOpen: Boolean = false,
         val isQuickProjectSheetOpen: Boolean = false,
-        val quickProjectCategoryOverride: String? = null
+        val quickProjectCategoryOverride: String? = null,
+        val fabMenuExpanded: Boolean = false,
+        val showDeleteConfirmation: Boolean = false,
+        val projectToDelete: ProjectListUiModel? = null
     )
 
     val uiState: StateFlow<TasksUiState> = combine(
@@ -152,7 +155,10 @@ class TasksViewModel @Inject constructor(
             isAddTaskItemSheetOpen = flags.isAddTaskItemSheetOpen,
             isAddPhotoSheetOpen = flags.isAddPhotoSheetOpen,
             isQuickProjectSheetOpen = flags.isQuickProjectSheetOpen,
-            quickProjectCategoryOverride = flags.quickProjectCategoryOverride
+            quickProjectCategoryOverride = flags.quickProjectCategoryOverride,
+            fabMenuExpanded = flags.fabMenuExpanded,
+            showDeleteConfirmation = flags.showDeleteConfirmation,
+            projectToDelete = flags.projectToDelete
         )
     }.stateIn(
         scope = viewModelScope,
@@ -362,6 +368,18 @@ class TasksViewModel @Inject constructor(
                     // 5. Trigger Navigation Side Effect
                     _effects.send(TasksSideEffect.ProjectCreated(projectId, newProject.name))
                 }
+            }
+
+            is TasksEvent.OnFabMenuToggle -> {
+                _uiFlags.update { it.copy(fabMenuExpanded = event.expanded) }
+            }
+
+            is TasksEvent.OnShowDeleteCategoryConfirmation -> {
+                _uiFlags.update { it.copy(showDeleteConfirmation = event.show) }
+            }
+
+            is TasksEvent.OnProjectToDeleteChanged -> {
+                _uiFlags.update { it.copy(projectToDelete = event.project) }
             }
         }
     }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/TasksListScreen.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/TasksListScreen.kt
@@ -32,10 +32,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -56,25 +53,15 @@ fun TasksListScreen(
     uiState: TasksUiState,
     onEvent: (TasksEvent) -> Unit,
     navTo: (PhotoTodoRoute?) -> Unit, // ✅ Standardized Navigation Channel
-    modifier: Modifier = Modifier
 ) {
-    var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
-
-    // Confirmation Dialog State
-    var showDeleteConfirmation by rememberSaveable { mutableStateOf(false) }
-    var projectToDelete by remember { mutableStateOf<ProjectListUiModel?>(null) }
-
-    BackHandler(fabMenuExpanded) { fabMenuExpanded = false }
+    BackHandler(uiState.fabMenuExpanded) { onEvent(TasksEvent.OnFabMenuToggle(false)) }
 
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
         topBar = {
             TopAppBar(
                 title = { Text(uiState.categoryName) },
                 navigationIcon = {
-                    // Assume we can always go back if we are in this specific screen? 
-                    // Actually, for top-level it might not show. 
-                    // But in standard Nav3, we just call back.
                     IconButton(onClick = { navTo(null) }) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
@@ -84,7 +71,7 @@ fun TasksListScreen(
                 },
                 actions = {
                     if (!uiState.isNoCategoriesYet) {
-                        IconButton(onClick = { showDeleteConfirmation = true }) {
+                        IconButton(onClick = { onEvent(TasksEvent.OnShowDeleteCategoryConfirmation(true)) }) {
                             Icon(
                                 Icons.Default.Delete,
                                 contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_delete_category_content_desc)
@@ -97,11 +84,11 @@ fun TasksListScreen(
         // ✅ 1. THE FAB IS RESTORED
         floatingActionButton = {
             FloatingActionButtonMenu(
-                expanded = fabMenuExpanded,
+                expanded = uiState.fabMenuExpanded,
                 button = {
                     ToggleFloatingActionButton(
-                        checked = fabMenuExpanded,
-                        onCheckedChange = { fabMenuExpanded = it }
+                        checked = uiState.fabMenuExpanded,
+                        onCheckedChange = { onEvent(TasksEvent.OnFabMenuToggle(it)) }
                     ) {
                         val imageVector by remember {
                             derivedStateOf {
@@ -118,7 +105,7 @@ fun TasksListScreen(
             ) {
                 FloatingActionButtonMenuItem(
                     onClick = {
-                        fabMenuExpanded = false
+                        onEvent(TasksEvent.OnFabMenuToggle(false))
                         onEvent(TasksEvent.OnAddQuickProjectClicked(overrideCategoryName = null))
                     },
                     icon = { Icon(Icons.AutoMirrored.Filled.FormatListBulleted, contentDescription = null) },
@@ -126,20 +113,12 @@ fun TasksListScreen(
                 )
                 FloatingActionButtonMenuItem(
                     onClick = {
-                        fabMenuExpanded = false
+                        onEvent(TasksEvent.OnFabMenuToggle(false))
                         onEvent(TasksEvent.OnAddListClicked) // Opens the Project Sheet!
                     },
                     icon = { Icon(Icons.Default.Add, contentDescription = null) },
                     text = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_new_project)) }
                 )
-                /*FloatingActionButtonMenuItem(
-                    onClick = {
-                        fabMenuExpanded = false
-                        onEvent(TasksEvent.OnAddCategoryClicked) // Opens the Category Sheet!
-                    },
-                    icon = { Icon(Icons.Default.Folder, contentDescription = null) },
-                    text = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_new_category)) }
-                )*/
             }
         }
     ) { localPadding ->
@@ -179,7 +158,7 @@ fun TasksListScreen(
                         ProjectCard(
                             project = project,
                             onEvent = onEvent, // Pass the channel straight down!
-                            onDeleteClicked = { projectToDelete = it },
+                            onDeleteClicked = { onEvent(TasksEvent.OnProjectToDeleteChanged(it)) },
                             navTo = navTo
                         )
                     }
@@ -215,15 +194,15 @@ fun TasksListScreen(
         )
     }
 
-    if (showDeleteConfirmation) {
+    if (uiState.showDeleteConfirmation) {
         AlertDialog(
-            onDismissRequest = { showDeleteConfirmation = false },
+            onDismissRequest = { onEvent(TasksEvent.OnShowDeleteCategoryConfirmation(false)) },
             title = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_delete_category_title)) },
             text = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_delete_category_message)) },
             confirmButton = {
                 TextButton(
                     onClick = {
-                        showDeleteConfirmation = false
+                        onEvent(TasksEvent.OnShowDeleteCategoryConfirmation(false))
                         uiState.categoryId?.let { id ->
                             onEvent(TasksEvent.OnDeleteCategoryClicked(id))
                         }
@@ -233,33 +212,33 @@ fun TasksListScreen(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showDeleteConfirmation = false }) {
+                TextButton(onClick = { onEvent(TasksEvent.OnShowDeleteCategoryConfirmation(false)) }) {
                     Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_cancel_button))
                 }
             }
         )
     }
 
-    if (projectToDelete != null) {
+    if (uiState.projectToDelete != null) {
         AlertDialog(
-            onDismissRequest = { projectToDelete = null },
+            onDismissRequest = { onEvent(TasksEvent.OnProjectToDeleteChanged(null)) },
             title = { Text("Delete Project?") },
-            text = { Text("This will permanently delete the '${projectToDelete?.title}' project and all its photos. This action cannot be undone.") },
+            text = { Text("This will permanently delete the '${uiState.projectToDelete.title}' project and all its photos. This action cannot be undone.") },
             confirmButton = {
                 TextButton(
                     onClick = {
-                        projectToDelete?.let {
+                        uiState.projectToDelete.let {
                             onEvent(TasksEvent.OnDeleteProject(it.projectId))
                         }
-                        projectToDelete = null
+                        onEvent(TasksEvent.OnProjectToDeleteChanged(null))
                     },
-                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error) // Fixed color logic
                 ) {
                     Text("Delete")
                 }
             },
             dismissButton = {
-                TextButton(onClick = { projectToDelete = null }) {
+                TextButton(onClick = { onEvent(TasksEvent.OnProjectToDeleteChanged(null)) }) {
                     Text("Cancel")
                 }
             }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailEvent.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailEvent.kt
@@ -26,4 +26,13 @@ sealed interface TaskDetailEvent {
     data object OnCameraClick : TaskDetailEvent
     data object OnBackFromCamera : TaskDetailEvent
     data object OnHelpClicked : TaskDetailEvent
+
+    // UI State Toggles
+    data class OnFabMenuToggle(val expanded: Boolean) : TaskDetailEvent
+    data class OnShowAddTaskDialog(val show: Boolean) : TaskDetailEvent
+    data class OnNewTaskTextChanged(val text: String) : TaskDetailEvent
+    data class OnShowAddExpenseDialog(val show: Boolean) : TaskDetailEvent
+    data class OnNewExpenseAmountChanged(val amount: String) : TaskDetailEvent
+    data class OnNewExpenseDescChanged(val desc: String) : TaskDetailEvent
+    data class OnShowDeleteProjectConfirmation(val show: Boolean) : TaskDetailEvent
 }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailScreen.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailScreen.kt
@@ -50,10 +50,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -82,22 +79,7 @@ fun TaskDetailScreen(
     uiState: TaskDetailUiState,
     onEvent: (TaskDetailEvent) -> Unit,
     navTo: (PhotoTodoRoute?) -> Unit,
-    modifier: Modifier = Modifier
 ) {
-    var fabMenuExpanded by rememberSaveable { mutableStateOf(false) }
-
-    // Task Dialog State
-    var showAddTaskDialog by rememberSaveable { mutableStateOf(false) }
-    var newTaskText by rememberSaveable { mutableStateOf("") }
-
-    // 🚀 Expense Dialog State
-    var showAddExpenseDialog by rememberSaveable { mutableStateOf(false) }
-    var newExpenseAmount by rememberSaveable { mutableStateOf("") }
-    var newExpenseDesc by rememberSaveable { mutableStateOf("") }
-
-    // 🚀 Confirmation Dialog States
-    var showDeleteProjectConfirmation by rememberSaveable { mutableStateOf(false) }
-
     val context = LocalContext.current
 
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -114,11 +96,11 @@ fun TaskDetailScreen(
     }
 
     BackHandler {
-        if (fabMenuExpanded) fabMenuExpanded = false else navTo(null)
+        if (uiState.fabMenuExpanded) onEvent(TaskDetailEvent.OnFabMenuToggle(false)) else navTo(null)
     }
 
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize(),
         topBar = {
             TopAppBar(
                 title = {
@@ -150,7 +132,7 @@ fun TaskDetailScreen(
                             }
                         }
 
-                        IconButton(onClick = { showDeleteProjectConfirmation = true }) {
+                        IconButton(onClick = { onEvent(TaskDetailEvent.OnShowDeleteProjectConfirmation(true)) }) {
                             Icon(
                                 Icons.Default.DeleteForever,
                                 contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_delete_project_content_desc)
@@ -162,11 +144,11 @@ fun TaskDetailScreen(
         },
         floatingActionButton = {
             FloatingActionButtonMenu(
-                expanded = fabMenuExpanded,
+                expanded = uiState.fabMenuExpanded,
                 button = {
                     ToggleFloatingActionButton(
-                        checked = fabMenuExpanded,
-                        onCheckedChange = { fabMenuExpanded = !fabMenuExpanded }
+                        checked = uiState.fabMenuExpanded,
+                        onCheckedChange = { onEvent(TaskDetailEvent.OnFabMenuToggle(it)) }
                     ) {
                         val imageVector by remember {
                             derivedStateOf { if (checkedProgress > 0.5f) Icons.Default.Close else Icons.Default.Add }
@@ -181,7 +163,7 @@ fun TaskDetailScreen(
             ) {
                 FloatingActionButtonMenuItem(
                     onClick = {
-                        fabMenuExpanded = false
+                        onEvent(TaskDetailEvent.OnFabMenuToggle(false))
                         val isGranted = ContextCompat.checkSelfPermission(
                             context, Manifest.permission.CAMERA
                         ) == PackageManager.PERMISSION_GRANTED
@@ -200,21 +182,12 @@ fun TaskDetailScreen(
                 )
                 FloatingActionButtonMenuItem(
                     onClick = {
-                        fabMenuExpanded = false
-                        showAddTaskDialog = true
+                        onEvent(TaskDetailEvent.OnFabMenuToggle(false))
+                        onEvent(TaskDetailEvent.OnShowAddTaskDialog(true))
                     },
                     icon = { Icon(Icons.Default.CheckBox, contentDescription = null) },
                     text = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_add_task)) }
                 )
-                // 🚀 NEW: Add Expense FAB Item
-                /* FloatingActionButtonMenuItem(
-                    onClick = {
-                        fabMenuExpanded = false
-                        showAddExpenseDialog = true
-                    },
-                    icon = { Icon(Icons.Default.AttachMoney, contentDescription = null) },
-                    text = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_add_expense)) }
-                )*/
             }
         }
     ) { innerPadding ->
@@ -372,17 +345,17 @@ fun TaskDetailScreen(
     // --- DIALOGS ---
 
     // 1. Add Task Dialog
-    if (showAddTaskDialog) {
+    if (uiState.showAddTaskDialog) {
         AlertDialog(
             onDismissRequest = {
-                newTaskText = ""
-                showAddTaskDialog = false
+                onEvent(TaskDetailEvent.OnShowAddTaskDialog(false))
+                onEvent(TaskDetailEvent.OnNewTaskTextChanged(""))
             },
             title = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_new_task_title)) },
             text = {
                 OutlinedTextField(
-                    value = newTaskText,
-                    onValueChange = { newTaskText = it },
+                    value = uiState.newTaskText,
+                    onValueChange = { onEvent(TaskDetailEvent.OnNewTaskTextChanged(it)) },
                     placeholder = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_new_task_placeholder)) },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
@@ -392,37 +365,37 @@ fun TaskDetailScreen(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        if (newTaskText.isNotBlank()) {
-                            onEvent(TaskDetailEvent.OnAddItemClicked(newTaskText.trim()))
-                            newTaskText = ""
-                            showAddTaskDialog = false
+                        if (uiState.newTaskText.isNotBlank()) {
+                            onEvent(TaskDetailEvent.OnAddItemClicked(uiState.newTaskText.trim()))
+                            onEvent(TaskDetailEvent.OnNewTaskTextChanged(""))
+                            onEvent(TaskDetailEvent.OnShowAddTaskDialog(false))
                         }
                     }
                 ) { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_add_button)) }
             },
             dismissButton = {
                 TextButton(onClick = {
-                    newTaskText = ""
-                    showAddTaskDialog = false
+                    onEvent(TaskDetailEvent.OnNewTaskTextChanged(""))
+                    onEvent(TaskDetailEvent.OnShowAddTaskDialog(false))
                 }) { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_cancel_button)) }
             }
         )
     }
 
-    // 🚀 2. NEW: Add Expense Dialog
-    if (showAddExpenseDialog) {
+    // 🚀 2. NEW: Add Expense Dialog (Removed but keeping if for refactor completeness if used)
+    if (uiState.showAddExpenseDialog) {
         AlertDialog(
             onDismissRequest = {
-                newExpenseAmount = ""
-                newExpenseDesc = ""
-                showAddExpenseDialog = false
+                onEvent(TaskDetailEvent.OnShowAddExpenseDialog(false))
+                onEvent(TaskDetailEvent.OnNewExpenseAmountChanged(""))
+                onEvent(TaskDetailEvent.OnNewExpenseDescChanged(""))
             },
             title = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_add_expense)) },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
-                        value = newExpenseDesc,
-                        onValueChange = { newExpenseDesc = it },
+                        value = uiState.newExpenseDesc,
+                        onValueChange = { onEvent(TaskDetailEvent.OnNewExpenseDescChanged(it)) },
                         label = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_expense_description_label)) },
                         placeholder = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_expense_description_placeholder)) },
                         singleLine = true,
@@ -430,8 +403,8 @@ fun TaskDetailScreen(
                         modifier = Modifier.fillMaxWidth()
                     )
                     OutlinedTextField(
-                        value = newExpenseAmount,
-                        onValueChange = { newExpenseAmount = it },
+                        value = uiState.newExpenseAmount,
+                        onValueChange = { onEvent(TaskDetailEvent.OnNewExpenseAmountChanged(it)) },
                         label = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_expense_amount_label)) },
                         placeholder = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_expense_amount_placeholder)) },
                         singleLine = true,
@@ -444,36 +417,35 @@ fun TaskDetailScreen(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        val amount = newExpenseAmount.toDoubleOrNull() ?: 0.0
-                        if (amount > 0 && newExpenseDesc.isNotBlank()) {
-                            // 👇 MAKE SURE TO ADD THIS EVENT TO YOUR SEALED CLASS
-                            onEvent(TaskDetailEvent.OnAddExpenseClicked(description = newExpenseDesc.trim(), amount = amount))
-                            newExpenseAmount = ""
-                            newExpenseDesc = ""
-                            showAddExpenseDialog = false
+                        val amount = uiState.newExpenseAmount.toDoubleOrNull() ?: 0.0
+                        if (amount > 0 && uiState.newExpenseDesc.isNotBlank()) {
+                            onEvent(TaskDetailEvent.OnAddExpenseClicked(description = uiState.newExpenseDesc.trim(), amount = amount))
+                            onEvent(TaskDetailEvent.OnNewExpenseAmountChanged(""))
+                            onEvent(TaskDetailEvent.OnNewExpenseDescChanged(""))
+                            onEvent(TaskDetailEvent.OnShowAddExpenseDialog(false))
                         }
                     }
                 ) { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_add_button)) }
             },
             dismissButton = {
                 TextButton(onClick = {
-                    newExpenseAmount = ""
-                    newExpenseDesc = ""
-                    showAddExpenseDialog = false
+                    onEvent(TaskDetailEvent.OnNewExpenseAmountChanged(""))
+                    onEvent(TaskDetailEvent.OnNewExpenseDescChanged(""))
+                    onEvent(TaskDetailEvent.OnShowAddExpenseDialog(false))
                 }) { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_cancel_button)) }
             }
         )
     }
 
-    if (showDeleteProjectConfirmation) {
+    if (uiState.showDeleteProjectConfirmation) {
         AlertDialog(
-            onDismissRequest = { showDeleteProjectConfirmation = false },
+            onDismissRequest = { onEvent(TaskDetailEvent.OnShowDeleteProjectConfirmation(false)) },
             title = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_delete_project_title)) },
             text = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_detail_delete_project_message)) },
             confirmButton = {
                 TextButton(
                     onClick = {
-                        showDeleteProjectConfirmation = false
+                        onEvent(TaskDetailEvent.OnShowDeleteProjectConfirmation(false))
                         onEvent(TaskDetailEvent.OnDeleteTaskListClicked)
                     }
                 ) {
@@ -481,7 +453,7 @@ fun TaskDetailScreen(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showDeleteProjectConfirmation = false }) {
+                TextButton(onClick = { onEvent(TaskDetailEvent.OnShowDeleteProjectConfirmation(false)) }) {
                     Text(stringResource(R.string.applications_photodo_apps_mobile_features_tasks_cancel_button))
                 }
             }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailUiState.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailUiState.kt
@@ -17,5 +17,12 @@ sealed interface DetailLoadState {
 data class TaskDetailUiState(
     val loadState: DetailLoadState = DetailLoadState.Loading,
     val showCamera: Boolean = false,
-    val isAiEnabled: Boolean = false
+    val isAiEnabled: Boolean = false,
+    val fabMenuExpanded: Boolean = false,
+    val showAddTaskDialog: Boolean = false,
+    val newTaskText: String = "",
+    val showAddExpenseDialog: Boolean = false,
+    val newExpenseAmount: String = "",
+    val newExpenseDesc: String = "",
+    val showDeleteProjectConfirmation: Boolean = false
 )

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailViewModel.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -44,6 +45,18 @@ class TaskDetailViewModel @Inject constructor(
     // This makes the ViewModel reactive to navigation arguments and survives process death.
     private val _projectId = MutableStateFlow<Long?>(savedStateHandle.get<Long?>("projectId"))
 
+    private data class UiFlags(
+        val fabMenuExpanded: Boolean = false,
+        val showAddTaskDialog: Boolean = false,
+        val newTaskText: String = "",
+        val showAddExpenseDialog: Boolean = false,
+        val newExpenseAmount: String = "",
+        val newExpenseDesc: String = "",
+        val showDeleteProjectConfirmation: Boolean = false
+    )
+
+    private val _uiFlags = MutableStateFlow(UiFlags())
+
     fun loadTaskDetails(projectId: Long) {
         savedStateHandle["projectId"] = projectId
         _projectId.value = projectId
@@ -53,12 +66,20 @@ class TaskDetailViewModel @Inject constructor(
         _projectId.asStateFlow().filterNotNull().flatMapLatest { id ->
             photoDoRepo.getProjectDetails(id)
         },
-        appSettingsRepository.isAiEnabledFlow
-    ) { projectDetails, isAiEnabled ->
+        appSettingsRepository.isAiEnabledFlow,
+        _uiFlags
+    ) { projectDetails, isAiEnabled, flags ->
         if (projectDetails != null) {
             TaskDetailUiState(
                 loadState = DetailLoadState.Success(projectDetails),
-                isAiEnabled = isAiEnabled
+                isAiEnabled = isAiEnabled,
+                fabMenuExpanded = flags.fabMenuExpanded,
+                showAddTaskDialog = flags.showAddTaskDialog,
+                newTaskText = flags.newTaskText,
+                showAddExpenseDialog = flags.showAddExpenseDialog,
+                newExpenseAmount = flags.newExpenseAmount,
+                newExpenseDesc = flags.newExpenseDesc,
+                showDeleteProjectConfirmation = flags.showDeleteProjectConfirmation
             )
         } else {
             TaskDetailUiState(loadState = DetailLoadState.Error("Project has been deleted."))
@@ -198,6 +219,28 @@ class TaskDetailViewModel @Inject constructor(
 
             TaskDetailEvent.OnHelpClicked -> {
                 // Navigation handled in UI
+            }
+
+            is TaskDetailEvent.OnFabMenuToggle -> {
+                _uiFlags.update { it.copy(fabMenuExpanded = event.expanded) }
+            }
+            is TaskDetailEvent.OnShowAddTaskDialog -> {
+                _uiFlags.update { it.copy(showAddTaskDialog = event.show) }
+            }
+            is TaskDetailEvent.OnNewTaskTextChanged -> {
+                _uiFlags.update { it.copy(newTaskText = event.text) }
+            }
+            is TaskDetailEvent.OnShowAddExpenseDialog -> {
+                _uiFlags.update { it.copy(showAddExpenseDialog = event.show) }
+            }
+            is TaskDetailEvent.OnNewExpenseAmountChanged -> {
+                _uiFlags.update { it.copy(newExpenseAmount = event.amount) }
+            }
+            is TaskDetailEvent.OnNewExpenseDescChanged -> {
+                _uiFlags.update { it.copy(newExpenseDesc = event.desc) }
+            }
+            is TaskDetailEvent.OnShowDeleteProjectConfirmation -> {
+                _uiFlags.update { it.copy(showDeleteProjectConfirmation = event.show) }
             }
         }
     }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/state/TasksUiState.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/state/TasksUiState.kt
@@ -24,5 +24,8 @@ data class TasksUiState(
     // --- NEW: SMART DEFAULT FIELDS ---
     val categoryId: Long? = null,
     val categoryName: String = "Loading...",
-    val isNoCategoriesYet: Boolean = false
+    val isNoCategoriesYet: Boolean = false,
+    val fabMenuExpanded: Boolean = false,
+    val showDeleteConfirmation: Boolean = false,
+    val projectToDelete: ProjectListUiModel? = null
 )

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/AdaptivePhotoDoScreen.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/AdaptivePhotoDoScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
-import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -37,9 +36,7 @@ enum class PhotoDoFoldableState {
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 fun AdaptivePhotoDoScreen(
-    windowSizeClass: WindowSizeClass,
     navTo: (PhotoTodoRoute) -> Unit,
-    modifier: Modifier = Modifier,
     initialCategoryId: Long? = null,
     initialProjectId: Long? = null
 ) {
@@ -54,7 +51,6 @@ fun AdaptivePhotoDoScreen(
 
     val navigator = rememberListDetailPaneScaffoldNavigator<Any>()
     val scope = rememberCoroutineScope()
-    val paneContrast = LocalPaneContrast.current
 
     // --- VIEW MODELS & DATA FETCHING (Moved to top level for stability!) ---
     val homeViewModel = hiltViewModel<HomeViewModel>()
@@ -98,9 +94,6 @@ fun AdaptivePhotoDoScreen(
         directive = navigator.scaffoldDirective,
         value = navigator.scaffoldValue,
         listPane = {
-            val listBackground = if (paneContrast == "TINTED") MaterialTheme.colorScheme.surfaceContainerLow
-            else MaterialTheme.colorScheme.surface
-
             if (currentState == PhotoDoFoldableState.CATEGORY_AND_PROJECTS) {
                 // Left Pane: Categories
                 HomeOverviewScreen(
@@ -126,8 +119,7 @@ fun AdaptivePhotoDoScreen(
                             }
                             else -> route?.let(navTo)
                         }
-                    },
-                    modifier = Modifier.fillMaxSize().background(listBackground)
+                    }
                 )
             } else {
                 // Left Pane: Projects
@@ -148,14 +140,11 @@ fun AdaptivePhotoDoScreen(
                             }
                             else -> route.let(navTo)
                         }
-                    },
-                    modifier = Modifier.fillMaxSize().background(listBackground)
+                    }
                 )
             }
         },
         detailPane = {
-            val detailBackground = MaterialTheme.colorScheme.surface
-
             if (currentState == PhotoDoFoldableState.CATEGORY_AND_PROJECTS) {
                 // Right Pane: Projects
                 TasksListScreen(
@@ -176,8 +165,7 @@ fun AdaptivePhotoDoScreen(
                             }
                             else -> route.let(navTo)
                         }
-                    },
-                    modifier = Modifier.fillMaxSize().background(detailBackground)
+                    }
                 )
             } else {
                 // Right Pane: Tasks (Detail)
@@ -196,11 +184,10 @@ fun AdaptivePhotoDoScreen(
                         } else {
                             route.let(navTo)
                         }
-                    },
-                    modifier = Modifier.fillMaxSize().background(detailBackground)
+                    }
                 )
             }
         },
-        modifier = modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize()
     )
 }

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/PhotoDoMainScreen.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/PhotoDoMainScreen.kt
@@ -10,9 +10,6 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass.Companion.calculateFromSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -35,51 +32,36 @@ fun PhotoDoMainScreen(
         photoTodoNavEntryProvider(key, size, ai, to, back)
     }
 ) {
-    val isAiEnabled by viewModel.isAiEnabled.collectAsStateWithLifecycle()
-    var backStack by remember { mutableStateOf(listOf<PhotoTodoRoute>(PhotoTodoRoute.Home)) }
-    val currentRoute = backStack.lastOrNull() ?: PhotoTodoRoute.Home
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         bottomBar = {
             PhotoTodoBottomBar(
-                currentRoute = currentRoute,
+                currentRoute = uiState.currentRoute,
                 navTo = { selectedRoute ->
-                    if (currentRoute != selectedRoute) {
-                        // 🚀 ATOMIC UPDATE: Ensure backstack is never transiently empty
-                        backStack = if (selectedRoute == PhotoTodoRoute.Home) {
-                            listOf(PhotoTodoRoute.Home)
-                        } else {
-                            listOf(PhotoTodoRoute.Home, selectedRoute)
-                        }
-                    }
+                    viewModel.onEvent(PhotoDoMainEvent.OnNavigateTo(selectedRoute))
                 }
             )
         }
     ) { innerPadding ->
         NavDisplay(
-            backStack = backStack,
+            backStack = uiState.backStack,
             modifier = Modifier.padding(innerPadding),
             onBack = { 
-                if (backStack.size > 1) {
-                    backStack = backStack.dropLast(1)
-                }
+                viewModel.onEvent(PhotoDoMainEvent.OnNavigateBack)
             },
             entryProvider = { key ->
                 // ✅ DELEGATE: Call the provider function
                 entryProvider(
                     key,
                     windowSizeClass,
-                    isAiEnabled,
+                    uiState.isAiEnabled,
                     { 
-                        if (backStack.size > 1) {
-                            backStack = backStack.dropLast(1)
-                        }
+                        viewModel.onEvent(PhotoDoMainEvent.OnNavigateBack)
                     },
                     { dest ->
-                        if (dest != backStack.lastOrNull()) {
-                            backStack = backStack + dest
-                        }
+                        viewModel.onEvent(PhotoDoMainEvent.OnNavigateTo(dest))
                     }
                 )
             }

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/PhotoDoMainViewModel.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/PhotoDoMainViewModel.kt
@@ -3,10 +3,14 @@ package com.zoewave.probase.photodo.mobile.ui.components
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.applications.photodo.db.repo.AppSettingsRepository
+import com.zoewave.probase.photodo.model.navigation.PhotoTodoRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
@@ -14,10 +18,54 @@ class PhotoDoMainViewModel @Inject constructor(
     private val appSettingsRepository: AppSettingsRepository
 ) : ViewModel() {
 
-    val isAiEnabled: StateFlow<Boolean> = appSettingsRepository.isAiEnabledFlow
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = false
+    private val _backStack = MutableStateFlow<List<PhotoTodoRoute>>(
+        listOf(PhotoTodoRoute.Home)
+    )
+
+    val uiState: StateFlow<PhotoDoMainUiState> = combine(
+        appSettingsRepository.isAiEnabledFlow,
+        _backStack
+    ) { isAiEnabled, backStack ->
+        PhotoDoMainUiState(
+            isAiEnabled = isAiEnabled,
+            backStack = backStack,
+            currentRoute = backStack.lastOrNull() ?: PhotoTodoRoute.Home
         )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = PhotoDoMainUiState()
+    )
+
+    fun onEvent(event: PhotoDoMainEvent) {
+        when (event) {
+            is PhotoDoMainEvent.OnNavigateTo -> {
+                _backStack.update { currentStack ->
+                    if (event.route == PhotoTodoRoute.Home) {
+                        listOf(PhotoTodoRoute.Home)
+                    } else if (event.route != currentStack.lastOrNull()) {
+                        currentStack + event.route
+                    } else {
+                        currentStack
+                    }
+                }
+            }
+            PhotoDoMainEvent.OnNavigateBack -> {
+                _backStack.update { currentStack ->
+                    if (currentStack.size > 1) currentStack.dropLast(1) else currentStack
+                }
+            }
+        }
+    }
+}
+
+data class PhotoDoMainUiState(
+    val isAiEnabled: Boolean = false,
+    val backStack: List<PhotoTodoRoute> = listOf(PhotoTodoRoute.Home),
+    val currentRoute: PhotoTodoRoute = PhotoTodoRoute.Home
+)
+
+sealed interface PhotoDoMainEvent {
+    data class OnNavigateTo(val route: PhotoTodoRoute) : PhotoDoMainEvent
+    data object OnNavigateBack : PhotoDoMainEvent
 }

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/navigation/photoTodoNavEntryProvider.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/navigation/photoTodoNavEntryProvider.kt
@@ -19,8 +19,10 @@ import com.zoewave.probase.photodo.features.camera.ui.components.SavePhotoBottom
 import com.zoewave.probase.photodo.features.smartadvice.ui.SmartAdviceUiRoute
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.HomeOverviewScreen
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.AdaptiveHomeScreen
+import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.HomeScreen
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.HomeViewModel
 import com.zoewave.probase.photodo.mobile.features.settings.ui.SettingsUiRoute
+import com.zoewave.probase.photodo.mobile.features.settings.ui.SettingsViewModel
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.TasksSideEffect
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.TasksViewModel
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.components.TasksListScreen
@@ -46,28 +48,33 @@ fun photoTodoNavEntryProvider(
         when (key) {
 
             // --- TAB 1: DASHBOARD ---
-            // ... inside your when(key) block:
-
             is PhotoTodoRoute.Home -> {
                 val viewModel: HomeViewModel = hiltViewModel()
                 val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-                AdaptiveHomeScreen(
-                    uiState = uiState,
-                    onEvent = viewModel::onEvent,
-                    navTo = { route ->
-                        if (route == null) navigateBack() else navigateTo(route)
-                    },
-                    windowSizeClass = windowSizeClass,
-                    modifier = Modifier.fillMaxSize()
-                )
+                
+                if (isExpanded) {
+                    AdaptiveHomeScreen(
+                        uiState = uiState,
+                        onEvent = viewModel::onEvent,
+                        navTo = { route ->
+                            if (route == null) navigateBack() else navigateTo(route)
+                        }
+                    )
+                } else {
+                    HomeScreen(
+                        uiState = uiState,
+                        onEvent = viewModel::onEvent,
+                        navTo = { route ->
+                            if (route == null) navigateBack() else navigateTo(route)
+                        }
+                    )
+                }
             }
 
             is PhotoTodoRoute.CategoryGrid -> {
                 if (isExpanded) {
                     AdaptivePhotoDoScreen(
-                        windowSizeClass = windowSizeClass,
-                        navTo = navigateTo,
-                        modifier = Modifier.fillMaxSize()
+                        navTo = navigateTo
                     )
                 } else {
                     val viewModel: HomeViewModel = hiltViewModel()
@@ -77,8 +84,7 @@ fun photoTodoNavEntryProvider(
                         onEvent = viewModel::onEvent,
                         navTo = { route ->
                             if (route == null) navigateBack() else navigateTo(route)
-                        },
-                        modifier = Modifier.fillMaxSize()
+                        }
                     )
                 }
             }
@@ -87,10 +93,8 @@ fun photoTodoNavEntryProvider(
             is TasksList -> {
                 if (isExpanded) {
                     AdaptivePhotoDoScreen(
-                        windowSizeClass = windowSizeClass,
                         navTo = navigateTo,
-                        initialCategoryId = key.categoryId,
-                        modifier = Modifier.fillMaxSize()
+                        initialCategoryId = key.categoryId
                     )
                 } else {
                     val viewModel: TasksViewModel = hiltViewModel()
@@ -125,8 +129,7 @@ fun photoTodoNavEntryProvider(
                         onEvent = viewModel::onEvent,
                         navTo = { route ->
                             if (route == null) navigateBack() else navigateTo(route)
-                        },
-                        modifier = Modifier.fillMaxSize()
+                        }
                     )
                 }
             }
@@ -135,10 +138,8 @@ fun photoTodoNavEntryProvider(
             is TaskDetail -> {
                 if (isExpanded) {
                     AdaptivePhotoDoScreen(
-                        windowSizeClass = windowSizeClass,
                         navTo = navigateTo,
-                        initialProjectId = key.projectId,
-                        modifier = Modifier.fillMaxSize()
+                        initialProjectId = key.projectId
                     )
                 } else {
                     val viewModel: TaskDetailViewModel = hiltViewModel()
@@ -166,13 +167,10 @@ fun photoTodoNavEntryProvider(
                         onEvent = viewModel::onEvent,
                         navTo = { route ->
                             if (route == null) navigateBack() else navigateTo(route)
-                        },
-                        modifier = Modifier.fillMaxSize()
+                        }
                     )
                 }
             }
-
-
 
             is PhotoTodoRoute.Camera -> {
                 // Grab our stateless Action Handler
@@ -232,14 +230,13 @@ fun photoTodoNavEntryProvider(
                 val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
                 // 🚀 NEW: Automatic navigation back to Home dashboard after success
-                if (uiState.isSaved) {
-                    val savedProjectId = uiState.savedProjectId
-                    val savedProjectTitle = uiState.savedProjectTitle
-                    LaunchedEffect(Unit) {
-                        if (savedProjectId != null && savedProjectTitle != null) {
-                            // First go back to pop SavePhoto, then navigate to TaskDetail
+                LaunchedEffect(uiState.isSaved) {
+                    if (uiState.isSaved) {
+                        val id = uiState.savedProjectId
+                        val title = uiState.savedProjectTitle
+                        if (id != null && title != null) {
                             navigateBack()
-                            navigateTo(PhotoTodoRoute.TaskDetail(savedProjectId, savedProjectTitle))
+                            navigateTo(PhotoTodoRoute.TaskDetail(id, title))
                         } else {
                             navigateBack()
                         }
@@ -276,12 +273,16 @@ fun photoTodoNavEntryProvider(
 
             // --- TAB 3: SETTINGS ---
             is Settings -> {
+                val viewModel: SettingsViewModel = hiltViewModel()
+                LaunchedEffect(key.title) {
+                    viewModel.setInitialExpandedKey(key.title)
+                }
+
                 SettingsUiRoute(
-                    modifier = Modifier.fillMaxSize(),
-                    initialCardKeyToExpand = key.title,
                     navTo = { route ->
                         if (route == null) navigateBack() else navigateTo(route)
                     },
+                    viewModel = viewModel
                 )
             }
 
@@ -299,8 +300,9 @@ fun photoTodoNavEntryProvider(
                 TasksListScreen(
                     uiState = uiState,
                     onEvent = viewModel::onEvent,
-                    navTo = { if (it == null) navigateBack() else navigateTo(it) },
-                    modifier = Modifier.fillMaxSize()
+                    navTo = { route ->
+                        if (route == null) navigateBack() else navigateTo(route)
+                    }
                 )
             }
         }

--- a/applications/photodo/docs/GenAI/ReFactor/implementation_plan.md
+++ b/applications/photodo/docs/GenAI/ReFactor/implementation_plan.md
@@ -1,0 +1,55 @@
+# Refactor Photodo Mobile Composables to MAD "Gold Standard"
+
+Refactor all top-level screen composables in `applications/photodo/apps/mobile` to strictly adhere to Modern Android Development (MAD) best practices. This ensures scalability, testability, and a clean separation of concerns.
+
+## User Review Required
+
+> [!IMPORTANT]
+> This refactor strictly enforces the `(UiState, onEvent, navTo)` pattern for all top-level composables. Any existing logic (like side-effect handling or complex navigation logic) will be hoisted to the `NavEntry` level or encapsulated within `onEvent`.
+
+## Proposed Changes
+
+### Screens to Refactor
+
+| Screen | File Path | Status |
+| :--- | :--- | :--- |
+| **Home** | `features/home/.../HomeScreen.kt` | To be updated |
+| **Adaptive Home** | `features/home/.../AdaptiveHomeScreen.kt` | To be updated |
+| **Home Overview** | `features/home/.../HomeOverviewScreen.kt` | To be updated |
+| **Tasks List** | `features/tasks/.../TasksListScreen.kt` | To be updated |
+| **Task Detail** | `features/tasks/.../TaskDetailScreen.kt` | To be updated |
+| **Settings** | `features/settings/.../SettingsScreen.kt` | To be updated |
+
+---
+
+### Refactoring Pattern
+
+For each screen, I will:
+1.  **Standardize Signature**: Ensure the composable takes exactly `uiState`, `onEvent: (Event) -> Unit`, and `navTo: (PhotoTodoRoute?) -> Unit`.
+2.  **Hoist Side Effects**: Move `LaunchedEffect` and complex navigation logic (e.g., handling ViewModel effects) to the `NavEntry` provider.
+3.  **Encapsulate State**: Ensure all UI-only state (e.g., dialog visibility) is managed cleanly within the composable or passed via the `UiState`.
+4.  **Simplify Navigation**: Use the `navTo` callback for all external navigation, passing `null` to indicate "navigate back".
+
+### Example: TaskDetailScreen
+
+#### [TaskDetailScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailScreen.kt)
+
+- Update `TaskDetailScreen` signature.
+- Remove redundant navigation logic and hoist to `NavEntry`.
+- Ensure all interactions dispatch `TaskDetailEvent`.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+- Run `gradle_build("app:assembleDebug")` to ensure compilation success.
+- Verify that Hilt DI is unaffected by the refactor.
+
+### Manual Verification
+- Deploy the app and walk through all screens:
+    - Home -> Category -> Task Detail.
+    - Settings updates.
+    - Camera flow and Smart Capture.
+- Verify that "back" navigation works correctly on all screens.
+- Ensure all dialogs (Add Task, Add Expense, Delete) still function perfectly.

--- a/applications/photodo/docs/GenAI/ReFactor/walkthrough.md
+++ b/applications/photodo/docs/GenAI/ReFactor/walkthrough.md
@@ -1,0 +1,89 @@
+# Smart Capture Improvements: ML Logs, Retake Navigation, and Privacy Enforcement
+
+I have updated the Smart Capture feature to provide more transparency during AI analysis, fixed the "Retake" button navigation, and strictly enforced user privacy by removing gallery access.
+
+## Key Changes
+
+### 1. ML Logs during AI Processing
+The AI engines now provide real-time feedback during the multimodal extraction and OCR processes.
+- **[CloudCaptureEngineImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/CloudCaptureEngineImpl.kt)**: Added logs for prompt preparation, request sending, and response parsing for the Gemini API.
+- **[LocalCaptureEngineImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/LocalCaptureEngineImpl.kt)**: Added logs for ML Kit OCR initialization and regex extraction steps.
+- **[SmartCaptureScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt)**: Increased the number of visible logs in the loading indicator from 3 to 5 for better visibility.
+
+### 2. Privacy Enforcement: No Gallery Access
+In accordance with the privacy requirement that the app never touches the user's personal data (camera roll):
+- **[SmartCaptureScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt)**: Removed all "Upload Photo" functionality, including the image picker and the upload button in the empty state.
+
+### 3. Fixed Retake Button Navigation
+The "Retake" button now correctly routes the user back to the camera flow.
+- **[SmartCaptureUiRoute](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt)**: Added an `onRetakeRequest` callback.
+- **[photoTodoNavEntryProvider.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/navigation/photoTodoNavEntryProvider.kt)**: Implemented the callback to pop the current screen and navigate directly to the camera.
+
+### 4. Cloud Fallback Diagnostics UI
+Added transparency when the cloud analysis falls back to local AI due to errors or missing configuration.
+- **[SmartCaptureScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt)**: Integrated an `IconButton` with a diagnostic icon directly into the "Cloud analysis unavailable" warning banner.
+- **[DiagnosticsDialog](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt)**: Added a dialog that displays the underlying logs and errors (e.g., "Orchestrator: Cloud failed...", "Tier 1: Cloud AI requested...") in a scrollable list when the icon is clicked.
+
+### 6. Text-Only AI Task Extraction
+Added the ability to generate tasks using Cloud AI from simple text commands, even without an image.
+- **[SmartCaptureScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureScreen.kt)**: Updated the `EmptyState` to include a task command input field and an "Analyze Text" button.
+- **[CloudCaptureEngineImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/CloudCaptureEngineImpl.kt)**: Implemented text-only prompt processing when no image is provided, correctly generating structured task drafts from user commands like "clean the car".
+- **[SmartCaptureOrchestrator.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/SmartCaptureOrchestrator.kt)**: Updated to allow text-only extraction when Cloud AI is enabled, providing a clear error message if attempted without a valid Cloud setup.
+
+### 7. Direct Access to AI Input
+Added a new entry point to navigate directly to the text-only AI input flow without taking a photo.
+- **[PhotoTodoRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/model/src/main/java/com/zoewave/probase/photodo/model/navigation/PhotoTodoRoute.kt)**: Updated `SmartCapture` route to make the photo URI optional, allowing for direct navigation.
+- **[HomeOverviewScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt)**: Integrated an **"AI Task"** button into the dashboard's Floating Action Button (FAB) menu, providing instant access to the text-only task extraction feature. The icon is tinted **Gold** (`#FFD700`) for visual distinction and **automatically hides** if Cloud AI is disabled in settings.
+
+### 8. Global Task Search in "Jump Back In" Section
+Relocated and implemented a powerful global search feature directly within the "Jump Back In" section of the Dashboard.
+- **[TaskSearchBar](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeSearchComponents.kt)**: A clean, modular search component positioned at the start of the task listing section.
+- **[TaskSearchResultsList](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeSearchComponents.kt)**: Replaces the urgent/favorite list when searching, displaying results grouped by project. Clicking on any task result navigates the user directly to the project detail screen.
+- **[HomeViewModel](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt)**: Reactive search logic that automatically filters tasks as the user types (2+ characters), providing an instant, contextual search experience.
+
+### 10. Independent Task and Category Search
+Decoupled the search queries for tasks and categories, allowing users to search for each independently without affecting the other.
+- **[HomeUiState](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt)**: Split the single `searchQuery` into `categorySearchQuery` and `taskSearchQuery`.
+- **[HomeEvent](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt)**: Added separate events `OnCategorySearchQueryChanged` and `OnTaskSearchQueryChanged`.
+- **[HomeViewModel](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt)**: Updated the reactive logic to independently handle and filter both task and category searches.
+- **[UI Variants](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt)**: Updated all home screen variants to use their respective search queries and handlers, ensuring a smooth and intuitive user experience.
+
+### 9. Collapsible Category Summary Section
+Made the "Total PhotoDo Categories" section collapsible to allow more vertical space for tasks when needed.
+- **[OverviewSummaryCard](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/OverviewSummaryCard.kt)**: Updated with a clickable header and an expand/collapse icon. The donut chart and detailed legend are now wrapped in an `AnimatedVisibility` block.
+- **[HomeUiState](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt)**: Added `isCategoriesSummaryExpanded` to track the toggle state.
+- **[HomeViewModel](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt)**: Implemented `OnToggleCategoriesSummary` event handling to update the expansion state reactively.
+- **[Adaptive/Compact Layouts](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeScreen.kt)**: Ensured consistent search behavior and UI placement across all device sizes and screen modes.
+
+### 11. Refactor to MAD Best Practices ("Gold Standard")
+Refactored all Photodo mobile top-level screen composables to strictly follow Modern Android Development best practices.
+- **Strict Signature**: Every screen now only takes exactly `(uiState, onEvent, navTo)`. This simplifies testing and separates UI from logic.
+- **Hoisted Side Effects**: Moved all `LaunchedEffect` and complex navigation decisions (e.g., auto-navigation on save, data loading on entry) from the screens to the `NavEntry` provider level.
+- **Standardized Navigation**: Unified all external navigation through a single `navTo` callback, improving predictability and code readability.
+- **Centralized UI State**: Moved UI-specific state (like dialog visibility and FAB expansion) into the respective ViewModels and `UiState` data classes, making the entire screen state observable and reproducible.
+
+### 8. Conditional Smart Advice Icon
+Ensured the Smart Advice icon (Question Mark) only appears when relevant and enabled.
+- **[TaskDetailScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailScreen.kt)**: Updated the top bar actions to conditionally show the AI help icon. It now only appears if:
+    1.  **AI features are enabled** in settings.
+    2.  The project has **at least one task or photo** to provide context to the AI.
+- **[TaskDetailViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailViewModel.kt)**: Updated to reactively track the AI enabled state from the settings repository and expose it to the UI.
+
+### 5. Fixed AI Model Synchronization and Log Preservation
+Ensured the correct AI model from settings is always used and preserved detailed logs for failed attempts.
+- **[SmartCaptureViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/ui/SmartCaptureViewModel.kt)**: Updated to fetch the latest model preference from the settings repository right before starting any image analysis.
+- **[SmartCaptureOrchestrator.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/SmartCaptureOrchestrator.kt)**: Updated to preserve and merge logs from the Cloud AI engine even when it fails, ensuring the model used and specific error messages are visible in the diagnostics.
+- **[CloudCaptureEngineImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/ai/capture/src/main/java/com/zoewave/probase/features/ai/capture/data/CloudCaptureEngineImpl.kt)**: Updated model discovery to keep the `models/` prefix for better SDK compatibility and improved error handling to return logs instead of throwing exceptions.
+
+> [!NOTE]
+> The issues with Gemini API key validation were identified as device-specific and have been rolled back to maintain the original codebase state for AI configuration.
+
+## Verification Summary
+
+### Build Verification
+- Successfully ran `gradle_build("app:assembleDebug")` to ensure the project remains stable after cleaning up the rollback state.
+
+### Manual Verification Steps (Performed via Code Analysis)
+- Verified that `SmartCaptureViewModel` uses `_uiState.update { ... }` to thread-safely append logs as they arrive from the orchestrator.
+- Verified that all call sites of `SmartCaptureUiRoute` were updated to handle the new callback.
+- Verified that `EmptyState` in `SmartCaptureScreen` no longer accepts or displays an upload button.


### PR DESCRIPTION
refactor(tasks): hoist UI component state to ViewModels

This commit moves ephemeral UI state—such as FAB menu expansion and dialog visibility—from local Composable `remember` variables into the `TasksViewModel` and `TaskDetailViewModel`. This centralization improves state consistency across configuration changes and aligns with the Unidirectional Data Flow (UDF) pattern.

- **`TasksViewModel.kt` & `TasksUiState.kt`**:
    - Added state properties for `fabMenuExpanded`, `showDeleteConfirmation`, and `projectToDelete`.
    - Implemented event handlers for toggling FAB menus and managing project/category deletion flows.
- **`TaskDetailViewModel.kt` & `TaskDetailUiState.kt`**:
    - Introduced a private `UiFlags` data class to manage visibility for the add task dialog, expense dialog, and project deletion confirmation.
    - Added state properties to track temporary input for new tasks and expenses.
- **`TasksListScreen.kt` & `TaskDetailScreen.kt`**:
    - Refactored UI components to use hoisted state from the `uiState` objects.
    - Updated `BackHandler` logic to prioritize closing expanded FAB menus before navigating back.
    - Standardized dialog management to trigger events via the provided `onEvent` lambdas.
- **`TasksEvent.kt` & `TaskDetailEvent.kt`**:
    - Defined new event interfaces for toggling UI states and updating transient text fields for tasks and expenses.