### PR TITLE
Sea weed budget

### DIFF
--- a/applications/seaweed/apps/mobile/core/build.gradle.kts
+++ b/applications/seaweed/apps/mobile/core/build.gradle.kts
@@ -16,4 +16,6 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:util"))
     implementation(project(":applications:seaweed:model"))
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
 }

--- a/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/BudgetComponents.kt
+++ b/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/BudgetComponents.kt
@@ -1,4 +1,4 @@
-package com.zoewave.probase.seaweed.mobile.home.ui.components
+package com.zoewave.probase.seaweed.mobile.core.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/CategoryComponents.kt
+++ b/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/CategoryComponents.kt
@@ -1,11 +1,23 @@
-package com.zoewave.probase.seaweed.mobile.home.ui.components
+package com.zoewave.probase.seaweed.mobile.core.ui.components
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Category
-import androidx.compose.material3.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -14,7 +26,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.seaweed.model.CategoryOverview
 import java.util.Locale
@@ -124,31 +135,3 @@ val categoryColors = listOf(
 
 private val String.absoluteValue: Int
     get() = if (this.hashCode() == Int.MIN_VALUE) 0 else Math.abs(this.hashCode())
-
-@Preview(showBackground = true)
-@Composable
-private fun CategoryQuickJumpCardPreview() {
-    MaterialTheme {
-        CategoryQuickJumpCard(
-            category = CategoryOverview("Shopping", 250.0, 5, 500.0),
-            onClick = {},
-            modifier = Modifier.padding(16.dp)
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun DonutChartPreview() {
-    MaterialTheme {
-        DonutChart(
-            spendingByCategory = mapOf(
-                "Food" to 400.0,
-                "Coffee" to 150.0,
-                "Rent" to 1200.0,
-                "Entertainment" to 200.0
-            ),
-            modifier = Modifier.size(200.dp).padding(16.dp)
-        )
-    }
-}

--- a/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/FinancialProfileComponents.kt
+++ b/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/FinancialProfileComponents.kt
@@ -1,4 +1,4 @@
-package com.zoewave.probase.seaweed.mobile.home.ui.components
+package com.zoewave.probase.seaweed.mobile.core.ui.components
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -111,21 +111,5 @@ fun FixedCostsSummaryCard(
                 Text("$${String.format(Locale.getDefault(), "%.2f", startingBalance)}", style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Black)
             }
         }
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun RealMoneyHeroCardPreview() {
-    MaterialTheme {
-        RealMoneyHeroCard(flexibleRemaining = 1234.56, monthProgress = 0.65f, modifier = Modifier.padding(16.dp))
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun FixedCostsSummaryCardPreview() {
-    MaterialTheme {
-        FixedCostsSummaryCard(totalFixedCosts = 1500.0, income = 5000.0, navTo = {}, modifier = Modifier.padding(16.dp))
     }
 }

--- a/applications/seaweed/apps/mobile/features/budget/src/main/java/com/zoewave/probase/seaweed/mobile/budget/ui/BudgetUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/budget/src/main/java/com/zoewave/probase/seaweed/mobile/budget/ui/BudgetUiRoute.kt
@@ -1,45 +1,30 @@
 package com.zoewave.probase.seaweed.mobile.budget.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.zoewave.probase.seaweed.mobile.core.ui.components.CategoryBudgetProgressBar
+import com.zoewave.probase.seaweed.mobile.core.ui.components.UnallocatedMoneyCard
 import com.zoewave.probase.seaweed.model.CategoryOverview
+import com.zoewave.probase.seaweed.model.FinancialProfile
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
+import java.util.Locale
 
 @Composable
 fun BudgetUiRoute(
@@ -91,19 +76,49 @@ fun BudgetScreen(
                 }
             }
             is BudgetUiState.Success -> {
+                val profile = uiState.profile
+                var editingCategory by remember { mutableStateOf<CategoryOverview?>(null) }
+
                 LazyColumn(
                     modifier = Modifier.fillMaxSize().padding(padding),
                     contentPadding = PaddingValues(16.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    items(uiState.categories) { category ->
-                        BudgetItem(
-                            category = category,
-                            onUpdateLimit = { newLimit ->
-                                onEvent(BudgetUiEvent.UpdateBudget(category.name, newLimit))
-                            }
+                    item {
+                        BudgetSummaryCard(profile = profile)
+                    }
+
+                    item {
+                        UnallocatedMoneyCard(unallocatedAmount = profile.unallocatedMoney)
+                    }
+
+                    item {
+                        Text(
+                            text = "Category Budgets",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(top = 8.dp)
                         )
                     }
+
+                    items(profile.categoryOverviews) { category ->
+                        BudgetItem(
+                            category = category,
+                            onEdit = { editingCategory = it },
+                            onDelete = { onEvent(BudgetUiEvent.DeleteBudget(category.name)) }
+                        )
+                    }
+                }
+
+                if (editingCategory != null) {
+                    BudgetEditBottomSheet(
+                        category = editingCategory!!,
+                        onDismiss = { editingCategory = null },
+                        onSave = { limit ->
+                            onEvent(BudgetUiEvent.UpdateBudget(editingCategory!!.name, limit))
+                            editingCategory = null
+                        }
+                    )
                 }
             }
         }
@@ -111,60 +126,116 @@ fun BudgetScreen(
 }
 
 @Composable
-private fun BudgetItem(
-    category: CategoryOverview,
-    onUpdateLimit: (Double) -> Unit
-) {
-    var showDialog by remember { mutableStateOf(false) }
-    var limitInput by remember { mutableStateOf(category.limitAmount.toString()) }
-
+private fun BudgetSummaryCard(profile: FinancialProfile) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        onClick = { showDialog = true }
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+        )
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            Text(category.name, style = MaterialTheme.typography.titleMedium)
+            Text("Total Monthly Budget", style = MaterialTheme.typography.labelSmall)
+            Text(
+                text = "$${String.format(Locale.getDefault(), "%.2f", profile.totalBudgetedAmount)}",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Black
+            )
             Spacer(modifier = Modifier.height(8.dp))
             LinearProgressIndicator(
-                progress = { 
-                    val limit = category.limitAmount ?: 0.0
-                    (category.totalAmount / limit.coerceAtLeast(1.0)).toFloat() 
-                },
-                modifier = Modifier.fillMaxWidth(),
+                progress = { (profile.totalBudgetedAmount / profile.realStartingBalance).toFloat().coerceIn(0f, 1f) },
+                modifier = Modifier.fillMaxWidth().height(8.dp).clip(CircleShape),
+                color = MaterialTheme.colorScheme.primary,
+                trackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.1f)
             )
+            Text(
+                text = "$${String.format(Locale.getDefault(), "%.0f", profile.realStartingBalance)} available after fixed costs",
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun BudgetItem(
+    category: CategoryOverview,
+    onEdit: (CategoryOverview) -> Unit,
+    onDelete: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
             Row(
-                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-                horizontalArrangement = Arrangement.SpaceBetween
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top
             ) {
-                Text("Spent: $${category.totalAmount}", style = MaterialTheme.typography.bodySmall)
-                Text("Limit: $${category.limitAmount ?: "No limit"}", style = MaterialTheme.typography.bodySmall)
+                CategoryBudgetProgressBar(
+                    category = category,
+                    modifier = Modifier.weight(1f)
+                )
+                Row {
+                    IconButton(onClick = { onEdit(category) }) {
+                        Icon(Icons.Default.Edit, contentDescription = "Edit", modifier = Modifier.size(20.dp))
+                    }
+                    if (category.limitAmount != null) {
+                        IconButton(onClick = onDelete) {
+                            Icon(Icons.Default.Delete, contentDescription = "Delete", modifier = Modifier.size(20.dp))
+                        }
+                    }
+                }
             }
         }
     }
+}
 
-    if (showDialog) {
-        AlertDialog(
-            onDismissRequest = { showDialog = false },
-            title = { Text("Update Limit for ${category.name}") },
-            text = {
-                OutlinedTextField(
-                    value = limitInput,
-                    onValueChange = { limitInput = it },
-                    label = { Text("New Limit") }
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        limitInput.toDoubleOrNull()?.let { onUpdateLimit(it) }
-                        showDialog = false
-                    }
-                ) { Text("Save") }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDialog = false }) { Text("Cancel") }
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BudgetEditBottomSheet(
+    category: CategoryOverview,
+    onDismiss: () -> Unit,
+    onSave: (Double) -> Unit
+) {
+    var limitInput by remember { mutableStateOf(category.limitAmount?.toString() ?: "") }
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Set Budget for ${category.name}",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            
+            OutlinedTextField(
+                value = limitInput,
+                onValueChange = { limitInput = it },
+                label = { Text("Monthly Limit") },
+                modifier = Modifier.fillMaxWidth(),
+                prefix = { Text("$") }
+            )
+
+            Button(
+                onClick = {
+                    limitInput.toDoubleOrNull()?.let { onSave(it) }
+                },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = limitInput.toDoubleOrNull() != null
+            ) {
+                Text("Save Budget")
             }
-        )
+        }
     }
 }
 
@@ -174,9 +245,19 @@ private fun BudgetScreenPreview() {
     MaterialTheme {
         BudgetScreen(
             uiState = BudgetUiState.Success(
-                categories = listOf(
-                    CategoryOverview("Food", 42.0, 1, 100.0),
-                    CategoryOverview("Coffee", 15.0, 1, 50.0)
+                profile = FinancialProfile(
+                    monthlyIncome = 5000.0,
+                    totalFixedCosts = 1500.0,
+                    realStartingBalance = 3500.0,
+                    monthlyVariableSpending = 1200.0,
+                    flexibleMoneyRemaining = 2300.0,
+                    totalBudgetedAmount = 2000.0,
+                    unallocatedMoney = 1500.0,
+                    categoryOverviews = listOf(
+                        CategoryOverview("Food", 400.0, 15, 500.0, 100.0, 0.8f),
+                        CategoryOverview("Coffee", 150.0, 20, 100.0, -50.0, 1.5f)
+                    ),
+                    monthProgress = 0.5f
                 )
             ),
             onEvent = {},

--- a/applications/seaweed/apps/mobile/features/budget/src/main/java/com/zoewave/probase/seaweed/mobile/budget/ui/BudgetViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/budget/src/main/java/com/zoewave/probase/seaweed/mobile/budget/ui/BudgetViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.seaweed.data.FinancialRepository
 import com.zoewave.probase.seaweed.data.BudgetTargetRepository
 import com.zoewave.probase.seaweed.model.BudgetTarget
-import com.zoewave.probase.seaweed.model.CategoryOverview
+import com.zoewave.probase.seaweed.model.FinancialProfile
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -21,9 +21,9 @@ class BudgetViewModel @Inject constructor(
     val uiState: StateFlow<BudgetUiState> = _uiState.asStateFlow()
 
     init {
-        financialRepository.getCategoryOverviews()
-            .onEach { overviews ->
-                _uiState.value = BudgetUiState.Success(overviews)
+        financialRepository.getFinancialProfile()
+            .onEach { profile ->
+                _uiState.value = BudgetUiState.Success(profile)
             }
             .launchIn(viewModelScope)
     }
@@ -45,7 +45,7 @@ class BudgetViewModel @Inject constructor(
 
 sealed interface BudgetUiState {
     object Loading : BudgetUiState
-    data class Success(val categories: List<CategoryOverview>) : BudgetUiState
+    data class Success(val profile: FinancialProfile) : BudgetUiState
 }
 
 sealed interface BudgetUiEvent {

--- a/applications/seaweed/apps/mobile/features/home/build.gradle.kts
+++ b/applications/seaweed/apps/mobile/features/home/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(project(":core:util"))
     implementation(project(":applications:seaweed:model"))
     implementation(project(":applications:seaweed:data"))
+    implementation(project(":applications:seaweed:apps:mobile:core"))
     implementation(project(":applications:seaweed:features:main"))
     implementation(project(":applications:seaweed:apps:mobile:features:transaction"))
     implementation(libs.androidx.compose.material3)

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/CategoryGridRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/CategoryGridRoute.kt
@@ -1,12 +1,23 @@
 package com.zoewave.probase.seaweed.mobile.home.ui
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.*
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -14,12 +25,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.zoewave.probase.core.ui.R as CoreUiR
+import com.zoewave.probase.seaweed.mobile.core.ui.components.CategoryQuickJumpCard
 import com.zoewave.probase.seaweed.model.CategoryOverview
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
-import com.zoewave.probase.seaweed.mobile.core.ui.components.CategoryQuickJumpCard
+import com.zoewave.probase.core.ui.R as CoreUiR
 
 @Composable
 fun CategoryGridRoute(

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/CategoryGridRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/CategoryGridRoute.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.core.ui.R as CoreUiR
 import com.zoewave.probase.seaweed.model.CategoryOverview
 import com.zoewave.probase.seaweed.model.navigation.SeaweedDestination
-import com.zoewave.probase.seaweed.mobile.home.ui.components.CategoryQuickJumpCard
+import com.zoewave.probase.seaweed.mobile.core.ui.components.CategoryQuickJumpCard
 
 @Composable
 fun CategoryGridRoute(

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
@@ -42,11 +42,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.zoewave.probase.seaweed.mobile.home.ui.components.CategoryBudgetProgressBar
-import com.zoewave.probase.seaweed.mobile.home.ui.components.DonutChart
-import com.zoewave.probase.seaweed.mobile.home.ui.components.FixedCostsSummaryCard
-import com.zoewave.probase.seaweed.mobile.home.ui.components.RealMoneyHeroCard
-import com.zoewave.probase.seaweed.mobile.home.ui.components.UnallocatedMoneyCard
+import com.zoewave.probase.seaweed.mobile.core.ui.components.CategoryBudgetProgressBar
+import com.zoewave.probase.seaweed.mobile.core.ui.components.DonutChart
+import com.zoewave.probase.seaweed.mobile.core.ui.components.FixedCostsSummaryCard
+import com.zoewave.probase.seaweed.mobile.core.ui.components.RealMoneyHeroCard
+import com.zoewave.probase.seaweed.mobile.core.ui.components.UnallocatedMoneyCard
 import com.zoewave.probase.seaweed.mobile.transaction.ui.components.TransactionItem
 import com.zoewave.probase.seaweed.model.CategoryOverview
 import com.zoewave.probase.seaweed.model.Transaction

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeViewModel.kt
@@ -4,11 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.seaweed.data.FinancialRepository
 import com.zoewave.probase.seaweed.data.TransactionRepository
-import com.zoewave.probase.seaweed.model.Transaction
+import com.zoewave.probase.seaweed.data.TestDataGenerator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.UUID
@@ -17,21 +17,24 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val repository: TransactionRepository,
-    private val financialRepository: FinancialRepository
+    private val financialRepository: FinancialRepository,
+    private val testDataGenerator: TestDataGenerator
 ) : ViewModel() {
 
-    val uiState: StateFlow<HomeUiState> = financialRepository.getFinancialProfile()
-        .map { profile ->
-            HomeUiState.Success(
-                transactions = emptyList(), // We might need recent transactions here
-                categoriesSummary = profile.categoryOverviews,
-                monthlyIncome = profile.monthlyIncome,
-                totalFixedCosts = profile.totalFixedCosts,
-                flexibleMoneyRemaining = profile.flexibleMoneyRemaining,
-                unallocatedMoney = profile.unallocatedMoney,
-                monthProgress = profile.monthProgress
-            )
-        }.stateIn(
+    val uiState: StateFlow<HomeUiState> = combine(
+        financialRepository.getFinancialProfile(),
+        repository.getAllTransactions()
+    ) { profile, transactions ->
+        HomeUiState.Success(
+            transactions = transactions.sortedByDescending { it.date }.take(10),
+            categoriesSummary = profile.categoryOverviews,
+            monthlyIncome = profile.monthlyIncome,
+            totalFixedCosts = profile.totalFixedCosts,
+            flexibleMoneyRemaining = profile.flexibleMoneyRemaining,
+            unallocatedMoney = profile.unallocatedMoney,
+            monthProgress = profile.monthProgress
+        )
+    }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
             initialValue = HomeUiState.Loading
@@ -46,15 +49,7 @@ class HomeViewModel @Inject constructor(
             }
             HomeUiEvent.AddRandomTransaction -> {
                 viewModelScope.launch {
-                    val categories = listOf("Food", "Transport", "Rent", "Entertainment", "Salary", "Investment")
-                    val randomTransaction = Transaction(
-                        id = UUID.randomUUID().toString(),
-                        amount = (10..10000).random().toDouble() / 100.0 * (if ((0..1).random() == 0) 1 else -1),
-                        category = categories.random(),
-                        description = "Random transaction",
-                        date = System.currentTimeMillis() - (0..30L * 24 * 60 * 60 * 1000).random()
-                    )
-                    repository.addTransaction(randomTransaction)
+                    testDataGenerator.generateSingleRandomTransaction()
                 }
             }
             HomeUiEvent.OnBackClicked -> { /* Handled in Route */ }

--- a/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/settings/src/main/java/com/zoewave/probase/seaweed/mobile/settings/ui/SettingsViewModel.kt
@@ -2,8 +2,7 @@ package com.zoewave.probase.seaweed.mobile.settings.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.zoewave.probase.seaweed.data.BudgetTargetRepository
-import com.zoewave.probase.seaweed.data.TransactionRepository
+import com.zoewave.probase.seaweed.data.TestDataGenerator
 import com.zoewave.probase.seaweed.data.UserSettingsRepository
 import com.zoewave.probase.seaweed.model.BudgetTarget
 import com.zoewave.probase.seaweed.model.SeaweedThemeConfig
@@ -20,8 +19,7 @@ import kotlin.random.Random
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val userSettingsRepository: UserSettingsRepository,
-    private val transactionRepository: TransactionRepository,
-    private val budgetRepository: BudgetTargetRepository,
+    private val testDataGenerator: TestDataGenerator,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<SettingsUiState>(SettingsUiState.Loading)
@@ -49,55 +47,10 @@ class SettingsViewModel @Inject constructor(
                     userSettingsRepository.saveUserSettings(currentSettings.copy(monthlyIncome = event.income))
                 }
                 is SettingsUiEvent.GenerateTestData -> {
-                    generateRandomTransactions()
+                    testDataGenerator.generateThreeMonthsOfData()
                 }
                 is SettingsUiEvent.NavigateTo -> { /* Handled in Route */ }
             }
-        }
-    }
-
-    private suspend fun generateRandomTransactions() {
-        val categories = listOf("Food", "Transport", "Shopping", "Entertainment", "Health", "Utilities")
-        
-        // Generate random budgets first
-        categories.forEach { category ->
-            val limit = when (category) {
-                "Food" -> Random.nextDouble(300.0, 600.0)
-                "Transport" -> Random.nextDouble(100.0, 300.0)
-                "Shopping" -> Random.nextDouble(200.0, 800.0)
-                "Entertainment" -> Random.nextDouble(100.0, 400.0)
-                "Health" -> Random.nextDouble(50.0, 200.0)
-                "Utilities" -> Random.nextDouble(200.0, 500.0)
-                else -> 500.0
-            }
-            budgetRepository.saveBudget(BudgetTarget(category, limit))
-        }
-
-        val now = System.currentTimeMillis()
-        val ninetyDaysMillis = 90L * 24 * 60 * 60 * 1000
-
-        repeat(150) {
-            val randomTimeOffset = Random.nextLong(0, ninetyDaysMillis)
-            val date = now - randomTimeOffset
-            val category = categories.random()
-            val amount = when (category) {
-                "Food" -> Random.nextDouble(5.0, 50.0)
-                "Transport" -> Random.nextDouble(2.0, 30.0)
-                "Shopping" -> Random.nextDouble(10.0, 200.0)
-                "Entertainment" -> Random.nextDouble(10.0, 100.0)
-                "Health" -> Random.nextDouble(20.0, 150.0)
-                "Utilities" -> Random.nextDouble(50.0, 300.0)
-                else -> Random.nextDouble(1.0, 100.0)
-            }
-
-            val transaction = Transaction(
-                id = UUID.randomUUID().toString(),
-                amount = amount,
-                category = category,
-                description = "Random $category expense",
-                date = date
-            )
-            transactionRepository.addTransaction(transaction)
         }
     }
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsUiRoute.kt
@@ -135,7 +135,7 @@ private fun AnalyticsContent(
     var selectedPeriod by remember { mutableStateOf(SpendingPeriod.DAILY) }
     var selectedTrendPoint by remember { mutableStateOf<TrendPoint?>(null) }
     var selectedHeatmapDate by remember { mutableStateOf<LocalDate?>(null) }
-    var isHabitsExpanded by remember { mutableStateOf(false) }
+    var isHabitsExpanded by remember { mutableStateOf(true) }
     var selectedCategory by remember { mutableStateOf<String?>(null) }
     var selectedTabIndex by remember { mutableIntStateOf(0) }
 
@@ -345,7 +345,7 @@ private fun AnalyticsContent(
                 AnimatedVisibility(visible = selectedHeatmapDate != null) {
                     val zoneId = ZoneId.systemDefault()
                     val dayTransactions = filteredTransactions.filter {
-                        Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() == selectedHeatmapDate
+                        it.amount < 0 && Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() == selectedHeatmapDate
                     }
                     
                     Column {

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AnalyticsViewModel.kt
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.WeekFields
 import java.util.Locale
 import javax.inject.Inject
+import kotlin.math.absoluteValue
 
 data class AnalyticsUiState(
     val isLoading: Boolean = true,
@@ -67,15 +68,16 @@ class AnalyticsViewModel @Inject constructor(
 
     private fun calculateTrends(transactions: List<Transaction>): Map<SpendingPeriod, List<TrendPoint>> {
         val zoneId = ZoneId.systemDefault()
+        val expenses = transactions.filter { it.amount < 0 }
         
         // Daily Trends (last 7 days)
-        val daily = transactions
+        val daily = expenses
             .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
             .groupBy { it.second }
             .map { (date, dailyTransactions) ->
                 TrendPoint(
                     label = date.format(DateTimeFormatter.ofPattern("MMM dd")),
-                    value = dailyTransactions.sumOf { it.first.amount },
+                    value = dailyTransactions.sumOf { it.first.amount }.absoluteValue,
                     timestamp = dailyTransactions.first().first.date,
                     transactionCount = dailyTransactions.size,
                     topCategory = dailyTransactions.groupBy { it.first.category }.maxByOrNull { it.value.size }?.key
@@ -84,13 +86,13 @@ class AnalyticsViewModel @Inject constructor(
 
         // Weekly Trends (last 4 weeks)
         val weekFields = WeekFields.of(Locale.getDefault())
-        val weekly = transactions
+        val weekly = expenses
             .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
             .groupBy { it.second.get(weekFields.weekOfWeekBasedYear()) }
             .map { (week, weeklyTransactions) ->
                 TrendPoint(
                     label = "Week $week",
-                    value = weeklyTransactions.sumOf { it.first.amount },
+                    value = weeklyTransactions.sumOf { it.first.amount }.absoluteValue,
                     timestamp = weeklyTransactions.minOf { it.first.date },
                     transactionCount = weeklyTransactions.size,
                     topCategory = weeklyTransactions.groupBy { it.first.category }.maxByOrNull { it.value.size }?.key
@@ -98,13 +100,13 @@ class AnalyticsViewModel @Inject constructor(
             }.sortedBy { it.timestamp }.takeLast(4)
 
         // Monthly Trends (last 6 months)
-        val monthly = transactions
+        val monthly = expenses
             .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
             .groupBy { it.second.month }
             .map { (month, monthlyTransactions) ->
                 TrendPoint(
                     label = month.name.lowercase(Locale.ROOT).replaceFirstChar { it.uppercase() }.take(3),
-                    value = monthlyTransactions.sumOf { it.first.amount },
+                    value = monthlyTransactions.sumOf { it.first.amount }.absoluteValue,
                     timestamp = monthlyTransactions.minOf { it.first.date },
                     transactionCount = monthlyTransactions.size,
                     topCategory = monthlyTransactions.groupBy { it.first.category }.maxByOrNull { it.value.size }?.key
@@ -122,22 +124,23 @@ class AnalyticsViewModel @Inject constructor(
         transactions: List<Transaction>,
         budgets: List<BudgetTarget>
     ): List<HabitInsight> {
-        if (transactions.isEmpty()) return emptyList()
+        val expenses = transactions.filter { it.amount < 0 }
+        if (expenses.isEmpty()) return emptyList()
         
         val zoneId = ZoneId.systemDefault()
         val now = LocalDate.now(zoneId)
         val thirtyDaysAgo = now.minusDays(30)
         
-        val recentTransactions = transactions.filter {
+        val recentTransactions = expenses.filter {
             Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate().isAfter(thirtyDaysAgo)
         }
 
         return recentTransactions.groupBy { it.category }
             .mapNotNull { (category, categoryTransactions) ->
                 val frequency = categoryTransactions.size
-                if (frequency < 4) return@mapNotNull null
+                if (frequency < 1) return@mapNotNull null
                 
-                val totalAmount = categoryTransactions.sumOf { it.amount }
+                val totalAmount = categoryTransactions.sumOf { it.amount }.absoluteValue
                 val dailyAverage = totalAmount / 30.0
                 
                 val trendMessage = when {
@@ -159,11 +162,11 @@ class AnalyticsViewModel @Inject constructor(
 
     private fun calculateHeatmapData(transactions: List<Transaction>): Map<LocalDate, Double> {
         val zoneId = ZoneId.systemDefault()
-        return transactions
+        return transactions.filter { it.amount < 0 }
             .map { it to Instant.ofEpochMilli(it.date).atZone(zoneId).toLocalDate() }
             .groupBy { it.second }
             .mapValues { (_, dailyTransactions) ->
-                dailyTransactions.sumOf { it.first.amount }
+                dailyTransactions.sumOf { it.first.amount }.absoluteValue
             }
     }
 }

--- a/applications/seaweed/data/src/main/java/com/zoewave/probase/seaweed/data/TestDataGenerator.kt
+++ b/applications/seaweed/data/src/main/java/com/zoewave/probase/seaweed/data/TestDataGenerator.kt
@@ -1,0 +1,75 @@
+package com.zoewave.probase.seaweed.data
+
+import com.zoewave.probase.seaweed.model.BudgetTarget
+import com.zoewave.probase.seaweed.model.Transaction
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+@Singleton
+class TestDataGenerator @Inject constructor(
+    private val transactionRepository: TransactionRepository,
+    private val budgetRepository: BudgetTargetRepository,
+) {
+    private val categories = listOf("Food", "Transport", "Shopping", "Entertainment", "Health", "Utilities")
+
+    suspend fun generateThreeMonthsOfData() {
+        // Generate random budgets
+        categories.forEach { category ->
+            val limit = when (category) {
+                "Food" -> Random.nextDouble(300.0, 600.0)
+                "Transport" -> Random.nextDouble(100.0, 300.0)
+                "Shopping" -> Random.nextDouble(200.0, 800.0)
+                "Entertainment" -> Random.nextDouble(100.0, 400.0)
+                "Health" -> Random.nextDouble(50.0, 200.0)
+                "Utilities" -> Random.nextDouble(200.0, 500.0)
+                else -> 500.0
+            }
+            budgetRepository.saveBudget(BudgetTarget(category, limit))
+        }
+
+        val now = System.currentTimeMillis()
+        val ninetyDaysMillis = 90L * 24 * 60 * 60 * 1000
+
+        repeat(150) {
+            val randomTimeOffset = Random.nextLong(0, ninetyDaysMillis)
+            val date = now - randomTimeOffset
+            val category = categories.random()
+            
+            // Crucial: Use negative amounts for expenses to match the app logic
+            val amount = when (category) {
+                "Food" -> Random.nextDouble(5.0, 50.0)
+                "Transport" -> Random.nextDouble(2.0, 30.0)
+                "Shopping" -> Random.nextDouble(10.0, 200.0)
+                "Entertainment" -> Random.nextDouble(10.0, 100.0)
+                "Health" -> Random.nextDouble(20.0, 150.0)
+                "Utilities" -> Random.nextDouble(50.0, 300.0)
+                else -> Random.nextDouble(1.0, 100.0)
+            } * -1.0 
+
+            val transaction = Transaction(
+                id = UUID.randomUUID().toString(),
+                amount = amount,
+                category = category,
+                description = "Random $category expense",
+                date = date
+            )
+            transactionRepository.addTransaction(transaction)
+        }
+    }
+
+    suspend fun generateSingleRandomTransaction() {
+        val category = categories.random()
+        val amount = Random.nextDouble(5.0, 100.0) * -1.0
+        
+        val transaction = Transaction(
+            id = UUID.randomUUID().toString(),
+            amount = amount,
+            category = category,
+            description = "Quick random expense",
+            date = System.currentTimeMillis()
+        )
+        transactionRepository.addTransaction(transaction)
+    }
+}


### PR DESCRIPTION
feat(transaction): implement tabbed layout for spending analytics

This commit introduces a tabbed navigation structure to the Spending Analytics screen, separating "Trends" and "Heatmap" views to improve information density and usability.

- **`AnalyticsUiRoute.kt`**:
    - Replaced the collapsible "Spending Trends" section with a `TabRow` allowing users to switch between "Trends" and "Heatmap" views.
    - Introduced `selectedTabIndex` state to manage the visibility of analytics components.
    - Refactored the `LazyColumn` to conditionally render the Trend chart or the Spending Heatmap and daily transaction details based on the active tab.
    - Removed legacy `isTrendsExpanded` state and associated toggle icons.
- **Documentation**:
    - Added `implementation_Layout.md` outlining the proposed reorganization of the analytics UI.
    - Added `walkthrough_Layout.md` providing a comprehensive overview of the Spending Heatmap feature, category filtering, and developer data generation tools.