### PR TITLE
feat(home): implement scoped search for categories and projects

### DIFF
--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/categories/HomeOverviewScreen.kt
@@ -59,6 +59,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -88,6 +91,8 @@ import com.zoewave.probase.photodo.mobile.core.ui.theme.PhotoDoTheme
 import com.zoewave.probase.photodo.mobile.features.home.R
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.HomeEvent
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.HomeUiState
+import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.SearchScope
+import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.TaskSearchResult
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.OverviewSummaryCard
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.home.components.bottomsheets.QuickTemplateBottomSheet
 import com.zoewave.probase.photodo.model.navigation.PhotoTodoRoute
@@ -301,25 +306,54 @@ fun HomeOverviewContent(
                         enter = fadeIn(),
                         exit = fadeOut()
                     ) {
-                        OutlinedTextField(
-                            value = uiState.categorySearchQuery,
-                            onValueChange = { onEvent(HomeEvent.OnCategorySearchQueryChanged(it)) },
+                        Column(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(bottom = 8.dp),
-                            placeholder = { Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_search_categories_placeholder)) },
-                            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-                            trailingIcon = {
-                                IconButton(onClick = {
-                                    onEvent(HomeEvent.OnCategorySearchQueryChanged(""))
-                                    onEvent(HomeEvent.OnSearchModeToggle(false))
-                                }) {
-                                    Icon(Icons.Default.Close, contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_home_close_search_content_desc))
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            OutlinedTextField(
+                                value = uiState.categorySearchQuery,
+                                onValueChange = { onEvent(HomeEvent.OnCategorySearchQueryChanged(it)) },
+                                modifier = Modifier.fillMaxWidth(),
+                                placeholder = { 
+                                    Text(
+                                        if (uiState.searchScope == SearchScope.CATEGORIES) 
+                                            stringResource(R.string.applications_photodo_apps_mobile_features_home_search_categories_placeholder)
+                                        else 
+                                            stringResource(R.string.applications_photodo_apps_mobile_features_home_search_projects_placeholder)
+                                    ) 
+                                },
+                                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                                trailingIcon = {
+                                    IconButton(onClick = {
+                                        onEvent(HomeEvent.OnCategorySearchQueryChanged(""))
+                                        onEvent(HomeEvent.OnSearchModeToggle(false))
+                                    }) {
+                                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.applications_photodo_apps_mobile_features_home_close_search_content_desc))
+                                    }
+                                },
+                                singleLine = true,
+                                shape = RoundedCornerShape(16.dp)
+                            )
+
+                            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                                SegmentedButton(
+                                    selected = uiState.searchScope == SearchScope.CATEGORIES,
+                                    onClick = { onEvent(HomeEvent.OnSearchScopeChanged(SearchScope.CATEGORIES)) },
+                                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
+                                ) {
+                                    Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_search_scope_categories))
                                 }
-                            },
-                            singleLine = true,
-                            shape = RoundedCornerShape(16.dp)
-                        )
+                                SegmentedButton(
+                                    selected = uiState.searchScope == SearchScope.PROJECTS,
+                                    onClick = { onEvent(HomeEvent.OnSearchScopeChanged(SearchScope.PROJECTS)) },
+                                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
+                                ) {
+                                    Text(stringResource(R.string.applications_photodo_apps_mobile_features_home_search_scope_projects))
+                                }
+                            }
+                        }
                     }
 
                     AnimatedVisibility(
@@ -363,15 +397,97 @@ fun HomeOverviewContent(
                     }
                 }
 
