### PR TITLE
Ashbike glass

### DIFF
--- a/applications/ashbike/apps/mobile/features/glass/docs/GenAI/AddVoiceControl/implementation_plan.md
+++ b/applications/ashbike/apps/mobile/features/glass/docs/GenAI/AddVoiceControl/implementation_plan.md
@@ -1,0 +1,41 @@
+# Voice Command Gear Control for AI Glasses
+
+Implement voice command support to change bike gears using the microphone on Samsung/Google AI Glasses (Android XR). This will allow hands-free operation while riding.
+
+## User Review Required
+
+> [!IMPORTANT]
+> - **Always-On Listening**: The implementation will keep the microphone active while the Glass mode is active to listen for commands. This might impact battery life.
+> - **Permissions**: The user will be prompted on their phone to grant `RECORD_AUDIO` permission for the glasses.
+
+## Proposed Changes
+
+### [Glass Module] (applications/ashbike/apps/mobile/features/glass)
+
+#### [AndroidManifest.xml](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/src/main/AndroidManifest.xml)
+- Add `android.permission.RECORD_AUDIO` permission.
+
+#### [NEW] [VoiceGearController.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/audio/VoiceGearController.kt)
+- Create a lifecycle-aware component that manages `SpeechRecognizer`.
+- Implement `RecognitionListener` to detect gear commands ("gear up", "gear down", etc.).
+- Call `BikeRepository` methods to change gears.
+- Handle automatic restart of listening for "always-on" behavior.
+
+#### [GlassesMainActivity.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/GlassesMainActivity.kt)
+- Integrate `VoiceGearController`.
+- Implement `ProjectedPermissionsResultContract` to request microphone access on the glasses.
+- Start the voice controller once permission is granted.
+
+#### [AudioInterface.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/audioInterface.kt)
+- Add a method to speak specifically for permission rationales if needed (as recommended by XR docs).
+
+## Verification Plan
+
+### Automated Tests
+- I will verify the logic by ensuring the code compiles and that the `SpeechRecognizer` is correctly initialized and started in the activity.
+- Since I cannot run an actual XR device or emulator with a microphone, I will rely on unit-testing the command matching logic if possible, or verifying the structural correctness of the implementation.
+
+### Manual Verification
+- Verify that `RECORD_AUDIO` is added to the manifest.
+- Verify that `GlassesMainActivity` correctly handles the permission flow using `ProjectedPermissionsResultContract`.
+- Verify that `VoiceGearController` is correctly lifecycle-bound to the activity.

--- a/applications/ashbike/apps/mobile/features/glass/docs/GenAI/AddVoiceControl/implementation_plan_t.md
+++ b/applications/ashbike/apps/mobile/features/glass/docs/GenAI/AddVoiceControl/implementation_plan_t.md
@@ -1,0 +1,41 @@
+# Voice Command Gear Control for AI Glasses
+
+Implement voice command support to change bike gears using the microphone on Samsung/Google AI Glasses (Android XR). This will allow hands-free operation while riding.
+
+## User Review Required
+
+> [!IMPORTANT]
+> - **Always-On Listening**: The implementation will keep the microphone active while the Glass mode is active to listen for commands. This might impact battery life.
+> - **Permissions**: The user will be prompted on their phone to grant `RECORD_AUDIO` permission for the glasses.
+
+## Proposed Changes
+
+### [Glass Module] (applications/ashbike/apps/mobile/features/glass)
+
+#### [AndroidManifest.xml](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/src/main/AndroidManifest.xml)
+- Add `android.permission.RECORD_AUDIO` permission.
+
+#### [NEW] [VoiceGearController.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/audio/VoiceGearController.kt)
+- Create a lifecycle-aware component that manages `SpeechRecognizer`.
+- Implement `RecognitionListener` to detect gear commands ("gear up", "gear down", etc.).
+- Call `BikeRepository` methods to change gears.
+- Handle automatic restart of listening for "always-on" behavior.
+
+#### [GlassesMainActivity.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/GlassesMainActivity.kt)
+- Integrate `VoiceGearController`.
+- Implement `ProjectedPermissionsResultContract` to request microphone access on the glasses.
+- Start the voice controller once permission is granted.
+
+#### [AudioInterface.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/audioInterface.kt)
+- Add a method to speak specifically for permission rationales if needed (as recommended by XR docs).
+
+## Verification Plan
+
+### Automated Tests
+- I will verify the logic by ensuring the code compiles and that the `SpeechRecognizer` is correctly initialized and started in the activity.
+- Since I cannot run an actual XR device or emulator with a microphone, I will rely on unit-testing the command matching logic if possible, or verifying the structural correctness of the implementation.
+
+### Manual Verification
+- Verify that `RECORD_AUDIO` is added to the manifest.
+- Verify that `GlassesMainActivity` correctly handles the permission flow using `ProjectedPermissionsResultContract`.
+- Verify that `VoiceGearController` is correctly lifecycle-bound to the activity.

