### PR TITLE
Seaweed cal

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.0" />
+    <option name="version" value="2.3.10" />
   </component>
 </project>

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
@@ -1,33 +1,58 @@
 package com.zoewave.probase.seaweed.mobile.home.ui
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ChevronRight
-import androidx.compose.material3.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.zoewave.probase.core.ui.R as CoreUiR
-import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
-import com.zoewave.probase.seaweed.mobile.home.ui.components.*
+import com.zoewave.probase.seaweed.mobile.home.ui.components.CategoryBudgetProgressBar
+import com.zoewave.probase.seaweed.mobile.home.ui.components.DonutChart
+import com.zoewave.probase.seaweed.mobile.home.ui.components.FixedCostsSummaryCard
+import com.zoewave.probase.seaweed.mobile.home.ui.components.RealMoneyHeroCard
+import com.zoewave.probase.seaweed.mobile.home.ui.components.UnallocatedMoneyCard
 import com.zoewave.probase.seaweed.mobile.transaction.ui.components.TransactionItem
 import com.zoewave.probase.seaweed.model.CategoryOverview
 import com.zoewave.probase.seaweed.model.Transaction
+import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import java.util.Locale
+import com.zoewave.probase.core.ui.R as CoreUiR
 
 @Composable
 fun HomeUiRoute(

--- a/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsUiRoute.kt
@@ -96,6 +96,17 @@ fun SettingsScreen(
                         title = "Seaweed Receipt AI",
                         description = "Use Gemini to automatically extract merchant and amount from receipts."
                     )
+
+                    HorizontalDivider()
+
+                    Text("Developer Options", style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.error)
+                    Button(
+                        onClick = { onEvent(SettingsUiEvent.GenerateTestData) },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.errorContainer, contentColor = MaterialTheme.colorScheme.onErrorContainer)
+                    ) {
+                        Text("Generate 3 Months of Random Data")
+                    }
                 }
             }
         }

--- a/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt
@@ -2,8 +2,10 @@ package com.zoewave.probase.seaweed.mobile.settings.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zoewave.probase.seaweed.data.BudgetTargetRepository
 import com.zoewave.probase.seaweed.data.TransactionRepository
 import com.zoewave.probase.seaweed.data.UserSettingsRepository
+import com.zoewave.probase.seaweed.model.BudgetTarget
 import com.zoewave.probase.seaweed.model.SeaweedThemeConfig
 import com.zoewave.probase.seaweed.model.ThemeMode
 import com.zoewave.probase.seaweed.model.Transaction
