### PR TITLE
feat(ai): enforce audio permissions and update Firebase AI SDK integr…

### DIFF
--- a/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/GlassesMainActivity.kt
+++ b/applications/ashbike/apps/mobile/features/glass/src/main/java/com/zoewave/ashbike/mobile/glass/GlassesMainActivity.kt
@@ -6,11 +6,11 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.annotation.OptIn
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
-import androidx.annotation.OptIn
-import androidx.xr.projected.experimental.ExperimentalProjectedApi
 import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.projected.experimental.ExperimentalProjectedApi
 import androidx.xr.projected.permissions.ProjectedPermissionsRequestParams
 import androidx.xr.projected.permissions.ProjectedPermissionsResultContract
 import com.zoewave.ashbike.data.repository.bike.BikeRepository
@@ -22,7 +22,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-
+@OptIn(ExperimentalProjectedApi::class, ExperimentalProjectedApi::class)
+@kotlin.OptIn(ExperimentalProjectedApi::class)
 @AndroidEntryPoint // <--- Required for Hilt injection
 class GlassesMainActivity : ComponentActivity() {
 
@@ -32,7 +33,6 @@ class GlassesMainActivity : ComponentActivity() {
     private lateinit var audioInterface: AudioInterface
     private lateinit var voiceGearController: VoiceGearController
 
-    @OptIn(ExperimentalProjectedApi::class)
     private val requestPermissionLauncher =
         registerForActivityResult(ProjectedPermissionsResultContract()) { results ->
             if (results[Manifest.permission.RECORD_AUDIO] == true) {
@@ -54,7 +54,9 @@ class GlassesMainActivity : ComponentActivity() {
 
         voiceGearController = VoiceGearController(this, repository) { command ->
             if (command == "AI Assistant") {
-                firebaseLiveSessionManager.startConversation()
+                if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
+                    firebaseLiveSessionManager.startConversation()
+                }
             } else {
                 audioInterface.speak("Changing $command")
             }

--- a/features/ai/firebase/src/main/java/com/zoewave/probase/features/ai/firebase/data/FirebaseLiveSessionManager.kt
+++ b/features/ai/firebase/src/main/java/com/zoewave/probase/features/ai/firebase/data/FirebaseLiveSessionManager.kt
@@ -1,9 +1,12 @@
 package com.zoewave.probase.features.ai.firebase.data
 
+import android.Manifest
 import android.util.Log
+import androidx.annotation.RequiresPermission
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.google.firebase.ai.LiveSession
+import com.google.firebase.ai.type.LiveSession
+import com.google.firebase.ai.type.PublicPreviewAPI
 import com.zoewave.probase.features.ai.firebase.domain.GeminiFirebaseManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,6 +18,7 @@ import javax.inject.Inject
 /**
  * Handles the lifecycle and connection of a Gemini Live session.
  */
+@OptIn(PublicPreviewAPI::class)
 class FirebaseLiveSessionManager @Inject constructor(
     private val geminiFirebaseManager: GeminiFirebaseManager
 ) : DefaultLifecycleObserver {
@@ -25,6 +29,7 @@ class FirebaseLiveSessionManager @Inject constructor(
     /**
      * Starts the audio conversation session.
      */
+    @RequiresPermission(Manifest.permission.RECORD_AUDIO)
     fun startConversation() {
         scope.launch {
             try {

--- a/features/ai/firebase/src/main/java/com/zoewave/probase/features/ai/firebase/domain/GeminiFirebaseManager.kt
+++ b/features/ai/firebase/src/main/java/com/zoewave/probase/features/ai/firebase/domain/GeminiFirebaseManager.kt
@@ -1,9 +1,11 @@
 package com.zoewave.probase.features.ai.firebase.domain
 
-import com.google.firebase.ai.GenerativeBackend
+import com.google.firebase.Firebase
 import com.google.firebase.ai.GenerativeModel
-import com.google.firebase.ai.Firebase
+import com.google.firebase.ai.LiveGenerativeModel
 import com.google.firebase.ai.ai
+import com.google.firebase.ai.type.GenerativeBackend
+import com.google.firebase.ai.type.PublicPreviewAPI
 import com.google.firebase.ai.type.ResponseModality
 import com.google.firebase.ai.type.liveGenerationConfig
 import javax.inject.Inject
@@ -13,6 +15,7 @@ import javax.inject.Singleton
  * Isolated manager for Firebase AI Logic SDK.
  * Used primarily for Android XR (AI Glasses) capabilities like Gemini Live.
  */
+@OptIn(PublicPreviewAPI::class)
 @Singleton
 class GeminiFirebaseManager @Inject constructor() {
 
@@ -21,7 +24,7 @@ class GeminiFirebaseManager @Inject constructor() {
      */
     fun createLiveModel(
         modelName: String = "gemini-2.5-flash-native-audio-preview-12-2025"
-    ): com.google.firebase.ai.LiveGenerativeModel {
+    ): LiveGenerativeModel {
         return Firebase.ai(backend = GenerativeBackend.googleAI())
             .liveModel(
                 modelName = modelName,


### PR DESCRIPTION
…ation

This commit introduces mandatory permission checks for audio recording before initiating Gemini Live sessions and updates the Firebase AI integration to align with the latest `PublicPreviewAPI` requirements.

- **`GlassesMainActivity.kt`**:
    - Implemented a runtime check for `RECORD_AUDIO` permission before calling `startConversation` within the voice gear controller logic.
    - Consolidated `ExperimentalProjectedApi` opt-in annotations at the class level.
- **`FirebaseLiveSessionManager.kt`**:
    - Added `@RequiresPermission(Manifest.permission.RECORD_AUDIO)` to `startConversation` to ensure API safety.
    - Updated imports and applied `@OptIn(PublicPreviewAPI::class)` to support the experimental Live Session API.
- **`GeminiFirebaseManager.kt`**:
    - Updated `createLiveModel` to use the correct `LiveGenerativeModel` and `GenerativeBackend` types from the updated Firebase AI package structure.
    - Applied the `PublicPreviewAPI` opt-in for the generative model configuration.