--- a/applications/ashbike/apps/mobile/features/glass/docs/GenAI/AddVoiceControl/walkthrough_add_voice.md
+++ b/applications/ashbike/apps/mobile/features/glass/docs/GenAI/AddVoiceControl/walkthrough_add_voice.md
@@ -1,0 +1,33 @@
+# Walkthrough - Voice Command Gear Control for AI Glasses
+
+I have implemented voice command support for changing bike gears on Samsung/Google AI Glasses (Android XR). This allows users to change gears hands-free while riding.
+
+## Changes
+
+### 1. Permissions
+- Added `RECORD_AUDIO` permission to the `AndroidManifest.xml` to allow the app to access the glasses' microphone.
+
+### 2. Voice Gear Controller
+- Created [VoiceGearController.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/audio/VoiceGearController.kt).
+- This component uses `SpeechRecognizer` to listen for specific commands:
+    - "Gear Up", "Shift Up", "Higher Gear" -> Triggers `repository.gearUp()`.
+    - "Gear Down", "Shift Down", "Lower Gear" -> Triggers `repository.gearDown()`.
+- It is lifecycle-aware and automatically restarts listening after a command is processed or an error occurs, providing a continuous "always-on" experience.
+
+### 3. Glass Main Activity Integration
+- Updated [GlassesMainActivity.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/GlassesMainActivity.kt).
+- Implemented the XR-specific permission flow using `ProjectedPermissionsResultContract`.
+- When the activity starts, it checks for microphone permission. If not granted, it prompts the user on their phone while providing an audible explanation on the glasses.
+- Once permission is granted, the `VoiceGearController` starts listening.
+- Integrated feedback: The glasses will speak "Changing Gear Up/Down" when a command is recognized.
+
+## Verification Results
+
+### Automated Tests
+- Verified that the code compiles and uses the correct XR SDK APIs for permissions on projected devices.
+- Verified that `RECORD_AUDIO` is correctly declared in the manifest.
+- Verified that `VoiceGearController` correctly maps voice strings to repository actions.
+
+### Manual Verification
+- Code review of the `SpeechRecognizer` implementation ensures it follows the recommended patterns for Android XR as found in the documentation.
+- The permission flow correctly uses `ProjectedPermissionsResultContract` as required for AI glasses.

--- a/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/GlassesMainActivity.kt
+++ b/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/GlassesMainActivity.kt
@@ -1,11 +1,20 @@
 package com.zoewave.ashbike.mobile.glass
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
+import androidx.annotation.OptIn
+import androidx.xr.projected.experimental.ExperimentalProjectedApi
 import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.projected.permissions.ProjectedPermissionsRequestParams
+import androidx.xr.projected.permissions.ProjectedPermissionsResultContract
 import com.zoewave.ashbike.data.repository.bike.BikeRepository
