### PR TITLE
Photodo name

### DIFF
--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailViewModel.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailViewModel.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -64,11 +63,13 @@ class TaskDetailViewModel @Inject constructor(
 
     val uiState: StateFlow<TaskDetailUiState> = combine(
         _projectId.asStateFlow().filterNotNull().flatMapLatest { id ->
+            Log.d("ProjectDebug", "TaskDetailViewModel: Fetching details for Project ID: $id")
             photoDoRepo.getProjectDetails(id)
         },
         appSettingsRepository.isAiEnabledFlow,
         _uiFlags
     ) { projectDetails, isAiEnabled, flags ->
+        Log.d("ProjectDebug", "TaskDetailViewModel: Received details? ${projectDetails != null}")
         if (projectDetails != null) {
             TaskDetailUiState(
                 loadState = DetailLoadState.Success(projectDetails),
@@ -82,6 +83,7 @@ class TaskDetailViewModel @Inject constructor(
                 showDeleteProjectConfirmation = flags.showDeleteProjectConfirmation
             )
         } else {
+            Log.w("ProjectDebug", "TaskDetailViewModel: Project NOT FOUND in DB!")
             TaskDetailUiState(loadState = DetailLoadState.Error("Project has been deleted."))
         }
     }
@@ -155,6 +157,17 @@ class TaskDetailViewModel @Inject constructor(
             }
             is TaskDetailEvent.OnEditList -> {
                 // TODO: Update project title/description
+                /*viewModelScope.launch {
+                    val currentState = uiState.value.loadState
+                    if (currentState is DetailLoadState.Success) {
+                        photoDoRepo.updateProject(
+                            currentState.projectDetails.project.copy(
+                                title = event.title,
+                                description = event.description
+                            )
+                        )
+                    }
+                }*/
             }
 
             // --- UI TOGGLES ---

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/AdaptivePhotoDoScreen.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/AdaptivePhotoDoScreen.kt
@@ -1,5 +1,6 @@
 package com.zoewave.probase.photodo.mobile.ui.components
 
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
@@ -59,10 +60,16 @@ fun AdaptivePhotoDoScreen(
 
     // Sync categories and projects viewmodels with our top-level remembered state
     LaunchedEffect(selectedCategoryId) {
-        selectedCategoryId?.let { tasksViewModel.setCategoryId(it) }
+        selectedCategoryId?.let { 
+            Log.d("ProjectDebug", "AdaptivePhotoDoScreen: Syncing Category ID: $it")
+            tasksViewModel.setCategoryId(it) 
+        }
     }
     LaunchedEffect(selectedProjectId) {
-        selectedProjectId?.let { detailViewModel.loadTaskDetails(it) }
+        selectedProjectId?.let { 
+            Log.d("ProjectDebug", "AdaptivePhotoDoScreen: Syncing Project ID: $it")
+            detailViewModel.loadTaskDetails(it) 
+        }
     }
 
     // 🚀 NEW: Ensure we navigate to the Detail pane if starting with a project ID

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/navigation/photoTodoNavEntryProvider.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/navigation/photoTodoNavEntryProvider.kt
@@ -225,15 +225,18 @@ fun photoTodoNavEntryProvider(
                 val context = LocalContext.current
                 
                 LaunchedEffect(key.photoUri, key.prefilledAiDraft) {
+                    Log.d("SavePhotoDebug", "NavEntry: Calling setInitialData for uri: ${key.photoUri}")
                     viewModel.setInitialData(key.photoUri, key.prefilledAiDraft)
                 }
                 val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
                 // 🚀 NEW: Automatic navigation back to Home dashboard after success
                 LaunchedEffect(uiState.isSaved) {
+                    Log.d("SavePhotoDebug", "NavEntry: uiState.isSaved changed to: ${uiState.isSaved}")
                     if (uiState.isSaved) {
                         val id = uiState.savedProjectId
                         val title = uiState.savedProjectTitle
+                        Log.d("SavePhotoDebug", "NavEntry: Auto-navigating to Detail for ID: $id")
                         if (id != null && title != null) {
                             navigateBack()
                             navigateTo(PhotoTodoRoute.TaskDetail(id, title))

--- a/applications/photodo/data/src/main/java/com/zoewave/probase/photodo/data/PhotoDoSyncEngine.kt
+++ b/applications/photodo/data/src/main/java/com/zoewave/probase/photodo/data/PhotoDoSyncEngine.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Log
+import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 import com.zoewave.probase.applications.photodo.db.entity.ProjectDetails
@@ -41,8 +42,10 @@ class PhotoDoSyncEngine @Inject constructor(
 
     private val dataClient = Wearable.getDataClient(context)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var isWearableApiAvailable = true
 
     fun startSyncing() {
+        if (!isWearableApiAvailable) return
         scope.launch {
             Log.d(TAG, "Starting sync observer...")
             // Combine categories/projects/tasks with project details (for photo counts)
@@ -62,6 +65,7 @@ class PhotoDoSyncEngine @Inject constructor(
      * Useful for responding to "request sync" pings from the watch.
      */
     fun triggerSync() {
+        if (!isWearableApiAvailable) return
         scope.launch {
             try {
                 Log.d(TAG, "Manual sync trigger received. Performing one-shot broadcast.")
@@ -76,6 +80,7 @@ class PhotoDoSyncEngine @Inject constructor(
     }
 
     private suspend fun broadcast(syncData: List<SyncCategory>) = withContext(Dispatchers.IO) {
+        if (!isWearableApiAvailable) return@withContext
         try {
             val jsonPayload = Json.encodeToString(syncData)
 
@@ -140,6 +145,13 @@ class PhotoDoSyncEngine @Inject constructor(
 
             dataClient.putDataItem(request).await()
             Log.d(TAG, "Successfully broadcasted sync state (${syncData.size} categories)")
+        } catch (e: ApiException) {
+            if (e.statusCode == 17) { // API_UNAVAILABLE
+                Log.w(TAG, "Wearable API is not available on this device. Sync disabled.")
+                isWearableApiAvailable = false
+            } else {
+                Log.e(TAG, "Failed to broadcast sync state (API Error: ${e.statusCode})", e)
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to broadcast sync state", e)
         }

--- a/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/PhotoDoDao.kt
+++ b/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/PhotoDoDao.kt
@@ -105,6 +105,9 @@ interface PhotoDoDao {
     @Query("SELECT * FROM projects WHERE projectId = :projectId")
     fun getProjectById(projectId: Long): Flow<ProjectEntity?>
 
+    @Query("SELECT * FROM projects WHERE categoryId = :categoryId AND name = :name LIMIT 1")
+    suspend fun getProjectByNameAndCategory(categoryId: Long, name: String): ProjectEntity?
+
     @Query("SELECT * FROM projects ORDER BY creationDate DESC")
     fun getAllProjects(): Flow<List<ProjectEntity>>
 

--- a/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/repo/PhotoDoRepo.kt
+++ b/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/repo/PhotoDoRepo.kt
@@ -32,6 +32,7 @@ interface PhotoDoRepo {
     suspend fun deleteProject(project: ProjectEntity)
     suspend fun deleteProjectById(projectId: Long)
     fun getProjectById(projectId: Long): Flow<ProjectEntity?>
+    suspend fun getProjectByNameAndCategory(categoryId: Long, name: String): ProjectEntity?
     fun getAllProjects(): Flow<List<ProjectEntity>>
     fun getProjectsForCategory(categoryId: Long): Flow<List<ProjectEntity>>
     suspend fun updateProject(project: ProjectEntity)

--- a/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/repo/PhotoDoRepoImpl.kt
+++ b/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/repo/PhotoDoRepoImpl.kt
@@ -84,6 +84,10 @@ class PhotoDoRepoImpl @Inject constructor(
         return photoDoDao.getProjectById(projectId)
     }
 
+    override suspend fun getProjectByNameAndCategory(categoryId: Long, name: String): ProjectEntity? {
+        return photoDoDao.getProjectByNameAndCategory(categoryId, name)
+    }
+
     override fun getAllProjects(): Flow<List<ProjectEntity>> {
         return photoDoDao.getAllProjects()
     }

--- a/applications/photodo/docs/GenAI/BugFixes/implementation_plan_CatName_Project_Name.md
+++ b/applications/photodo/docs/GenAI/BugFixes/implementation_plan_CatName_Project_Name.md
@@ -1,0 +1,42 @@
+# Add Dropdown Selection for Category and Project in Save Photo
+
+The goal is to improve the user experience when saving a project by providing dropdown menus for "Category Name" and "Project Name". This allows users to easily reuse existing categories and projects while still supporting AI-provided values, quick-set icons, and manual typing.
+
+## User Review Required
+
+> [!NOTE]
+> The dropdowns will be implemented using `ExposedDropdownMenuBox` which supports both manual text entry (editable) and selection from a list.
+
+## Proposed Changes
+
+### PhotoDo Camera Feature (`features/camera`)
+
+---
+
+#### [SavePhotoViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt)
+
+- Update the `uiState` combination logic to include `repo.getAllProjects()`.
+- Map the resulting projects list into the `SavePhotoUiState`.
+
+#### [SavePhotoBottomSheet.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/components/SavePhotoBottomSheet.kt)
+
+- **Category Selection**: Refine the `ExposedDropdownMenuBox` to ensure it correctly handles manual typing and AI-generated state.
+- **Project Selection**: Wrap the "Project Name" `AiEnhancedTextField` in an `ExposedDropdownMenuBox`.
+- Populate both dropdowns with unique names from `uiState.categories` and `uiState.projects` respectively.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+- Run `gradle_build("app:assembleDebug")` to ensure compilation success.
+
+### Manual Verification
+- Perform a Smart Capture analysis or type a task command.
+- On the save screen:
+    - Verify that clicking the "Category Name" field shows a dropdown of existing categories.
+    - Verify that selecting a category from the dropdown updates the field.
+    - Verify that clicking the "Project Name" field shows a dropdown of existing projects.
+    - Verify that selecting a project from the dropdown updates the field.
+    - Verify that manual typing still works for both fields.
+    - Verify that quick-set icons still work for both fields.

--- a/applications/photodo/docs/GenAI/Project/implementation_add_project.md
+++ b/applications/photodo/docs/GenAI/Project/implementation_add_project.md
@@ -1,0 +1,42 @@
+# Refine Project Merging Logic in Save Photo
+
+Refine the project saving logic to properly merge new information when an existing project name and category are selected.
+
+## User Review Required
+
+> [!IMPORTANT]
+> When an existing project is found:
+> 1.  **Budgets are summed**: The existing budget and the new input budget will be added together.
+> 2.  **Due Date update**: If the new input has a due date, it will overwrite the existing one.
+> 3.  **Data Merging**: New tasks and photos will be added to the existing project ID.
+
+## Proposed Changes
+
+### PhotoDo Camera Feature (`features/camera`)
+
+---
+
+#### [SavePhotoViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt)
+
+- Update `saveTask` logic:
+    - If `existingProject` is found:
+        - Calculate `newTotalBudget = existingProject.projectBudget + currentInputBudget`.
+        - Determine `finalDueDate = currentInputDueDate ?: existingProject.dueDate`.
+        - Update the `existingProject` entity with the new budget and due date.
+        - Call `repo.updateProject(updatedProject)`.
+        - Use `existingProject.projectId` for subsequent task and photo attachments.
+    - Otherwise, create a new project as before.
+
+## Verification Plan
+
+### Automated Tests
+- Run `gradle_build("app:assembleDebug")` to ensure compilation success.
+
+### Manual Verification
+1.  **Merge Check**:
+    - Select an existing category and project.
+    - Add a new budget amount and a different due date.
+    - Save and view the project.
+    - Verify that the budget is the sum of old + new.
+    - Verify that the due date matches the new input.
+    - Verify that new tasks and photos are added to the existing list.

--- a/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
+++ b/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
@@ -198,16 +198,24 @@ class SavePhotoViewModel @Inject constructor(
             val finalCategory = _categoryName.value.ifBlank { "Uncategorized" }
             val categoryId = repo.getOrCreateCategoryByName(finalCategory)
 
-            // 2. Create Project
+            // 2. Check for Existing Project in this Category
             val finalProjectName = _projectName.value.ifBlank { _taskName.value.ifBlank { "New Project" } }
-            val newProject = ProjectEntity(
-                categoryId = categoryId,
-                name = finalProjectName,
-                projectBudget = _budgetInput.value.toDoubleOrNull() ?: 0.0,
-                dueDate = _dueDateMillis.value,
-                notes = if (_duration.value.isNotBlank()) "Duration: ${_duration.value}" else null
-            )
-            val projectId = repo.upsertProject(newProject)
+            val existingProject = repo.getProjectByNameAndCategory(categoryId, finalProjectName)
+
+            val projectId = if (existingProject != null) {
+                // Reuse existing project ID
+                existingProject.projectId
+            } else {
+                // Create new Project
+                val newProject = ProjectEntity(
+                    categoryId = categoryId,
+                    name = finalProjectName,
+                    projectBudget = _budgetInput.value.toDoubleOrNull() ?: 0.0,
+                    dueDate = _dueDateMillis.value,
+                    notes = if (_duration.value.isNotBlank()) "Duration: ${_duration.value}" else null
+                )
+                repo.upsertProject(newProject)
+            }
 
             // 3. Create Main Task (if name provided)
             if (_taskName.value.isNotBlank()) {

--- a/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
+++ b/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
@@ -64,10 +64,26 @@ class SavePhotoViewModel @Inject constructor(
         _savedProjectId,
         _savedProjectTitle
     ) { args: Array<Any?> ->
+        val categories = args[10] as List<CategoryEntity>
+        val allProjects = args[11] as List<ProjectEntity>
+        val currentCategoryName = args[2] as String
+
+        // 🚀 NEW: Filter projects by the currently selected category name
+        val filteredProjects = if (currentCategoryName.isNotBlank()) {
+            val matchedCategoryId = categories.find { it.name.equals(currentCategoryName, ignoreCase = true) }?.categoryId
+            if (matchedCategoryId != null) {
+                allProjects.filter { it.categoryId == matchedCategoryId }
+            } else {
+                emptyList()
+            }
+        } else {
+            emptyList()
+        }
+
         SavePhotoUiState(
             photoUri = args[0] as String,
             isFromAi = args[1] as Boolean,
-            categoryName = args[2] as String,
+            categoryName = currentCategoryName,
             projectName = args[3] as String,
             taskName = args[4] as String,
             duration = args[5] as String,
@@ -75,8 +91,8 @@ class SavePhotoViewModel @Inject constructor(
             dueDateMillis = args[7] as Long?,
             subTasks = args[8] as List<String>,
             aiGeneratedFields = args[9] as Set<String>,
-            categories = args[10] as List<CategoryEntity>,
-            projects = args[11] as List<ProjectEntity>, // 🚀 NEW: Map projects
+            categories = categories,
+            projects = filteredProjects, // 🚀 NEW: Use filtered list
             isSaving = args[12] as Boolean,
             isSaved = args[13] as Boolean,
             savedProjectId = args[14] as Long?,

--- a/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
+++ b/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
@@ -106,9 +106,14 @@ class SavePhotoViewModel @Inject constructor(
     )
 
     fun setInitialData(uri: String?, draft: SmartTaskDraft? = null) {
-        if (_photoUri.value == uri && draft == null) return
+        Log.d("SavePhotoDebug", "ViewModel: setInitialData called. Current isSaved: ${_isSaved.value}")
+        if (_photoUri.value == uri && draft == null) {
+            Log.d("SavePhotoDebug", "ViewModel: setInitialData ignored (same URI and no draft)")
+            return
+        }
         
         // 🚀 CRITICAL: Reset the status flags so we don't skip the form if the ViewModel is reused.
+        Log.d("SavePhotoDebug", "ViewModel: Resetting status flags to false")
         _isSaving.value = false
         _isSaved.value = false
         _savedProjectId.value = null
@@ -209,15 +214,26 @@ class SavePhotoViewModel @Inject constructor(
             val finalProjectName = _projectName.value.ifBlank { _taskName.value.ifBlank { "New Project" } }
             val existingProject = repo.getProjectByNameAndCategory(categoryId, finalProjectName)
 
+            val inputBudget = _budgetInput.value.toDoubleOrNull() ?: 0.0
             val projectId = if (existingProject != null) {
-                Log.d("ProjectDebug", "Reusing existing project: ${existingProject.name} (ID: ${existingProject.projectId})")
+                Log.d("ProjectDebug", "Merging into existing project: ${existingProject.name} (ID: ${existingProject.projectId})")
+                
+                // 🚀 MERGE LOGIC:
+                // 1. Add budgets together
+                // 2. Use new due date if provided
+                val updatedProject = existingProject.copy(
+                    projectBudget = existingProject.projectBudget + inputBudget,
+                    dueDate = _dueDateMillis.value ?: existingProject.dueDate,
+                    lastModified = System.currentTimeMillis()
+                )
+                repo.updateProject(updatedProject)
                 existingProject.projectId
             } else {
                 Log.d("ProjectDebug", "Creating new project: $finalProjectName in Category ID: $categoryId")
                 val newProject = ProjectEntity(
                     categoryId = categoryId,
                     name = finalProjectName,
-                    projectBudget = _budgetInput.value.toDoubleOrNull() ?: 0.0,
+                    projectBudget = inputBudget,
                     dueDate = _dueDateMillis.value,
                     notes = if (_duration.value.isNotBlank()) "Duration: ${_duration.value}" else null
                 )
@@ -245,6 +261,7 @@ class SavePhotoViewModel @Inject constructor(
             _savedProjectTitle.value = finalProjectName
             _isSaving.value = false
             _isSaved.value = true
+            Log.d("SavePhotoDebug", "ViewModel: saveTask complete. isSaved set to true for ID: $projectId")
         }
     }
 }

--- a/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
+++ b/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
@@ -3,7 +3,6 @@ package com.zoewave.probase.photodo.features.camera.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.applications.photodo.db.entity.CategoryEntity
-import com.zoewave.probase.applications.photodo.db.entity.PhotoEntity
 import com.zoewave.probase.applications.photodo.db.entity.ProjectEntity
 import com.zoewave.probase.applications.photodo.db.entity.TaskEntity
 import com.zoewave.probase.applications.photodo.db.repo.PhotoDoRepo
@@ -12,7 +11,6 @@ import com.zoewave.probase.core.model.tasks.SmartTaskDraft
 import com.zoewave.probase.photodo.features.camera.domain.AddPhotoToTaskUseCase
 import com.zoewave.probase.photodo.features.camera.ui.state.SavePhotoUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -60,6 +58,7 @@ class SavePhotoViewModel @Inject constructor(
         _subTasks,
         _aiGeneratedFields,
         repo.getAllCategories(),
+        repo.getAllProjects(), // 🚀 NEW: Fetch existing projects
         _isSaving,
         _isSaved,
         _savedProjectId,
@@ -77,10 +76,11 @@ class SavePhotoViewModel @Inject constructor(
             subTasks = args[8] as List<String>,
             aiGeneratedFields = args[9] as Set<String>,
             categories = args[10] as List<CategoryEntity>,
-            isSaving = args[11] as Boolean,
-            isSaved = args[12] as Boolean,
-            savedProjectId = args[13] as Long?,
-            savedProjectTitle = args[14] as String?
+            projects = args[11] as List<ProjectEntity>, // 🚀 NEW: Map projects
+            isSaving = args[12] as Boolean,
+            isSaved = args[13] as Boolean,
+            savedProjectId = args[14] as Long?,
+            savedProjectTitle = args[15] as String?
         )
     }.stateIn(
         scope = viewModelScope,

--- a/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
+++ b/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/SavePhotoViewModel.kt
@@ -1,5 +1,6 @@
 package com.zoewave.probase.photodo.features.camera.ui
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.applications.photodo.db.entity.CategoryEntity
@@ -107,6 +108,12 @@ class SavePhotoViewModel @Inject constructor(
     fun setInitialData(uri: String?, draft: SmartTaskDraft? = null) {
         if (_photoUri.value == uri && draft == null) return
         
+        // 🚀 CRITICAL: Reset the status flags so we don't skip the form if the ViewModel is reused.
+        _isSaving.value = false
+        _isSaved.value = false
+        _savedProjectId.value = null
+        _savedProjectTitle.value = null
+
         _photoUri.value = uri ?: ""
         if (draft != null) {
             _isFromAi.value = true
@@ -203,10 +210,10 @@ class SavePhotoViewModel @Inject constructor(
             val existingProject = repo.getProjectByNameAndCategory(categoryId, finalProjectName)
 
             val projectId = if (existingProject != null) {
-                // Reuse existing project ID
+                Log.d("ProjectDebug", "Reusing existing project: ${existingProject.name} (ID: ${existingProject.projectId})")
                 existingProject.projectId
             } else {
-                // Create new Project
+                Log.d("ProjectDebug", "Creating new project: $finalProjectName in Category ID: $categoryId")
                 val newProject = ProjectEntity(
                     categoryId = categoryId,
                     name = finalProjectName,
@@ -216,6 +223,8 @@ class SavePhotoViewModel @Inject constructor(
                 )
                 repo.upsertProject(newProject)
             }
+
+            Log.d("ProjectDebug", "Final Project ID for navigation: $projectId")
 
             // 3. Create Main Task (if name provided)
             if (_taskName.value.isNotBlank()) {

--- a/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/components/SavePhotoBottomSheet.kt
+++ b/applications/photodo/features/camera/src/main/java/com/zoewave/probase/photodo/features/camera/ui/components/SavePhotoBottomSheet.kt
@@ -148,6 +148,7 @@ internal fun SavePhotoForm(
     val containerColor = if (uiState.isFromAi) MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.2f) else Color.Transparent
 
     var isCategoryDropdownExpanded by remember { mutableStateOf(false) }
+    var isProjectDropdownExpanded by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -252,15 +253,46 @@ internal fun SavePhotoForm(
 
         FormSection(title = "Project Details", themeColor = themeColor) {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                AiEnhancedTextField(
-                    value = uiState.projectName,
-                    onValueChange = onProjectNameChanged,
-                    label = "Project Name",
-                    isAiGenerated = uiState.aiGeneratedFields.contains("project"),
-                    onReportClick = onReportIssue,
-                    onClearAiClick = onClearAiData,
+                ExposedDropdownMenuBox(
+                    expanded = isProjectDropdownExpanded,
+                    onExpandedChange = { isProjectDropdownExpanded = it },
                     modifier = Modifier.fillMaxWidth()
-                )
+                ) {
+                    AiEnhancedTextField(
+                        value = uiState.projectName,
+                        onValueChange = onProjectNameChanged,
+                        label = "Project Name",
+                        isAiGenerated = uiState.aiGeneratedFields.contains("project"),
+                        onReportClick = onReportIssue,
+                        onClearAiClick = onClearAiData,
+                        modifier = Modifier.fillMaxWidth().menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable, true),
+                        trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = isProjectDropdownExpanded) 
+                        },
+                        colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
+                    )
+
+                    ExposedDropdownMenu(
+                        expanded = isProjectDropdownExpanded,
+                        onDismissRequest = { isProjectDropdownExpanded = false }
+                    ) {
+                        // Show unique project names from current category if possible, or all projects
+                        val filteredProjects = uiState.projects
+                            .filter { it.name.isNotBlank() }
+                            .distinctBy { it.name }
+                        
+                        filteredProjects.forEach { project ->
+                            DropdownMenuItem(
+                                text = { Text(project.name) },
+                                onClick = {
+                                    onProjectNameChanged(project.name)
+                                    isProjectDropdownExpanded = false
+                                },
+                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                            )
+                        }
+                    }
+                }
 
                 QuickIconRow(
                     items = projectTemplates,


### PR DESCRIPTION
feat(camera): implement project merging and refine save navigation

This commit introduces logic to merge new information into existing projects during the photo-saving process. When a user selects an existing project name and category, the system now sums the budgets and updates the due date rather than creating a duplicate entry.

- **`SavePhotoViewModel.kt`**:
    - Enhanced `saveTask` to detect existing projects and update them with combined budget totals and new due dates.
    - Updated `setInitialData` to reset lifecycle flags (`isSaved`, `isSaving`), ensuring the form behaves correctly when the ViewModel is reused.
    - Added debug logging to track the save and initialization state.
- **`photoTodoNavEntryProvider.kt`**:
    - Refined the post-save navigation flow using a `LaunchedEffect` to automatically transition to the `TaskDetail` screen once `isSaved` is confirmed.
- **Documentation**:
    - Added `implementation_add_project.md` to document the merging business logic, specifically regarding budget summation and due date overwriting.