@@ -19,6 +21,7 @@ import kotlin.random.Random
 class SettingsViewModel @Inject constructor(
     private val userSettingsRepository: UserSettingsRepository,
     private val transactionRepository: TransactionRepository,
+    private val budgetRepository: BudgetTargetRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
@@ -55,6 +58,21 @@ class SettingsViewModel @Inject constructor(
 
     private suspend fun generateRandomTransactions() {
         val categories = listOf("Food", "Transport", "Shopping", "Entertainment", "Health", "Utilities")
+        
+        // Generate random budgets first
+        categories.forEach { category ->
+            val limit = when (category) {
+                "Food" -> Random.nextDouble(300.0, 600.0)
+                "Transport" -> Random.nextDouble(100.0, 300.0)
+                "Shopping" -> Random.nextDouble(200.0, 800.0)
+                "Entertainment" -> Random.nextDouble(100.0, 400.0)
+                "Health" -> Random.nextDouble(50.0, 200.0)
+                "Utilities" -> Random.nextDouble(200.0, 500.0)
+                else -> 500.0
+            }
+            budgetRepository.saveBudget(BudgetTarget(category, limit))
+        }
+
         val now = System.currentTimeMillis()
         val ninetyDaysMillis = 90L * 24 * 60 * 60 * 1000
 

--- a/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt
@@ -2,25 +2,30 @@ package com.zoewave.probase.seaweed.mobile.settings.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zoewave.probase.seaweed.data.TransactionRepository
 import com.zoewave.probase.seaweed.data.UserSettingsRepository
 import com.zoewave.probase.seaweed.model.SeaweedThemeConfig
 import com.zoewave.probase.seaweed.model.ThemeMode
+import com.zoewave.probase.seaweed.model.Transaction
 import com.zoewave.probase.seaweed.model.UserSettings
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import java.util.UUID
 import javax.inject.Inject
+import kotlin.random.Random
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val repository: UserSettingsRepository
+    private val userSettingsRepository: UserSettingsRepository,
+    private val transactionRepository: TransactionRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
     init {
-        repository.getUserSettings()
+        userSettingsRepository.getUserSettings()
             .onEach { settings ->
                 _uiState.value = SettingsUiState.Success(settings)
             }
@@ -32,16 +37,49 @@ class SettingsViewModel @Inject constructor(
             val currentSettings = (uiState.value as? SettingsUiState.Success)?.settings ?: UserSettings()
             when (event) {
                 is SettingsUiEvent.UpdateTheme -> {
-                    repository.saveUserSettings(currentSettings.copy(themeConfig = event.themeConfig))
+                    userSettingsRepository.saveUserSettings(currentSettings.copy(themeConfig = event.themeConfig))
                 }
                 is SettingsUiEvent.UpdateThemeMode -> {
-                    repository.saveUserSettings(currentSettings.copy(themeMode = event.themeMode))
+                    userSettingsRepository.saveUserSettings(currentSettings.copy(themeMode = event.themeMode))
                 }
                 is SettingsUiEvent.UpdateIncome -> {
-                    repository.saveUserSettings(currentSettings.copy(monthlyIncome = event.income))
+                    userSettingsRepository.saveUserSettings(currentSettings.copy(monthlyIncome = event.income))
+                }
+                is SettingsUiEvent.GenerateTestData -> {
+                    generateRandomTransactions()
                 }
                 is SettingsUiEvent.NavigateTo -> { /* Handled in Route */ }
             }
+        }
+    }
+
+    private suspend fun generateRandomTransactions() {
+        val categories = listOf("Food", "Transport", "Shopping", "Entertainment", "Health", "Utilities")
+        val now = System.currentTimeMillis()
+        val ninetyDaysMillis = 90L * 24 * 60 * 60 * 1000
+
+        repeat(150) {
+            val randomTimeOffset = Random.nextLong(0, ninetyDaysMillis)
+            val date = now - randomTimeOffset
+            val category = categories.random()
+            val amount = when (category) {
+                "Food" -> Random.nextDouble(5.0, 50.0)
+                "Transport" -> Random.nextDouble(2.0, 30.0)
+                "Shopping" -> Random.nextDouble(10.0, 200.0)
+                "Entertainment" -> Random.nextDouble(10.0, 100.0)
+                "Health" -> Random.nextDouble(20.0, 150.0)
+                "Utilities" -> Random.nextDouble(50.0, 300.0)
+                else -> Random.nextDouble(1.0, 100.0)
+            }
+
+            val transaction = Transaction(
+                id = UUID.randomUUID().toString(),
+                amount = amount,
+                category = category,
+                description = "Random $category expense",
+                date = date
+            )
+            transactionRepository.addTransaction(transaction)
         }
     }
 }
@@ -55,5 +93,6 @@ sealed interface SettingsUiEvent {
     data class UpdateTheme(val themeConfig: SeaweedThemeConfig) : SettingsUiEvent
     data class UpdateThemeMode(val themeMode: ThemeMode) : SettingsUiEvent
     data class UpdateIncome(val income: Double) : SettingsUiEvent
+    object GenerateTestData : SettingsUiEvent
     data class NavigateTo(val destination: com.zoewave.probase.seaweed.model.navigation.SeaweedDestination) : SettingsUiEvent
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
@@ -29,8 +29,10 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -414,11 +416,32 @@ private fun HabitInsightCard(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary
                 )
-                Text(
-                    text = String.format(Locale.getDefault(), "Total: $%.2f this month", insight.totalAmount),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                
+                val budgetLimit = insight.budgetLimit
+                if (budgetLimit != null) {
+                    val progress = (insight.totalAmount / budgetLimit).toFloat()
+                    val progressColor = if (progress > 0.9f) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+                    
+                    Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                        LinearProgressIndicator(
+                            progress = { progress.coerceIn(0f, 1f) },
+                            modifier = Modifier.fillMaxWidth().height(4.dp).clip(CircleShape),
+                            color = progressColor,
+                            trackColor = progressColor.copy(alpha = 0.2f)
+                        )
+                        Text(
+                            text = String.format(Locale.getDefault(), "$%.2f of $%.0f budget", insight.totalAmount, budgetLimit),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (progress > 0.9f) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else {
+                    Text(
+                        text = String.format(Locale.getDefault(), "Total: $%.2f this month", insight.totalAmount),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
@@ -2,6 +2,8 @@ package com.zoewave.probase.seaweed.mobile.transaction.ui
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -122,13 +125,28 @@ private fun AnalyticsContent(
     uiState: AnalyticsUiState,
     @Suppress("UnusedParameter") onEvent: (AnalyticsUiEvent) -> Unit,
     @Suppress("UnusedParameter") navTo: (SeaweedDestination) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    viewModel: AnalyticsViewModel = hiltViewModel()
 ) {
     var selectedPeriod by remember { mutableStateOf(SpendingPeriod.DAILY) }
     var selectedTrendPoint by remember { mutableStateOf<TrendPoint?>(null) }
     var selectedHeatmapDate by remember { mutableStateOf<LocalDate?>(null) }
     var isHabitsExpanded by remember { mutableStateOf(false) }
     var isTrendsExpanded by remember { mutableStateOf(true) }
+    var selectedCategory by remember { mutableStateOf<String?>(null) }
+
+    val filteredTransactions = remember(selectedCategory, uiState.allTransactions) {
+        if (selectedCategory == null) uiState.allTransactions
+        else uiState.allTransactions.filter { it.category == selectedCategory }
+    }
+
+    val trends = remember(filteredTransactions, selectedCategory) {
+        viewModel.calculateTrendsForTransactions(filteredTransactions)
+    }
+
+    val heatmapData = remember(filteredTransactions, selectedCategory) {
+        viewModel.calculateHeatmapDataForTransactions(filteredTransactions)
+    }
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
@@ -142,11 +160,20 @@ private fun AnalyticsContent(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        "Spending Habits",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
+                    Column {
+                        Text(
+                            "Spending Habits",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        if (selectedCategory != null) {
+                            Text(
+                                "Filtering by: $selectedCategory",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
                     IconButton(onClick = { isHabitsExpanded = !isHabitsExpanded }) {
                         Icon(
                             imageVector = if (isHabitsExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
@@ -158,7 +185,15 @@ private fun AnalyticsContent(
             
             if (isHabitsExpanded) {
                 items(uiState.habitInsights) { insight ->
-                    HabitInsightCard(insight = insight)
+                    HabitInsightCard(
+                        insight = insight,
+                        isSelected = selectedCategory == insight.category,
+                        onClick = {
+                            selectedCategory = if (selectedCategory == insight.category) null else insight.category
+                            selectedTrendPoint = null
+                            selectedHeatmapDate = null
+                        }
+                    )
                 }
             }
         }
@@ -214,7 +249,7 @@ private fun AnalyticsContent(
                         
                         Spacer(modifier = Modifier.height(16.dp))
                         
-                        val trendData = uiState.spendingTrends[selectedPeriod] ?: emptyList()
+                        val trendData = trends[selectedPeriod] ?: emptyList()
                         if (trendData.isNotEmpty()) {
                             SimpleBarChart(
                                 data = trendData.map { BarData(it.label, it.value) },
@@ -294,7 +329,7 @@ private fun AnalyticsContent(
                     modifier = Modifier.padding(bottom = 16.dp)
                 )
                 SpendingHeatmap(
-                    heatmapData = uiState.heatmapData,
+                    heatmapData = heatmapData,
                     selectedDate = selectedHeatmapDate,
                     onDayClick = { selectedHeatmapDate = it }
                 )
@@ -304,7 +339,7 @@ private fun AnalyticsContent(
         item {
             AnimatedVisibility(visible = selectedHeatmapDate != null) {
                 val zoneId = ZoneId.systemDefault()
-                val dayTransactions = uiState.allTransactions.filter {
+                val dayTransactions = filteredTransactions.filter {
                     Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() == selectedHeatmapDate
                 }
                 
@@ -336,9 +371,20 @@ private fun AnalyticsContent(
 }
 
 @Composable
-private fun HabitInsightCard(insight: HabitInsight) {
+private fun HabitInsightCard(
+    insight: HabitInsight,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .border(
+                width = if (isSelected) 2.dp else 0.dp,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
+                shape = CardDefaults.shape
+            ),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Row(

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Analytics
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -125,6 +127,8 @@ private fun AnalyticsContent(
     var selectedPeriod by remember { mutableStateOf(SpendingPeriod.DAILY) }
     var selectedTrendPoint by remember { mutableStateOf<TrendPoint?>(null) }
     var selectedHeatmapDate by remember { mutableStateOf<LocalDate?>(null) }
+    var isHabitsExpanded by remember { mutableStateOf(false) }
+    var isTrendsExpanded by remember { mutableStateOf(true) }
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
@@ -133,81 +137,167 @@ private fun AnalyticsContent(
     ) {
         if (uiState.habitInsights.isNotEmpty()) {
             item {
-                Text("Spending Habits", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            }
-            
-            items(uiState.habitInsights) { insight ->
-                HabitInsightCard(insight = insight)
-            }
-        }
-
-        item {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text("Spending Trends", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-                        
-                        Row {
-                            SpendingPeriod.entries.forEach { period ->
-                                FilterChip(
-                                    selected = selectedPeriod == period,
-                                    onClick = { 
-                                        selectedPeriod = period 
-                                        selectedTrendPoint = null
-                                    },
-                                    label = { Text(period.name.lowercase().replaceFirstChar { it.uppercase() }) },
-                                    modifier = Modifier.padding(start = 4.dp)
-                                )
-                            }
-                        }
-                    }
-                    
-                    Spacer(modifier = Modifier.height(16.dp))
-                    
-                    val trendData = uiState.spendingTrends[selectedPeriod] ?: emptyList()
-                    if (trendData.isNotEmpty()) {
-                        SimpleBarChart(
-                            data = trendData.map { BarData(it.label, it.value) },
-                            onBarClick = { barData ->
-                                selectedTrendPoint = trendData.find { it.label == barData.label }
-                            },
-                            selectedBar = selectedTrendPoint?.let { BarData(it.label, it.value) },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    } else {
-                        Box(Modifier.fillMaxWidth().height(150.dp), contentAlignment = Alignment.Center) {
-                            Text("No data for this period")
-                        }
-                    }
-                }
-            }
-        }
-
-        item {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     Text(
-                        "Spending Heatmap",
+                        "Spending Habits",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold
                     )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    SpendingHeatmap(
-                        heatmapData = uiState.heatmapData,
-                        selectedDate = selectedHeatmapDate,
-                        onDayClick = { selectedHeatmapDate = it }
+                    IconButton(onClick = { isHabitsExpanded = !isHabitsExpanded }) {
+                        Icon(
+                            imageVector = if (isHabitsExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                            contentDescription = if (isHabitsExpanded) "Collapse" else "Expand"
+                        )
+                    }
+                }
+            }
+            
+            if (isHabitsExpanded) {
+                items(uiState.habitInsights) { insight ->
+                    HabitInsightCard(insight = insight)
+                }
+            }
+        }
+
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Spending Trends",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                IconButton(onClick = { isTrendsExpanded = !isTrendsExpanded }) {
+                    Icon(
+                        imageVector = if (isTrendsExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = if (isTrendsExpanded) "Collapse" else "Expand"
                     )
                 }
+            }
+        }
+
+        if (isTrendsExpanded) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text("Summary", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                            
+                            Row {
+                                SpendingPeriod.entries.forEach { period ->
+                                    FilterChip(
+                                        selected = selectedPeriod == period,
+                                        onClick = { 
+                                            selectedPeriod = period 
+                                            selectedTrendPoint = null
+                                        },
+                                        label = { Text(period.name.lowercase().replaceFirstChar { it.uppercase() }) },
+                                        modifier = Modifier.padding(start = 4.dp)
+                                    )
+                                }
+                            }
+                        }
+                        
+                        Spacer(modifier = Modifier.height(16.dp))
+                        
+                        val trendData = uiState.spendingTrends[selectedPeriod] ?: emptyList()
+                        if (trendData.isNotEmpty()) {
+                            SimpleBarChart(
+                                data = trendData.map { BarData(it.label, it.value) },
+                                onBarClick = { barData ->
+                                    selectedTrendPoint = trendData.find { it.label == barData.label }
+                                },
+                                selectedBar = selectedTrendPoint?.let { BarData(it.label, it.value) },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        } else {
+                            Box(Modifier.fillMaxWidth().height(150.dp), contentAlignment = Alignment.Center) {
+                                Text("No data for this period")
+                            }
+                        }
+                    }
+                }
+            }
+
+            item {
+                AnimatedVisibility(visible = selectedTrendPoint != null) {
+                    selectedTrendPoint?.let { point ->
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+                        ) {
+                            Column(modifier = Modifier.padding(16.dp)) {
+                                Text(
+                                    text = "Details for ${point.label}",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.Bold
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween
+                                ) {
+                                    Column {
+                                        Text("Total spent", style = MaterialTheme.typography.labelSmall)
+                                        Text(
+                                            text = String.format(Locale.getDefault(), "$%.2f", point.value),
+                                            style = MaterialTheme.typography.headlineSmall,
+                                            fontWeight = FontWeight.Black
+                                        )
+                                    }
+                                    Column(horizontalAlignment = Alignment.End) {
+                                        Text("Transactions", style = MaterialTheme.typography.labelSmall)
+                                        Text(
+                                            text = "${point.transactionCount}",
+                                            style = MaterialTheme.typography.headlineSmall,
+                                            fontWeight = FontWeight.Black
+                                        )
+                                    }
+                                }
+                                val topCategory = point.topCategory
+                                if (topCategory != null) {
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    Text("Top Category", style = MaterialTheme.typography.labelSmall)
+                                    Text(
+                                        text = topCategory,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            Column {
+                Text(
+                    "Spending Heatmap",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                SpendingHeatmap(
+                    heatmapData = uiState.heatmapData,
+                    selectedDate = selectedHeatmapDate,
+                    onDayClick = { selectedHeatmapDate = it }
+                )
             }
         }
 
@@ -235,57 +325,6 @@ private fun AnalyticsContent(
                                 onClick = {}
                             )
                             Spacer(modifier = Modifier.height(8.dp))
-                        }
-                    }
-                }
-            }
-        }
-
-        item {
-            AnimatedVisibility(visible = selectedTrendPoint != null) {
-                selectedTrendPoint?.let { point ->
-                    Card(
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
-                    ) {
-                        Column(modifier = Modifier.padding(16.dp)) {
-                            Text(
-                                text = "Details for ${point.label}",
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.Bold
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween
-                            ) {
-                                Column {
-                                    Text("Total spent", style = MaterialTheme.typography.labelSmall)
-                                    Text(
-                                        text = String.format(Locale.getDefault(), "$%.2f", point.value),
-                                        style = MaterialTheme.typography.headlineSmall,
-                                        fontWeight = FontWeight.Black
-                                    )
-                                }
-                                Column(horizontalAlignment = Alignment.End) {
-                                    Text("Transactions", style = MaterialTheme.typography.labelSmall)
-                                    Text(
-                                        text = "${point.transactionCount}",
-                                        style = MaterialTheme.typography.headlineSmall,
-                                        fontWeight = FontWeight.Black
-                                    )
-                                }
-                            }
-                            val topCategory = point.topCategory
-                            if (topCategory != null) {
-                                Spacer(modifier = Modifier.height(8.dp))
-                                Text("Top Category", style = MaterialTheme.typography.labelSmall)
-                                Text(
-                                    text = topCategory,
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    fontWeight = FontWeight.Bold
-                                )
-                            }
                         }
                     }
                 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
@@ -46,10 +46,16 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.core.ui.components.BarData
 import com.zoewave.probase.core.ui.components.SimpleBarChart
+import com.zoewave.probase.seaweed.mobile.transaction.ui.components.SpendingHeatmap
+import com.zoewave.probase.seaweed.mobile.transaction.ui.components.TransactionItem
 import com.zoewave.probase.seaweed.model.HabitInsight
 import com.zoewave.probase.seaweed.model.SpendingPeriod
+import com.zoewave.probase.seaweed.model.Transaction
 import com.zoewave.probase.seaweed.model.TrendPoint
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import java.util.Locale
 
 @Composable
@@ -118,12 +124,23 @@ private fun AnalyticsContent(
 ) {
     var selectedPeriod by remember { mutableStateOf(SpendingPeriod.DAILY) }
     var selectedTrendPoint by remember { mutableStateOf<TrendPoint?>(null) }
+    var selectedHeatmapDate by remember { mutableStateOf<LocalDate?>(null) }
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
+        if (uiState.habitInsights.isNotEmpty()) {
+            item {
+                Text("Spending Habits", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            }
+            
+            items(uiState.habitInsights) { insight ->
+                HabitInsightCard(insight = insight)
+            }
+        }
+
         item {
             Card(
                 modifier = Modifier.fillMaxWidth(),
@@ -167,6 +184,57 @@ private fun AnalyticsContent(
                     } else {
                         Box(Modifier.fillMaxWidth().height(150.dp), contentAlignment = Alignment.Center) {
                             Text("No data for this period")
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        "Spending Heatmap",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    SpendingHeatmap(
+                        heatmapData = uiState.heatmapData,
+                        selectedDate = selectedHeatmapDate,
+                        onDayClick = { selectedHeatmapDate = it }
+                    )
+                }
+            }
+        }
+
+        item {
+            AnimatedVisibility(visible = selectedHeatmapDate != null) {
+                val zoneId = ZoneId.systemDefault()
+                val dayTransactions = uiState.allTransactions.filter {
+                    Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() == selectedHeatmapDate
+                }
+                
+                Column {
+                    Text(
+                        text = "Transactions for ${selectedHeatmapDate?.toString()}",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(vertical = 8.dp)
+                    )
+                    if (dayTransactions.isEmpty()) {
+                        Text("No transactions for this day", style = MaterialTheme.typography.bodyMedium)
+                    } else {
+                        dayTransactions.forEach { transaction ->
+                            TransactionItem(
+                                transaction = transaction,
+                                onDelete = {},
+                                onClick = {}
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
                         }
                     }
                 }
@@ -224,15 +292,7 @@ private fun AnalyticsContent(
             }
         }
 
-        if (uiState.habitInsights.isNotEmpty()) {
-            item {
-                Text("Spending Habits", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            }
-            
-            items(uiState.habitInsights) { insight ->
-                HabitInsightCard(insight = insight)
-            }
-        }
+        /* Spending Habits moved to the top */
     }
 }
 

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
@@ -35,10 +35,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -57,7 +60,6 @@ import com.zoewave.probase.seaweed.mobile.transaction.ui.components.SpendingHeat
 import com.zoewave.probase.seaweed.mobile.transaction.ui.components.TransactionItem
 import com.zoewave.probase.seaweed.model.HabitInsight
 import com.zoewave.probase.seaweed.model.SpendingPeriod
-import com.zoewave.probase.seaweed.model.Transaction
 import com.zoewave.probase.seaweed.model.TrendPoint
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
 import java.time.Instant
@@ -134,8 +136,8 @@ private fun AnalyticsContent(
     var selectedTrendPoint by remember { mutableStateOf<TrendPoint?>(null) }
     var selectedHeatmapDate by remember { mutableStateOf<LocalDate?>(null) }
     var isHabitsExpanded by remember { mutableStateOf(false) }
-    var isTrendsExpanded by remember { mutableStateOf(true) }
     var selectedCategory by remember { mutableStateOf<String?>(null) }
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
 
     val filteredTransactions = remember(selectedCategory, uiState.allTransactions) {
         if (selectedCategory == null) uiState.allTransactions
@@ -201,26 +203,26 @@ private fun AnalyticsContent(
         }
 
         item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+            TabRow(
+                selectedTabIndex = selectedTabIndex,
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.primary,
+                divider = { HorizontalDivider() }
             ) {
-                Text(
-                    "Spending Trends",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
+                Tab(
+                    selected = selectedTabIndex == 0,
+                    onClick = { selectedTabIndex = 0 },
+                    text = { Text("Trends") }
                 )
-                IconButton(onClick = { isTrendsExpanded = !isTrendsExpanded }) {
-                    Icon(
-                        imageVector = if (isTrendsExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                        contentDescription = if (isTrendsExpanded) "Collapse" else "Expand"
-                    )
-                }
+                Tab(
+                    selected = selectedTabIndex == 1,
+                    onClick = { selectedTabIndex = 1 },
+                    text = { Text("Heatmap") }
+                )
             }
         }
 
-        if (isTrendsExpanded) {
+        if (selectedTabIndex == 0) {
             item {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
@@ -322,46 +324,48 @@ private fun AnalyticsContent(
             }
         }
 
-        item {
-            Column {
-                Text(
-                    "Spending Heatmap",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(bottom = 16.dp)
-                )
-                SpendingHeatmap(
-                    heatmapData = heatmapData,
-                    selectedDate = selectedHeatmapDate,
-                    onDayClick = { selectedHeatmapDate = it }
-                )
-            }
-        }
-
-        item {
-            AnimatedVisibility(visible = selectedHeatmapDate != null) {
-                val zoneId = ZoneId.systemDefault()
-                val dayTransactions = filteredTransactions.filter {
-                    Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() == selectedHeatmapDate
-                }
-                
+        if (selectedTabIndex == 1) {
+            item {
                 Column {
                     Text(
-                        text = "Transactions for ${selectedHeatmapDate?.toString()}",
-                        style = MaterialTheme.typography.titleSmall,
+                        "Spending Heatmap",
+                        style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(vertical = 8.dp)
+                        modifier = Modifier.padding(bottom = 16.dp)
                     )
-                    if (dayTransactions.isEmpty()) {
-                        Text("No transactions for this day", style = MaterialTheme.typography.bodyMedium)
-                    } else {
-                        dayTransactions.forEach { transaction ->
-                            TransactionItem(
-                                transaction = transaction,
-                                onDelete = {},
-                                onClick = {}
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
+                    SpendingHeatmap(
+                        heatmapData = heatmapData,
+                        selectedDate = selectedHeatmapDate,
+                        onDayClick = { selectedHeatmapDate = it }
+                    )
+                }
+            }
+
+            item {
+                AnimatedVisibility(visible = selectedHeatmapDate != null) {
+                    val zoneId = ZoneId.systemDefault()
+                    val dayTransactions = filteredTransactions.filter {
+                        Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() == selectedHeatmapDate
+                    }
+                    
+                    Column {
+                        Text(
+                            text = "Transactions for ${selectedHeatmapDate?.toString()}",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(vertical = 8.dp)
+                        )
+                        if (dayTransactions.isEmpty()) {
+                            Text("No transactions for this day", style = MaterialTheme.typography.bodyMedium)
+                        } else {
+                            dayTransactions.forEach { transaction ->
+                                TransactionItem(
+                                    transaction = transaction,
+                                    onDelete = {},
+                                    onClick = {}
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                            }
                         }
                     }
                 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
@@ -24,6 +24,8 @@ data class AnalyticsUiState(
     val isLoading: Boolean = true,
     val spendingTrends: Map<SpendingPeriod, List<TrendPoint>> = emptyMap(),
     val habitInsights: List<HabitInsight> = emptyList(),
+    val heatmapData: Map<LocalDate, Double> = emptyMap(),
+    val allTransactions: List<Transaction> = emptyList(),
 )
 
 sealed interface AnalyticsUiEvent {
@@ -40,7 +42,9 @@ class AnalyticsViewModel @Inject constructor(
             AnalyticsUiState(
                 isLoading = false,
                 spendingTrends = calculateTrends(transactions),
-                habitInsights = calculateHabitInsights(transactions)
+                habitInsights = calculateHabitInsights(transactions),
+                heatmapData = calculateHeatmapData(transactions),
+                allTransactions = transactions
             )
         }.stateIn(
             scope = viewModelScope,
@@ -134,5 +138,15 @@ class AnalyticsViewModel @Inject constructor(
                     trendMessage = trendMessage
                 )
             }.sortedByDescending { it.totalAmount }
+    }
+
+    private fun calculateHeatmapData(transactions: List<Transaction>): Map<LocalDate, Double> {
+        val zoneId = ZoneId.systemDefault()
+        return transactions
+            .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
+            .groupBy { it.second }
+            .mapValues { (_, dailyTransactions) ->
+                dailyTransactions.sumOf { it.first.amount }
+            }
     }
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
@@ -2,7 +2,9 @@ package com.zoewave.probase.seaweed.mobile.transaction.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zoewave.probase.seaweed.data.BudgetTargetRepository
 import com.zoewave.probase.seaweed.data.TransactionRepository
+import com.zoewave.probase.seaweed.model.BudgetTarget
 import com.zoewave.probase.seaweed.model.HabitInsight
 import com.zoewave.probase.seaweed.model.SpendingPeriod
 import com.zoewave.probase.seaweed.model.Transaction
@@ -10,7 +12,7 @@ import com.zoewave.probase.seaweed.model.TrendPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import java.time.Instant
 import java.time.LocalDate
@@ -34,23 +36,26 @@ sealed interface AnalyticsUiEvent {
 
 @HiltViewModel
 class AnalyticsViewModel @Inject constructor(
-    private val repository: TransactionRepository
+    private val repository: TransactionRepository,
+    private val budgetRepository: BudgetTargetRepository
 ) : ViewModel() {
 
-    val uiState: StateFlow<AnalyticsUiState> = repository.getAllTransactions()
-        .map { transactions ->
-            AnalyticsUiState(
-                isLoading = false,
-                spendingTrends = calculateTrends(transactions),
-                habitInsights = calculateHabitInsights(transactions),
-                heatmapData = calculateHeatmapData(transactions),
-                allTransactions = transactions
-            )
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = AnalyticsUiState()
+    val uiState: StateFlow<AnalyticsUiState> = combine(
+        repository.getAllTransactions(),
+        budgetRepository.getAllBudgets()
+    ) { transactions, budgets ->
+        AnalyticsUiState(
+            isLoading = false,
+            spendingTrends = calculateTrends(transactions),
+            habitInsights = calculateHabitInsights(transactions, budgets),
+            heatmapData = calculateHeatmapData(transactions),
+            allTransactions = transactions
         )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = AnalyticsUiState()
+    )
 
     fun calculateTrendsForTransactions(transactions: List<Transaction>): Map<SpendingPeriod, List<TrendPoint>> {
         return calculateTrends(transactions)
@@ -113,7 +118,10 @@ class AnalyticsViewModel @Inject constructor(
         )
     }
 
-    private fun calculateHabitInsights(transactions: List<Transaction>): List<HabitInsight> {
+    private fun calculateHabitInsights(
+        transactions: List<Transaction>,
+        budgets: List<BudgetTarget>
+    ): List<HabitInsight> {
         if (transactions.isEmpty()) return emptyList()
         
         val zoneId = ZoneId.systemDefault()
@@ -143,7 +151,8 @@ class AnalyticsViewModel @Inject constructor(
                     frequency = frequency,
                     totalAmount = totalAmount,
                     dailyAverage = dailyAverage,
-                    trendMessage = trendMessage
+                    trendMessage = trendMessage,
+                    budgetLimit = budgets.find { it.categoryName == category }?.limitAmount
                 )
             }.sortedByDescending { it.totalAmount }
     }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
@@ -52,6 +52,14 @@ class AnalyticsViewModel @Inject constructor(
             initialValue = AnalyticsUiState()
         )
 
+    fun calculateTrendsForTransactions(transactions: List<Transaction>): Map<SpendingPeriod, List<TrendPoint>> {
+        return calculateTrends(transactions)
+    }
+
+    fun calculateHeatmapDataForTransactions(transactions: List<Transaction>): Map<LocalDate, Double> {
+        return calculateHeatmapData(transactions)
+    }
+
     private fun calculateTrends(transactions: List<Transaction>): Map<SpendingPeriod, List<TrendPoint>> {
         val zoneId = ZoneId.systemDefault()
         

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt
@@ -6,13 +6,21 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -40,15 +48,26 @@ fun SpendingHeatmap(
     val currentMonth = YearMonth.now()
     val months = (0 until monthsToDisplay).map { currentMonth.minusMonths(it.toLong()) }.reversed()
 
-    Column(modifier = modifier.fillMaxWidth()) {
-        months.forEach { month ->
-            MonthHeatmap(
-                month = month,
-                heatmapData = heatmapData,
-                selectedDate = selectedDate,
-                onDayClick = onDayClick,
-                modifier = Modifier.padding(bottom = 16.dp)
-            )
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(horizontal = 4.dp)
+    ) {
+        items(months) { month ->
+            Card(
+                modifier = Modifier.width(300.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                )
+            ) {
+                MonthHeatmap(
+                    month = month,
+                    heatmapData = heatmapData,
+                    selectedDate = selectedDate,
+                    onDayClick = onDayClick,
+                    modifier = Modifier.padding(12.dp)
+                )
+            }
         }
     }
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt
@@ -1,0 +1,165 @@
+package com.zoewave.probase.seaweed.mobile.transaction.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.util.Locale
+
+@Composable
+fun SpendingHeatmap(
+    heatmapData: Map<LocalDate, Double>,
+    modifier: Modifier = Modifier,
+    monthsToDisplay: Int = 3,
+    selectedDate: LocalDate? = null,
+    onDayClick: (LocalDate) -> Unit = {}
+) {
+    val currentMonth = YearMonth.now()
+    val months = (0 until monthsToDisplay).map { currentMonth.minusMonths(it.toLong()) }.reversed()
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        months.forEach { month ->
+            MonthHeatmap(
+                month = month,
+                heatmapData = heatmapData,
+                selectedDate = selectedDate,
+                onDayClick = onDayClick,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun MonthHeatmap(
+    month: YearMonth,
+    heatmapData: Map<LocalDate, Double>,
+    selectedDate: LocalDate?,
+    onDayClick: (LocalDate) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val daysInMonth = month.lengthOfMonth()
+    val firstDayOfMonth = month.atDay(1)
+    val firstDayOfWeek = firstDayOfMonth.dayOfWeek.value % 7 // 0 for Sunday, 1 for Monday, ..., 6 for Saturday
+    
+    val maxSpending = heatmapData.values.maxOrNull() ?: 1.0
+
+    Column(modifier = modifier) {
+        Text(
+            text = month.month.getDisplayName(TextStyle.FULL, Locale.getDefault()) + " " + month.year,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            DayOfWeek.entries.rotate(1).forEach { day ->
+                Text(
+                    text = day.getDisplayName(TextStyle.NARROW, Locale.getDefault()),
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.weight(1f),
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        var currentDay = 1
+        for (week in 0 until 6) {
+            if (currentDay > daysInMonth) break
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                for (dayOfWeek in 0 until 7) {
+                    val isDayInMonth = (week > 0 || dayOfWeek >= firstDayOfWeek) && currentDay <= daysInMonth
+                    if (isDayInMonth) {
+                        val date = month.atDay(currentDay)
+                        val spending = heatmapData[date] ?: 0.0
+                        DayBox(
+                            day = currentDay,
+                            intensity = (spending / maxSpending).toFloat(),
+                            isSelected = date == selectedDate,
+                            onClick = { onDayClick(date) },
+                            modifier = Modifier.weight(1f)
+                        )
+                        currentDay++
+                    } else {
+                        Spacer(modifier = Modifier.weight(1f).aspectRatio(1f))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun <T> List<T>.rotate(n: Int): List<T> {
+    if (isEmpty()) return this
+    val shift = n % size
+    return drop(shift) + take(shift)
+}
+
+@Composable
+private fun DayBox(
+    day: Int,
+    intensity: Float,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val baseColor = MaterialTheme.colorScheme.primary
+    val color = if (intensity == 0f) {
+        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f)
+    } else {
+        baseColor.copy(alpha = 0.2f + (intensity * 0.8f))
+    }
+
+    Box(
+        modifier = modifier
+            .padding(2.dp)
+            .aspectRatio(1f)
+            .clip(RoundedCornerShape(4.dp))
+            .background(color)
+            .border(
+                width = if (isSelected) 2.dp else 0.5.dp,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f),
+                shape = RoundedCornerShape(4.dp)
+            )
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = day.toString(),
+            fontSize = 10.sp,
+            color = if (intensity > 0.6f) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
+            fontWeight = if (intensity > 0f) FontWeight.Bold else FontWeight.Normal
+        )
+    }
+}

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt
@@ -16,9 +16,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -167,8 +167,8 @@ private fun DayBox(
             .clip(RoundedCornerShape(4.dp))
             .background(color)
             .border(
-                width = if (isSelected) 2.dp else 0.5.dp,
-                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f),
+                width = if (isSelected) 3.dp else 0.5.dp,
+                color = if (isSelected) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f),
                 shape = RoundedCornerShape(4.dp)
             )
             .clickable { onClick() },
@@ -177,8 +177,12 @@ private fun DayBox(
         Text(
             text = day.toString(),
             fontSize = 10.sp,
-            color = if (intensity > 0.6f) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
-            fontWeight = if (intensity > 0f) FontWeight.Bold else FontWeight.Normal
+            color = when {
+                isSelected -> MaterialTheme.colorScheme.onSecondaryContainer
+                intensity > 0.6f -> MaterialTheme.colorScheme.onPrimary
+                else -> MaterialTheme.colorScheme.onSurface
+            },
+            fontWeight = if (intensity > 0f || isSelected) FontWeight.Bold else FontWeight.Normal
         )
     }
 }

--- a/applications/seaweed/docs/GenAI/SpendingCal/implementation_Layout.md
+++ b/applications/seaweed/docs/GenAI/SpendingCal/implementation_Layout.md
@@ -1,0 +1,29 @@
+# Tabbed Analytics Insights
+
+Reorganize the Spending Analytics screen to use a tabbed layout for the main insights (Trends and Heatmap), while maintaining the Spending Habits at the top as a global filter.
+
+## Proposed Changes
+
+### [Transaction Feature]
+
+#### [AnalyticsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt)
+
+- Introduce a new state `selectedTabIndex` to manage the active tab (0 for Trends, 1 for Heatmap).
+- Add a `TabRow` below the Spending Habits section.
+- Define two tabs: "Trends" and "Heatmap".
+- Reorganize the `LazyColumn`:
+    - Spending Habits remain as items at the top.
+    - Add a `TabRow` as a sticky item or regular item.
+    - Show either Trends or Heatmap content based on the `selectedTabIndex`.
+- Remove the individual collapsible logic for Trends and Heatmap as the tabs provide the necessary organization.
+
+## Verification Plan
+
+### Automated Tests
+- Run Gradle assemble: `:applications:seaweed:apps:mobile:features:transaction:assembleDebug`.
+
+### Manual Verification
+- Deploy the app and navigate to **Spending Analytics**.
+- Verify that **Spending Habits** filter is still functional.
+- Switch between **Trends** and **Heatmap** tabs.
+- Confirm filtering works correctly in both tabs.

--- a/applications/seaweed/docs/GenAI/SpendingCal/implementation_cal.md
+++ b/applications/seaweed/docs/GenAI/SpendingCal/implementation_cal.md
@@ -1,0 +1,32 @@
+# Spending Heatmap Calendar Feature
+
+Implement a calendar-looking UI that visualizes daily spending trends using a heatmap. Darker colors represent higher spending days, while lighter colors represent lower spending days.
+
+## Proposed Changes
+
+### [Transaction Feature]
+
+#### [AnalyticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt)
+
+- Update `AnalyticsUiState` to include `heatmapData: Map<LocalDate, Double>`.
+- Implement `calculateHeatmapData` to group transactions by day for the last 3 months.
+
+#### [NEW] [SpendingHeatmap.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt)
+
+- Create a new Composable that renders a grid of days for a given month.
+- Each day will be colored based on the spending amount relative to the maximum spending in that period.
+
+#### [AnalyticsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt)
+
+- Integrate the `SpendingHeatmap` into the `AnalyticsContent` LazyColumn.
+
+## Verification Plan
+
+### Automated Tests
+- Add a unit test to `AnalyticsViewModelTest` (if it exists) or create one to verify the heatmap data calculation.
+
+### Manual Verification
+- Deploy the app and navigate to the "Spending Analytics" screen.
+- Verify that the heatmap calendar is displayed correctly.
+- Verify that days with higher spending are darker and days with lower/no spending are lighter.
+- Check if it helps identify patterns (e.g., higher spending on weekends or lunch M-F as mentioned by the user).

--- a/applications/seaweed/docs/GenAI/SpendingCal/implementation_cat.md
+++ b/applications/seaweed/docs/GenAI/SpendingCal/implementation_cat.md
@@ -1,0 +1,34 @@
+# Category-Based Filtering for Spending Analytics
+
+Implement cross-component filtering on the Spending Analytics page. Clicking on a "Spending Habit" (category) will filter the Trends chart, the Heatmap, and the Transaction details to show only data for that specific category.
+
+## Proposed Changes
+
+### [Transaction Feature]
+
+#### [AnalyticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt)
+
+- Update `AnalyticsUiState` to include `categoryHeatmapData: Map<String, Map<LocalDate, Double>>` and `categoryTrends: Map<String, Map<SpendingPeriod, List<TrendPoint>>>`.
+- This pre-calculates filtered data for each category to ensure smooth UI transitions.
+
+#### [AnalyticsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt)
+
+- Add local state `selectedCategory: String?` to track the active filter.
+- Update `HabitInsightCard` to be clickable and show a selection state (e.g., border).
+- Pass the filtered data (based on `selectedCategory`) to `SimpleBarChart` and `SpendingHeatmap`.
+- Update the daily transaction list logic to filter by `selectedCategory` when a day is selected in the heatmap.
+- Add a way to clear the filter (e.g., clicking the same habit again or a "Clear" button).
+
+## Verification Plan
+
+### Automated Tests
+- Run Gradle assemble to verify compilation.
+
+### Manual Verification
+- Deploy the app and navigate to **Spending Analytics**.
+- Click on a "Spending Habit" card (e.g., "Food").
+- Verify that:
+    - The **Spending Trends** chart updates to show only "Food" spending.
+    - The **Spending Heatmap** updates its intensity to show only "Food" transactions.
+    - Clicking a day in the filtered heatmap shows only "Food" transactions in the list.
+- Click the habit again to clear the filter and verify all components return to showing "All" data.

--- a/applications/seaweed/docs/GenAI/SpendingCal/implementation_spend_cal.md
+++ b/applications/seaweed/docs/GenAI/SpendingCal/implementation_spend_cal.md
@@ -1,0 +1,27 @@
+# Heatmap Selection Visibility Enhancement
+
+Improve the visual feedback for the selected day in the Spending Heatmap to ensure it is easily identifiable at a glance, even when scrolling.
+
+## Proposed Changes
+
+### [Transaction Feature]
+
+#### [SpendingHeatmap.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt)
+
+- Fix duplicate imports for `LazyRow` and `items`.
+- Update `DayBox` selection visuals:
+    - Change selection border color from `primary` to `secondary` (or `tertiary` for even more contrast).
+    - Increase selection border width from `2.dp` to `3.dp`.
+    - Apply a slight `scale(1.1f)` or `z-index` to the selected box to make it "float" above others if possible, or simply use the thick contrasting border.
+    - Ensure the text color within the selected box is high-contrast.
+
+## Verification Plan
+
+### Automated Tests
+- Run Gradle assemble to verify compilation.
+
+### Manual Verification
+- Deploy the app and navigate to **Spending Analytics**.
+- Click on various days in the heatmap.
+- Verify that the selected day is highly visible (thick contrasting border).
+- Scroll down to the transactions and glance back up to confirm the selected day remains easily identifiable.

--- a/applications/seaweed/docs/GenAI/SpendingCal/implementation_spending.md
+++ b/applications/seaweed/docs/GenAI/SpendingCal/implementation_spending.md
@@ -1,0 +1,35 @@
+# Spending Analytics UI Enhancements
+
+Improve the Spending Analytics screen by reordering components and adding interactive details to the Spending Heatmap.
+
+## Proposed Changes
+
+### [Transaction Feature]
+
+#### [AnalyticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt)
+
+- Update `AnalyticsUiState` to include `allTransactions: List<Transaction>`.
+- This will allow the UI to filter transactions for a specific day when clicked in the heatmap.
+
+#### [SpendingHeatmap.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt)
+
+- Add `onDayClick: (LocalDate) -> Unit` and `selectedDate: LocalDate?` parameters to `SpendingHeatmap`.
+- Make `DayBox` clickable and highlight the selected day.
+
+#### [AnalyticsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt)
+
+- Reorder the `LazyColumn` content to show **Spending Habits** at the top.
+- Add local state `selectedHeatmapDate` to track the clicked day in the heatmap.
+- Add an `AnimatedVisibility` block below the heatmap to show transactions for the selected day using `TransactionItem`.
+
+## Verification Plan
+
+### Automated Tests
+- Run Gradle assemble to verify compilation.
+
+### Manual Verification
+- Deploy the app and navigate to **Spending Analytics**.
+- Verify that **Spending Habits** are now at the top.
+- Click on a day in the **Spending Heatmap**.
+- Verify that the day is highlighted and a list of transactions for that day appears below the heatmap.
+- Click a different day and verify the list updates.

--- a/applications/seaweed/docs/GenAI/SpendingCal/walkthrough_Layout.md
+++ b/applications/seaweed/docs/GenAI/SpendingCal/walkthrough_Layout.md
@@ -1,0 +1,39 @@
+# Spending Heatmap Feature Walkthrough
+
+I have implemented a new Spending Heatmap feature for the Seaweed finance app. This feature provides a calendar-style visualization of daily spending, helping users identify trends and patterns.
+
+## Changes Made
+
+### Transaction Feature
+
+- **[AnalyticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt)**: Updated to calculate daily spending data for the heatmap and provide the full list of transactions for detailed view.
+- **[SpendingHeatmap.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt)**:
+    - Refactored to use a `LazyRow` for horizontal scrolling by month.
+    - Wrapped each month in a `Card` for better visual separation.
+    - **Selection Visibility**: Improved selection feedback with a thick `3.dp` `secondary` color border and high-contrast text for the selected day.
+- **[AnalyticsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt)**:
+    - Added collapsible "Spending Habits" and "Spending Trends" sections with expand/collapse toggles.
+    - Updated the layout to accommodate the new horizontal heatmap scroll.
+    - **Reordered Components**: Moved the Trend Chart details (day/week/month selection) to be positioned directly under the chart and above the Spending Heatmap.
+    - **Category Filtering**: Clicking on a Spending Habit now filters the entire analytics page (Trends, Heatmap, and Transaction list) to show data for that specific category.
+    - **Budget vs. Reality Overlay**: Each Spending Habit card now includes a progress bar showing spending relative to the category budget. The bar turns red when spending exceeds 90% of the budget.
+    - **Tabbed Navigation**: Reorganized the main analytics content into two tabs: **"Trends"** (bar charts and summaries) and **"Heatmap"** (calendar grid and daily details). This keeps the filter (Habits) always accessible while reducing visual clutter.
+
+### Settings Feature (Data Generation)
+
+- **[SettingsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt)**: Implemented `generateRandomTransactions` to create 150 random transactions across the last 90 days.
+- **[SettingsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsUiRoute.kt)**: Added a "Developer Options" section with a button to trigger the data generation.
+
+## Verification Summary
+
+### Automated Tests
+- Ran `:applications:seaweed:apps:mobile:features:transaction:assembleDebug` and `:applications:seaweed:apps:mobile:features:settings:assembleDebug` to ensure all changes compile correctly. Both builds finished successfully.
+
+### Manual Verification
+- Navigate to **Settings**.
+- Scroll down to **Developer Options**.
+- Click **Generate 3 Months of Random Data**.
+- Navigate to **Spending Analytics** to see the populated heatmap.
+
+> [!NOTE]
+> Since I cannot run the app and see the UI directly, I have verified the implementation through code review and successful compilation.

--- a/applications/seaweed/docs/GenAI/SpendingCal/walkthrough_cal.md
+++ b/applications/seaweed/docs/GenAI/SpendingCal/walkthrough_cal.md
@@ -1,0 +1,25 @@
+# Spending Heatmap Feature Walkthrough
+
+I have implemented a new Spending Heatmap feature for the Seaweed finance app. This feature provides a calendar-style visualization of daily spending, helping users identify trends and patterns.
+
+## Changes Made
+
+### Transaction Feature
+
+- **[AnalyticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt)**: Updated to calculate daily spending data for the heatmap.
+- **[SpendingHeatmap.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt)**: Created a new Composable component that renders a grid of days for the last 3 months. Each day's color intensity is proportional to the spending on that day relative to the maximum daily spending in the period.
+- **[AnalyticsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt)**: Integrated the `SpendingHeatmap` into the Spending Analytics screen.
+
+## Verification Summary
+
+### Automated Tests
+- Ran `:applications:seaweed:apps:mobile:features:transaction:assembleDebug` to ensure the changes compile correctly. The build finished successfully.
+
+### Manual Verification
+- The feature is integrated into the "Spending Analytics" screen.
+- Days with higher spending will appear in a darker shade of the primary color.
+- Days with no spending will appear as light gray boxes.
+- The heatmap displays the last 3 months of data.
+
+> [!NOTE]
+> Since I cannot run the app and see the UI directly, I have verified the implementation through code review and successful compilation.

--- a/applications/seaweed/docs/GenAI/SpendingCal/walkthrough_cat.md
+++ b/applications/seaweed/docs/GenAI/SpendingCal/walkthrough_cat.md
@@ -1,0 +1,37 @@
+# Spending Heatmap Feature Walkthrough
+
+I have implemented a new Spending Heatmap feature for the Seaweed finance app. This feature provides a calendar-style visualization of daily spending, helping users identify trends and patterns.
+
+## Changes Made
+
+### Transaction Feature
+
+- **[AnalyticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt)**: Updated to calculate daily spending data for the heatmap and provide the full list of transactions for detailed view.
+- **[SpendingHeatmap.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt)**:
+    - Refactored to use a `LazyRow` for horizontal scrolling by month.
+    - Wrapped each month in a `Card` for better visual separation.
+    - **Selection Visibility**: Improved selection feedback with a thick `3.dp` `secondary` color border and high-contrast text for the selected day.
+- **[AnalyticsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt)**:
+    - Added collapsible "Spending Habits" and "Spending Trends" sections with expand/collapse toggles.
+    - Updated the layout to accommodate the new horizontal heatmap scroll.
+    - **Reordered Components**: Moved the Trend Chart details (day/week/month selection) to be positioned directly under the chart and above the Spending Heatmap.
+    - **Category Filtering**: Clicking on a Spending Habit now filters the entire analytics page (Trends, Heatmap, and Transaction list) to show data for that specific category.
+
+### Settings Feature (Data Generation)
+
+- **[SettingsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt)**: Implemented `generateRandomTransactions` to create 150 random transactions across the last 90 days.
+- **[SettingsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsUiRoute.kt)**: Added a "Developer Options" section with a button to trigger the data generation.
+
+## Verification Summary
+
+### Automated Tests
+- Ran `:applications:seaweed:apps:mobile:features:transaction:assembleDebug` and `:applications:seaweed:apps:mobile:features:settings:assembleDebug` to ensure all changes compile correctly. Both builds finished successfully.
+
+### Manual Verification
+- Navigate to **Settings**.
+- Scroll down to **Developer Options**.
+- Click **Generate 3 Months of Random Data**.
+- Navigate to **Spending Analytics** to see the populated heatmap.
+
+> [!NOTE]
+> Since I cannot run the app and see the UI directly, I have verified the implementation through code review and successful compilation.

--- a/applications/seaweed/docs/GenAI/SpendingCal/walkthrough_color.md
+++ b/applications/seaweed/docs/GenAI/SpendingCal/walkthrough_color.md
@@ -1,0 +1,36 @@
+# Spending Heatmap Feature Walkthrough
+
+I have implemented a new Spending Heatmap feature for the Seaweed finance app. This feature provides a calendar-style visualization of daily spending, helping users identify trends and patterns.
+
+## Changes Made
+
+### Transaction Feature
+
+- **[AnalyticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt)**: Updated to calculate daily spending data for the heatmap and provide the full list of transactions for detailed view.
+- **[SpendingHeatmap.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/components/SpendingHeatmap.kt)**:
+    - Refactored to use a `LazyRow` for horizontal scrolling by month.
+    - Wrapped each month in a `Card` for better visual separation.
+    - **Selection Visibility**: Improved selection feedback with a thick `3.dp` `secondary` color border and high-contrast text for the selected day.
+- **[AnalyticsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt)**:
+    - Added collapsible "Spending Habits" and "Spending Trends" sections with expand/collapse toggles.
+    - Updated the layout to accommodate the new horizontal heatmap scroll.
+    - **Reordered Components**: Moved the Trend Chart details (day/week/month selection) to be positioned directly under the chart and above the Spending Heatmap.
+
+### Settings Feature (Data Generation)
+
+- **[SettingsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt)**: Implemented `generateRandomTransactions` to create 150 random transactions across the last 90 days.
+- **[SettingsUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsUiRoute.kt)**: Added a "Developer Options" section with a button to trigger the data generation.
+
+## Verification Summary
+
+### Automated Tests
+- Ran `:applications:seaweed:apps:mobile:features:transaction:assembleDebug` and `:applications:seaweed:apps:mobile:features:settings:assembleDebug` to ensure all changes compile correctly. Both builds finished successfully.
+
+### Manual Verification
+- Navigate to **Settings**.
+- Scroll down to **Developer Options**.
+- Click **Generate 3 Months of Random Data**.
+- Navigate to **Spending Analytics** to see the populated heatmap.
+
+> [!NOTE]
+> Since I cannot run the app and see the UI directly, I have verified the implementation through code review and successful compilation.

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/SpendingAnalytics.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/SpendingAnalytics.kt
@@ -17,7 +17,8 @@ data class HabitInsight(
     val frequency: Int,
     val totalAmount: Double,
     val dailyAverage: Double,
-    val trendMessage: String
+    val trendMessage: String,
+    val budgetLimit: Double? = null
 )
 
 enum class SpendingPeriod {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ android-minSdk = "34"
 android-targetSdk = "35"
 
 # -- Build Tools --
-agp = "9.2.0-alpha08"
+agp = "9.3.0-alpha01"
 kotlin = "2.3.0"
 # KSP version must match Kotlin version exactly
 ksp = "2.3.4"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 #Wed Jan 28 12:36:08 PST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionSha256Sum=be0a8f2e9f1c0f4d4764cc8903afcbce6c1134df8b980ae517583b18a0fce57b
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-milestone-7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
feat(home): implement scoped search for categories and projects

This commit introduces a scoped search feature on the home screen, allowing users to toggle between searching for categories and searching for specific projects and tasks.

- **`HomeViewModel.kt` & `HomeUiState.kt`**:
    - Introduced `SearchScope` enum to differentiate between `CATEGORIES` and `PROJECTS`.
    - Updated search logic to aggregate results from both project name matches and task content matches when in project search mode.
    - Implemented result deduplication using `distinctBy` on project IDs.
- **`HomeOverviewScreen.kt`**:
    - Added a `SingleChoiceSegmentedButtonRow` within the search bar to allow users to switch search scopes.
    - Implemented `ProjectSearchResultCard` to display matching projects along with a preview of up to three relevant tasks.
    - Updated the search bar placeholder to dynamically reflect the active search scope.
- **`HomeEvent.kt`**:
    - Added `OnSearchScopeChanged` to handle user interaction with the search scope toggle.
- **Resources**:
    - Added string resources for search scope labels and project-specific search placeholders.