+import com.zoewave.ashbike.mobile.glass.audio.VoiceGearController
 import com.zoewave.ashbike.mobile.glass.ui.GlassApp
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -19,6 +28,18 @@ class GlassesMainActivity : ComponentActivity() {
     // Inject the shared repository instance
     @Inject lateinit var repository: BikeRepository
     private lateinit var audioInterface: AudioInterface
+    private lateinit var voiceGearController: VoiceGearController
+
+    @OptIn(ExperimentalProjectedApi::class)
+    private val requestPermissionLauncher =
+        registerForActivityResult(ProjectedPermissionsResultContract()) { results ->
+            if (results[Manifest.permission.RECORD_AUDIO] == true) {
+                onPermissionGranted()
+            } else {
+                onPermissionDenied()
+            }
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -28,6 +49,13 @@ class GlassesMainActivity : ComponentActivity() {
             getString(R.string.applications_ashbike_apps_mobile_features_glass_hello_ai_glasses)
         )
         lifecycle.addObserver(audioInterface)
+
+        voiceGearController = VoiceGearController(this, repository) { command ->
+            audioInterface.speak("Changing $command")
+        }
+        lifecycle.addObserver(voiceGearController)
+
+        checkAndRequestAudioPermission()
 
         setContent {
             GlimmerTheme {
@@ -49,6 +77,39 @@ class GlassesMainActivity : ComponentActivity() {
             }
         }
     }
+
+    private fun checkAndRequestAudioPermission() {
+        val permission = Manifest.permission.RECORD_AUDIO
+        val permissionStatus = ContextCompat.checkSelfPermission(this, permission)
+
+        if (permissionStatus == PackageManager.PERMISSION_GRANTED) {
+            onPermissionGranted()
+        } else {
+            requestAudioPermission()
+        }
+    }
+
+    @OptIn(ExperimentalProjectedApi::class)
+    private fun requestAudioPermission() {
+        val params = ProjectedPermissionsRequestParams(
+            permissions = listOf(Manifest.permission.RECORD_AUDIO),
+            rationale = "Microphone access is essential for hands-free gear changes on these AI glasses."
+        )
+        // Speak rationale as recommended by XR docs
+        audioInterface.speak("Please review the microphone permission request on your phone to enable voice commands.")
+        requestPermissionLauncher.launch(listOf(params))
+    }
+
+    private fun onPermissionGranted() {
+        voiceGearController.startListening()
+    }
+
+    private fun onPermissionDenied() {
+        Log.w("GlassesMainActivity", "Microphone permission denied. Voice commands will be disabled.")
+        // We could also finish() here if voice is considered critical, 
+        // but for now we just log it as the UI buttons still work.
+    }
+
 
     override fun onStart() {
         super.onStart()

--- a/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/GlassesMainActivity.kt
+++ b/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/GlassesMainActivity.kt
@@ -16,6 +16,7 @@ import androidx.xr.projected.permissions.ProjectedPermissionsResultContract
 import com.zoewave.ashbike.data.repository.bike.BikeRepository
 import com.zoewave.ashbike.mobile.glass.audio.VoiceGearController
 import com.zoewave.ashbike.mobile.glass.ui.GlassApp
+import com.zoewave.probase.features.ai.firebase.data.FirebaseLiveSessionManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -27,6 +28,7 @@ class GlassesMainActivity : ComponentActivity() {
 
     // Inject the shared repository instance
     @Inject lateinit var repository: BikeRepository
+    @Inject lateinit var firebaseLiveSessionManager: FirebaseLiveSessionManager
     private lateinit var audioInterface: AudioInterface
     private lateinit var voiceGearController: VoiceGearController
 
@@ -51,9 +53,14 @@ class GlassesMainActivity : ComponentActivity() {
         lifecycle.addObserver(audioInterface)
 
         voiceGearController = VoiceGearController(this, repository) { command ->
-            audioInterface.speak("Changing $command")
+            if (command == "AI Assistant") {
+                firebaseLiveSessionManager.startConversation()
+            } else {
+                audioInterface.speak("Changing $command")
+            }
         }
         lifecycle.addObserver(voiceGearController)
+        lifecycle.addObserver(firebaseLiveSessionManager)
 
         checkAndRequestAudioPermission()
 

--- a/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/audio/VoiceGearController.kt
+++ b/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/audio/VoiceGearController.kt
@@ -1,0 +1,147 @@
+package com.zoewave.ashbike.mobile.glass.audio
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.zoewave.ashbike.data.repository.bike.BikeRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+class VoiceGearController(
+    private val context: Context,
+    private val repository: BikeRepository,
+    private val onCommandDetected: (String) -> Unit = {}
+) : DefaultLifecycleObserver {
+
+    private var speechRecognizer: SpeechRecognizer? = null
+    private val scope = CoroutineScope(Dispatchers.Main + Job())
+    private var isListening = false
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        // Note: RECORD_AUDIO permission must be granted before this is used
+    }
+
+    fun startListening() {
+        if (isListening) return
+        
+        scope.launch {
+            if (speechRecognizer == null) {
+                speechRecognizer = SpeechRecognizer.createOnDeviceSpeechRecognizer(context).apply {
+                    setRecognitionListener(createRecognitionListener())
+                }
+            }
+
+            val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+            }
+            speechRecognizer?.startListening(intent)
+            isListening = true
+            Log.d(TAG, "Started listening for voice commands")
+        }
+    }
+
+    fun stopListening() {
+        speechRecognizer?.stopListening()
+        isListening = false
+        Log.d(TAG, "Stopped listening")
+    }
+
+    private fun createRecognitionListener() = object : RecognitionListener {
+        override fun onReadyForSpeech(params: Bundle?) {
+            Log.d(TAG, "onReadyForSpeech")
+        }
+
+        override fun onBeginningOfSpeech() {
+            Log.d(TAG, "onBeginningOfSpeech")
+        }
+
+        override fun onRmsChanged(rmsdB: Float) {}
+
+        override fun onBufferReceived(buffer: ByteArray?) {}
+
+        override fun onEndOfSpeech() {
+            Log.d(TAG, "onEndOfSpeech")
+            isListening = false
+            // Automatically restart listening for continuous experience
+            startListening()
+        }
+
+        override fun onError(error: Int) {
+            val message = when (error) {
+                SpeechRecognizer.ERROR_AUDIO -> "Audio recording error"
+                SpeechRecognizer.ERROR_CLIENT -> "Client side error"
+                SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> "Insufficient permissions"
+                SpeechRecognizer.ERROR_NETWORK -> "Network error"
+                SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "Network timeout"
+                SpeechRecognizer.ERROR_NO_MATCH -> "No match"
+                SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "RecognitionService busy"
+                SpeechRecognizer.ERROR_SERVER -> "Server sends error status"
+                SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "No speech input"
+                else -> "Unknown error"
+            }
+            Log.e(TAG, "Speech recognition error: $message ($error)")
+            isListening = false
+            
+            // Restart listening unless it was a fatal error or busy
+            if (error != SpeechRecognizer.ERROR_RECOGNIZER_BUSY) {
+                startListening()
+            }
+        }
+
+        override fun onResults(results: Bundle?) {
+            val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+            matches?.forEach { text ->
+                Log.d(TAG, "Heard: $text")
+                processCommand(text)
+            }
+            isListening = false
+            startListening()
+        }
+
+        override fun onPartialResults(partialResults: Bundle?) {
+            val matches = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+            matches?.forEach { text ->
+                Log.d(TAG, "Partial: $text")
+                processCommand(text)
+            }
+        }
+
+        override fun onEvent(eventType: Int, params: Bundle?) {}
+    }
+
+    private fun processCommand(text: String) {
+        val normalized = text.lowercase()
+        when {
+            normalized.contains("gear up") || normalized.contains("shift up") || normalized.contains("higher gear") -> {
+                Log.i(TAG, "Command detected: GEAR UP")
+                onCommandDetected("Gear Up")
+                scope.launch { repository.gearUp() }
+            }
+            normalized.contains("gear down") || normalized.contains("shift down") || normalized.contains("lower gear") -> {
+                Log.i(TAG, "Command detected: GEAR DOWN")
+                onCommandDetected("Gear Down")
+                scope.launch { repository.gearDown() }
+            }
+        }
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        speechRecognizer?.destroy()
+        speechRecognizer = null
+    }
+
+    companion object {
+        private const val TAG = "VoiceGearController"
+    }
+}

--- a/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/audio/VoiceGearController.kt
+++ b/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/audio/VoiceGearController.kt
@@ -132,6 +132,10 @@ class VoiceGearController(
                 onCommandDetected("Gear Down")
                 scope.launch { repository.gearDown() }
             }
+            normalized.contains("hey ash") || normalized.contains("talk to ash") -> {
+                Log.i(TAG, "Triggering AI Assistant")
+                onCommandDetected("AI Assistant")
+            }
         }
     }
 

--- a/applications/ashbike/apps/mobile/src/main/AndroidManifest.xml
+++ b/applications/ashbike/apps/mobile/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
 
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
     <uses-permission android:name="android.permission.health.WRITE_HEART_RATE" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,7 +94,7 @@ mlkitTextRecognition = "16.0.1"
 googleAiEdgeAicore = "0.0.1-exp02"
 googleGenerativeAi = "0.9.0"
 playServicesCodeScanner = "16.1.0"
-firebaseBom = "34.8.0"
+firebaseBom = "34.10.0"
 googleGmsGoogleServices = "4.4.4"
 googleFirebaseCrashlytics = "3.0.6"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -64,6 +64,7 @@ include(":features:compliance")
 include(":features:ai:capture")
 include(":features:ai:vision")
 include(":features:ai:configuration")
+include(":features:ai:firebase")
 
 
 include(":applications:ashbike:apps:wear:features:home")


### PR DESCRIPTION
feat(glass): integrate voice-triggered AI assistant support

This commit introduces voice activation for an AI assistant within the smart glasses interface. Users can now initiate a session using phrases like "hey ash" or "talk to ash," which triggers a live conversation managed via Firebase.

- **`VoiceGearController.kt`**:
    - Added recognition for "hey ash" and "talk to ash" voice triggers.
    - Maps these phrases to a new "AI Assistant" command.
- **`GlassesMainActivity.kt`**:
    - Injected `FirebaseLiveSessionManager` and registered it as a lifecycle observer.
    - Updated the voice command callback to handle the "AI Assistant" command by invoking `firebaseLiveSessionManager.startConversation()`, while maintaining existing text-to-speech feedback for gear changes.