### PR TITLE
feat(categories): implement add and combine functionality

### DIFF
--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/CategoryGridRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/CategoryGridRoute.kt
@@ -2,8 +2,13 @@ package com.zoewave.probase.seaweed.mobile.home.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -11,8 +16,10 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Merge
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -21,10 +28,13 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -75,6 +86,8 @@ fun CategoryGridScreen(
 ) {
     var categoryToDelete by remember { mutableStateOf<String?>(null) }
     var showMenu by remember { mutableStateOf(false) }
+    var showAddDialog by remember { mutableStateOf(false) }
+    var showCombineSheet by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -97,20 +110,20 @@ fun CategoryGridScreen(
                     onDismissRequest = { showMenu = false }
                 ) {
                     DropdownMenuItem(
-                        text = { Text(stringResource(CoreUiR.string.core_ui_add_random_data)) },
+                        text = { Text("Add Category") },
                         onClick = {
-                            onEvent(HomeUiEvent.AddRandomTransaction)
+                            showAddDialog = true
                             showMenu = false
                         },
                         leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) }
                     )
                     DropdownMenuItem(
-                        text = { Text("Refresh") },
+                        text = { Text("Combine Categories") },
                         onClick = {
-                            onEvent(HomeUiEvent.Refresh)
+                            showCombineSheet = true
                             showMenu = false
                         },
-                        leadingIcon = { Icon(Icons.Default.Refresh, contentDescription = null) }
+                        leadingIcon = { Icon(Icons.Default.Merge, contentDescription = null) }
                     )
                 }
             }
@@ -138,6 +151,46 @@ fun CategoryGridScreen(
                             onDelete = { categoryToDelete = category.name }
                         )
                     }
+                }
+
+                if (showAddDialog) {
+                    var newCategoryName by remember { mutableStateOf("") }
+                    AlertDialog(
+                        onDismissRequest = { showAddDialog = false },
+                        title = { Text("Add New Category") },
+                        text = {
+                            OutlinedTextField(
+                                value = newCategoryName,
+                                onValueChange = { newCategoryName = it },
+                                label = { Text("Category Name") },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        },
+                        confirmButton = {
+                            TextButton(
+                                onClick = {
+                                    if (newCategoryName.isNotBlank()) {
+                                        onEvent(HomeUiEvent.AddCategory(newCategoryName))
+                                        showAddDialog = false
+                                    }
+                                }
+                            ) { Text("Add") }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showAddDialog = false }) { Text("Cancel") }
+                        }
+                    )
+                }
+
+                if (showCombineSheet) {
+                    CombineCategoriesBottomSheet(
+                        categories = uiState.categoriesSummary.map { it.name },
+                        onDismiss = { showCombineSheet = false },
+                        onCombine = { from, to ->
+                            onEvent(HomeUiEvent.CombineCategories(from, to))
+                            showCombineSheet = false
+                        }
+                    )
                 }
             }
         }