-                itemsIndexed(
-                    items = filteredCategories,
-                    key = { _, category -> category.id }
-                ) { index, category ->
-                    CategoryDashboardCard(
-                        category = category,
-                        index = index,
-                        onDeleteClicked = { onEvent(HomeEvent.OnCategoryToDeleteChanged(it)) },
-                        navTo = navTo
+                if (uiState.isSearchMode && uiState.searchScope == SearchScope.PROJECTS) {
+                    if (uiState.taskSearchResults.isEmpty() && uiState.categorySearchQuery.length >= 2) {
+                        item(span = { GridItemSpan(2) }) {
+                            Text(
+                                text = stringResource(R.string.applications_photodo_apps_mobile_features_home_no_matching_tasks),
+                                modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                        }
+                    } else {
+                        itemsIndexed(
+                            items = uiState.taskSearchResults,
+                            key = { _, result -> "search_${result.projectId}" }
+                        ) { _, result ->
+                            ProjectSearchResultCard(
+                                result = result,
+                                onClick = {
+                                    navTo(PhotoTodoRoute.TaskDetail(result.projectId, result.projectTitle))
+                                },
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            )
+                        }
+                    }
+                } else {
+                    itemsIndexed(
+                        items = filteredCategories,
+                        key = { _, category -> category.id }
+                    ) { index, category ->
+                        CategoryDashboardCard(
+                            category = category,
+                            index = index,
+                            onDeleteClicked = { onEvent(HomeEvent.OnCategoryToDeleteChanged(it)) },
+                            navTo = navTo
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ProjectSearchResultCard(
+    result: TaskSearchResult,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = result.projectTitle,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+            
+            if (result.tasks.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                result.tasks.take(3).forEach { task ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(vertical = 2.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Checklist,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = task.text,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1
+                        )
+                    }
+                }
+                if (result.tasks.size > 3) {
+                    Text(
+                        text = "+ ${result.tasks.size - 3} more tasks",
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.padding(start = 24.dp, top = 4.dp),
+                        color = MaterialTheme.colorScheme.secondary
                     )
                 }
             }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeEvent.kt
@@ -25,4 +25,5 @@ sealed interface HomeEvent {
     data class OnCategoryToDeleteChanged(val category: CategoryOverviewUiModel?) : HomeEvent
     data class OnFabMenuToggle(val expanded: Boolean) : HomeEvent
     data class OnSearchModeToggle(val enabled: Boolean) : HomeEvent
+    data class OnSearchScopeChanged(val scope: SearchScope) : HomeEvent
 }

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeUiState.kt
@@ -6,6 +6,11 @@ import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories
 import com.zoewave.probase.photodo.mobile.features.tasks.ui.state.ProjectListUiModel
 
 @Immutable
+enum class SearchScope {
+    CATEGORIES, PROJECTS
+}
+
+@Immutable
 data class TaskSearchResult(
     val projectId: Long,
     val projectTitle: String,
@@ -28,6 +33,7 @@ data class HomeUiState(
     val categoryToDelete: CategoryOverviewUiModel? = null,
     val fabMenuExpanded: Boolean = false,
     val isSearchMode: Boolean = false,
+    val searchScope: SearchScope = SearchScope.CATEGORIES,
     val animationsEnabled: Boolean = true
 ) {
     val isEmpty: Boolean = !isLoading && categories.isEmpty()

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModel.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -46,7 +45,8 @@ class HomeViewModel @Inject constructor(
         val showAddCategoryDialog: Boolean = false,
         val categoryToDelete: CategoryOverviewUiModel? = null,
         val fabMenuExpanded: Boolean = false,
-        val isSearchMode: Boolean = false
+        val isSearchMode: Boolean = false,
+        val searchScope: SearchScope = SearchScope.CATEGORIES
     )
 
     private val _uiFlags = MutableStateFlow(UiFlags())
@@ -56,19 +56,25 @@ class HomeViewModel @Inject constructor(
     val uiState: StateFlow<HomeUiState> = combine(
         photoDoRepo.getCategoriesWithProjectsAndTasks(),
         _uiFlags.flatMapLatest { flags ->
-            if (flags.taskSearchQuery.length >= 2) {
-                photoDoRepo.getProjectsWithMatchingTasks(flags.taskSearchQuery)
-                    .map { projects ->
-                        projects.map { projectDetails ->
-                            TaskSearchResult(
-                                projectId = projectDetails.project.projectId,
-                                projectTitle = projectDetails.project.name,
-                                tasks = projectDetails.tasks.filter { 
-                                    it.text.contains(flags.taskSearchQuery, ignoreCase = true) 
-                                }
-                            )
-                        }
+            val query = if (flags.isSearchMode) flags.categorySearchQuery else flags.taskSearchQuery
+            if (query.length >= 2) {
+                // Combine results from searching project names and matching tasks
+                combine(
+                    photoDoRepo.searchProjectsWithDetails(query),
+                    photoDoRepo.getProjectsWithMatchingTasks(query)
+                ) { byName, byTask ->
+                    // Merge and deduplicate by projectId
+                    val merged = (byName + byTask).distinctBy { it.project.projectId }
+                    merged.map { projectDetails ->
+                        TaskSearchResult(
+                            projectId = projectDetails.project.projectId,
+                            projectTitle = projectDetails.project.name,
+                            tasks = projectDetails.tasks.filter { 
+                                it.text.contains(query, ignoreCase = true) 
+                            }
+                        )
                     }
+                }
             } else {
                 flowOf(emptyList<TaskSearchResult>())
             }
@@ -145,6 +151,7 @@ class HomeViewModel @Inject constructor(
                 categoryToDelete = flags.categoryToDelete,
                 fabMenuExpanded = flags.fabMenuExpanded,
                 isSearchMode = flags.isSearchMode,
+                searchScope = flags.searchScope,
                 animationsEnabled = animationsEnabled
             )
         }
@@ -271,6 +278,10 @@ class HomeViewModel @Inject constructor(
 
             is HomeEvent.OnSearchModeToggle -> {
                 _uiFlags.update { it.copy(isSearchMode = event.enabled) }
+            }
+
+            is HomeEvent.OnSearchScopeChanged -> {
+                _uiFlags.update { it.copy(searchScope = event.scope) }
             }
         }
     }

--- a/applications/photodo/apps/mobile/features/home/src/main/res/values/strings.xml
+++ b/applications/photodo/apps/mobile/features/home/src/main/res/values/strings.xml
@@ -103,4 +103,7 @@
     <string name="applications_photodo_apps_mobile_features_home_budget_range_format">$%1$d / $%2$d</string>
     <string name="applications_photodo_apps_mobile_features_home_percentage">%1$d%%</string>
     <string name="applications_photodo_apps_mobile_features_home_currency_symbol">$</string>
+    <string name="applications_photodo_apps_mobile_features_home_search_scope_categories">Categories</string>
+    <string name="applications_photodo_apps_mobile_features_home_search_scope_projects">Projects</string>
+    <string name="applications_photodo_apps_mobile_features_home_search_projects_placeholder">Search projects…</string>
 </resources>


### PR DESCRIPTION
This commit introduces a scoped search feature on the home screen, allowing users to toggle between searching for categories and searching for specific projects and tasks.

- **`HomeViewModel.kt` & `HomeUiState.kt`**:
    - Introduced `SearchScope` enum to differentiate between `CATEGORIES` and `PROJECTS`.
    - Updated search logic to aggregate results from both project name matches and task content matches when in project search mode.
    - Implemented result deduplication using `distinctBy` on project IDs.
- **`HomeOverviewScreen.kt`**:
    - Added a `SingleChoiceSegmentedButtonRow` within the search bar to allow users to switch search scopes.
    - Implemented `ProjectSearchResultCard` to display matching projects along with a preview of up to three relevant tasks.
    - Updated the search bar placeholder to dynamically reflect the active search scope.
- **`HomeEvent.kt`**:
    - Added `OnSearchScopeChanged` to handle user interaction with the search scope toggle.
- **Resources**:
    - Added string resources for search scope labels and project-specific search placeholders.