@@ -167,6 +220,95 @@ fun CategoryGridScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CombineCategoriesBottomSheet(
+    categories: List<String>,
+    onDismiss: () -> Unit,
+    onCombine: (String, String) -> Unit
+) {
+    var fromCategory by remember { mutableStateOf(categories.firstOrNull() ?: "") }
+    var toCategory by remember { mutableStateOf(categories.getOrNull(1) ?: categories.firstOrNull() ?: "") }
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text("Combine Categories", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+            Text("Move all transactions from one category into another.", style = MaterialTheme.typography.bodyMedium)
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                CategoryPicker(
+                    label = "From",
+                    selected = fromCategory,
+                    options = categories,
+                    onSelected = { fromCategory = it },
+                    modifier = Modifier.weight(1f)
+                )
+                CategoryPicker(
+                    label = "To",
+                    selected = toCategory,
+                    options = categories.filter { it != fromCategory },
+                    onSelected = { toCategory = it },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            Button(
+                onClick = { onCombine(fromCategory, toCategory) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = fromCategory.isNotBlank() && toCategory.isNotBlank() && fromCategory != toCategory
+            ) {
+                Text("Combine")
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryPicker(
+    label: String,
+    selected: String,
+    options: List<String>,
+    onSelected: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier = modifier) {
+        OutlinedTextField(
+            value = selected,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(label) },
+            modifier = Modifier.fillMaxWidth(),
+            trailingIcon = {
+                IconButton(onClick = { expanded = true }) {
+                    Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+                }
+            }
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option) },
+                    onClick = {
+                        onSelected(option)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun CategoryGridScreenPreview() {
@@ -175,23 +317,9 @@ private fun CategoryGridScreenPreview() {
             uiState = HomeUiState.Success(
                 categoriesSummary = listOf(
                     CategoryOverview("Food", 42.0, 1, 100.0),
-                    CategoryOverview("Coffee", 15.0, 1, 50.0),
-                    CategoryOverview("Transport", 80.0, 1, 150.0),
-                    CategoryOverview("Shopping", 250.0, 1, 500.0)
+                    CategoryOverview("Coffee", 15.0, 1, 50.0)
                 )
             ),
-            onEvent = {},
-            navTo = {}
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun CategoryGridScreenLoadingPreview() {
-    MaterialTheme {
-        CategoryGridScreen(
-            uiState = HomeUiState.Loading,
             onEvent = {},
             navTo = {}
         )

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiState.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiState.kt
@@ -19,7 +19,8 @@ sealed interface HomeUiState {
 sealed interface HomeUiEvent {
     data class DeleteTransaction(val id: String) : HomeUiEvent
     data class DeleteCategory(val category: String) : HomeUiEvent
+    data class AddCategory(val name: String) : HomeUiEvent
+    data class CombineCategories(val from: String, val to: String) : HomeUiEvent
     object AddRandomTransaction : HomeUiEvent
-    object Refresh : HomeUiEvent
     object OnBackClicked : HomeUiEvent
 }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeViewModel.kt
@@ -6,6 +6,7 @@ import com.zoewave.probase.seaweed.data.FinancialRepository
 import com.zoewave.probase.seaweed.data.TransactionRepository
 import com.zoewave.probase.seaweed.data.BudgetTargetRepository
 import com.zoewave.probase.seaweed.data.TestDataGenerator
+import com.zoewave.probase.seaweed.model.BudgetTarget
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -60,9 +61,16 @@ class HomeViewModel @Inject constructor(
                     budgetRepository.deleteBudget(event.category)
                 }
             }
-            HomeUiEvent.Refresh -> {
-                // The combine flow will automatically refresh if underlying flows emit.
-                // If we need a force refresh, we could trigger a dummy emit here.
+            is HomeUiEvent.AddCategory -> {
+                viewModelScope.launch {
+                    budgetRepository.saveBudget(BudgetTarget(event.name, 0.0))
+                }
+            }
+            is HomeUiEvent.CombineCategories -> {
+                viewModelScope.launch {
+                    repository.updateTransactionsCategory(event.from, event.to)
+                    budgetRepository.deleteBudget(event.from)
+                }
             }
             HomeUiEvent.OnBackClicked -> { /* Handled in Route */ }
         }

--- a/applications/seaweed/data/src/main/java/com/zoewave/probase/seaweed/data/TransactionRepository.kt
+++ b/applications/seaweed/data/src/main/java/com/zoewave/probase/seaweed/data/TransactionRepository.kt
@@ -9,4 +9,5 @@ interface TransactionRepository {
     suspend fun addTransaction(transaction: Transaction)
     suspend fun deleteTransaction(id: String)
     suspend fun deleteTransactionsByCategory(category: String)
+    suspend fun updateTransactionsCategory(fromCategory: String, toCategory: String)
 }

--- a/applications/seaweed/data/src/main/java/com/zoewave/probase/seaweed/data/TransactionRepositoryImpl.kt
+++ b/applications/seaweed/data/src/main/java/com/zoewave/probase/seaweed/data/TransactionRepositoryImpl.kt
@@ -30,4 +30,8 @@ class TransactionRepositoryImpl @Inject constructor(
     override suspend fun deleteTransactionsByCategory(category: String) {
         transactionDao.deleteTransactionsByCategory(category)
     }
+
+    override suspend fun updateTransactionsCategory(fromCategory: String, toCategory: String) {
+        transactionDao.updateTransactionsCategory(fromCategory, toCategory)
+    }
 }

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/TransactionDao.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/TransactionDao.kt
@@ -22,4 +22,7 @@ interface TransactionDao {
 
     @Query("DELETE FROM transactions WHERE category = :category")
     suspend fun deleteTransactionsByCategory(category: String)
+
+    @Query("UPDATE transactions SET category = :toCategory WHERE category = :fromCategory")
+    suspend fun updateTransactionsCategory(fromCategory: String, toCategory: String)
 }

--- a/applications/seaweed/docs/GenAI/Categories/implementation_cat_menu.md
+++ b/applications/seaweed/docs/GenAI/Categories/implementation_cat_menu.md
@@ -1,0 +1,60 @@
+# Category Management: Add & Combine
+
+Enhance the Categories screen with the ability to add new categories and combine existing ones. Combining categories will merge all transactions from one category into another.
+
+## Proposed Changes
+
+### [Data Module]
+
+#### [TransactionDao.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/TransactionDao.kt)
+
+- Add `@Query("UPDATE transactions SET category = :toCategory WHERE category = :fromCategory")` to handle transaction merging.
+
+#### [TransactionRepository.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/data/src/main/java/com/zoewave/probase/seaweed/data/TransactionRepository.kt)
+
+- Add `updateCategory(fromCategory: String, toCategory: String)` method.
+
+#### [TransactionRepositoryImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/data/src/main/java/com/zoewave/probase/seaweed/data/TransactionRepositoryImpl.kt)
+
+- Implement `updateCategory`.
+
+---
+
+### [Home Feature]
+
+#### [HomeUiState.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiState.kt)
+
+- Add `AddCategory(name: String)` and `CombineCategories(from: String, to: String)` events.
+- Remove `Refresh` and `AddRandomTransaction` (as requested).
+
+#### [HomeViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeViewModel.kt)
+
+- Implement `AddCategory`:
+    - This just needs to save a `BudgetTarget` with the new category name (limit 0) to ensure the category appears in lists.
+- Implement `CombineCategories`:
+    - Call `transactionRepository.updateCategory(from, to)`.
+    - Delete the `BudgetTarget` for the `from` category.
+
+#### [CategoryGridRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/CategoryGridRoute.kt)
+
+- Update FAB menu:
+    - Remove "Add Random Data" and "Refresh".
+    - Add "Add Category" and "Combine Categories".
+- Implement `AddCategoryDialog`:
+    - Simple text input for the new category name.
+- Implement `CombineCategoriesBottomSheet`:
+    - Use `ModalBottomSheet`.
+    - Provide two pickers (Dropdowns or similar) to select the source and destination categories.
+    - Confirm button to trigger the merge.
+
+## Verification Plan
+
+### Manual Verification
+- Navigate to **All Categories**.
+- Click FAB > **Add Category**.
+- Verify new category appears in the grid.
+- Click FAB > **Combine Categories**.
+- Select "Coffee" to merge into "Food".
+- Verify "Coffee" category disappears.
+- Verify "Food" category total now includes the previous "Coffee" transactions.
+- Check **Transactions** tab to confirm all "Coffee" items are now labeled "Food".

--- a/applications/seaweed/docs/GenAI/Categories/walkthrough_cat_menu.md
+++ b/applications/seaweed/docs/GenAI/Categories/walkthrough_cat_menu.md
@@ -1,0 +1,55 @@
+# Seaweed Financial App Enhancements Walkthrough
+
+I have implemented several major features and UI/UX improvements to the Seaweed finance app, focusing on data visualization, consistency, and intuitive budget management.
+
+## Key Changes
+
+### 1. Spending Heatmap & Analytics
+- **Interactive Calendar Grid**: A new calendar visualization in the "Analytics" screen that shows daily spending intensity over the last 3 months.
+- **Horizontal Navigation**: Heatmap months are arranged in a horizontally scrollable carousel for easy browsing.
+- **Deep Drill-Down**: Clicking any day in the heatmap highlights it and displays a detailed list of transactions for that specific day.
+- **Tabbed Layout**: Organized the analytics screen into **"Trends"** (charts) and **"Heatmap"** tabs to reduce clutter while keeping filters accessible.
+
+### 2. Category-Based Filtering
+- **Dynamic Dashboard**: Users can click on any "Spending Habit" card at the top of the Analytics screen to filter all charts and the heatmap for that specific category.
+- **Visual Feedback**: Active filters are clearly highlighted, making it easy to analyze specific spending patterns (e.g., "Food" or "Shopping").
+
+### 3. Budget Management Overhaul
+- **Summary Overview**: Added a high-level card showing total budgeted amount vs. real starting balance (income minus fixed costs).
+- **Modern Editing**: Replaced basic dialogs with a `ModalBottomSheet` for setting and updating category limits.
+- **Budget vs. Reality Overlay**: Habit cards now include a progress bar that turns **red** if spending exceeds 90% of the category budget.
+
+### 4. Data Consistency & Reliability
+- **Recent Transactions**: Fixed an issue where the main page showed no data; it now correctly displays the 10 most recent transactions.
+- **Accurate Analytics**: Refined the logic to ensure that only **Expenses** (amounts < 0) are used for "spending" visualizations, preventing income from skewing the charts.
+- **Restored Spending Habits**: Fixed an issue where the Spending Habits section was hidden by default or missing due to strict criteria. It is now expanded by default and includes all active categories from the last 30 days to act as a global filter.
+
+### 5. Developer Tools & Clean Up
+- **Centralized Mock Data**: Created a new `TestDataGenerator` class that centralizes the creation of test transactions and budgets.
+- **Improved Generation Logic**: Updated the generator to always use **negative amounts for expenses**. This ensures all generated data works perfectly with the "expenses-only" analytics and budget logic.
+- **Home Screen Alignment**: Updated the **[+]** button on the home screen to use the new centralized generator, ensuring that quick-add data is consistent with the full dataset generation.
+- **Code Clean-Up**: Removed redundant generation code from `SettingsViewModel` and `HomeViewModel`, significantly cleaning up the codebase.
+
+### 6. Interactive Category Management
+- **Add & Combine**: New features to create fresh categories and merge existing ones.
+- **Merge Logic**: Combining two categories automatically moves all transactions from the source to the destination and removes the source category.
+- **Cascading Deletion**: Deleting a category safely removes all associated transactions and budget targets with a confirmation prompt.
+- **Action FAB & Menu**: Centralized management actions under a new Floating Action Button on the "All Categories" screen.
+
+## Verification Summary
+
+### Automated Tests
+- Successfully ran Gradle builds for all affected modules:
+    - `:applications:seaweed:apps:mobile:features:home:assembleDebug`
+    - `:applications:seaweed:apps:mobile:features:transaction:assembleDebug`
+    - `:applications:seaweed:apps:mobile:features:budget:assembleDebug`
+    - `:applications:seaweed:apps:mobile:features:settings:assembleDebug`
+
+### Manual Verification
+1.  **Generate Data**: Go to **Settings** > **Developer Options** and click **Generate 3 Months of Random Data**.
+2.  **Home Screen**: Confirm that **Recent Transactions** appear at the bottom.
+3.  **Budget Screen**: Confirm the **Total Monthly Budget** summary and individual category progress bars.
+4.  **Analytics Screen**:
+    - Verify that **Spending Habits** are at the top and clickable.
+    - Switch between **Trends** and **Heatmap** tabs.
+    - Click a day in the heatmap and confirm the transaction list appears below.


### PR DESCRIPTION
This commit introduces the ability to create new categories and merge existing ones within the Seaweed finance app. Merging categories reassigns all associated transactions to a target category and cleans up the source category's budget configuration.

- **Data Layer**:
    - Added `updateTransactionsCategory` to `TransactionDao` and `TransactionRepository` to support bulk updates of transaction categories in the database.
- **`HomeViewModel.kt` & `HomeUiState.kt`**:
    - Introduced `AddCategory` and `CombineCategories` events.
    - Implemented logic to persist new categories by creating a `BudgetTarget` with a zero-limit.
    - Implemented merging logic that updates transaction history and deletes the legacy `BudgetTarget`.
- **`CategoryGridRoute.kt`**:
    - Updated the overflow menu to replace "Add Random Data" and "Refresh" with "Add Category" and "Combine Categories" actions.
    - Added `AddCategoryDialog` for simple name input.
    - Implemented `CombineCategoriesBottomSheet` using `ModalBottomSheet` and custom `CategoryPicker` components to facilitate the merging workflow.
- **Documentation**:
    - Added `implementation_cat_menu.md` and `walkthrough_cat_menu.md` to document the architecture and verification plan for these enhancements.