### PR TITLE
refactor: centralize theme management, externalize strings, and add u…

### DIFF
--- a/applications/photodo/apps/mobile/features/home/build.gradle.kts
+++ b/applications/photodo/apps/mobile/features/home/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("composetemplate.android.library.compose")
     id("composetemplate.android.hilt")
     id("composetemplate.kotlin.serialization")
+    id("composetemplate.test")
 }
 
 android {

--- a/applications/photodo/apps/mobile/features/home/src/test/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModelTest.kt
+++ b/applications/photodo/apps/mobile/features/home/src/test/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/HomeViewModelTest.kt
@@ -1,0 +1,88 @@
+package com.zoewave.probase.photodo.mobile.features.home.ui.components.home
+
+import com.google.common.truth.Truth.assertThat
+import com.zoewave.probase.applications.photodo.db.entity.CategoryEntity
+import com.zoewave.probase.applications.photodo.db.entity.CategoryWithProjectsAndTasks
+import com.zoewave.probase.applications.photodo.db.entity.ProjectEntity
+import com.zoewave.probase.applications.photodo.db.entity.ProjectWithTasks
+import com.zoewave.probase.applications.photodo.db.entity.TaskEntity
+import com.zoewave.probase.applications.photodo.db.repo.AppSettingsRepository
+import com.zoewave.probase.applications.photodo.db.repo.PhotoDoRepo
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var photoDoRepo: PhotoDoRepo
+    private lateinit var appSettingsRepository: AppSettingsRepository
+    private lateinit var viewModel: HomeViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        photoDoRepo = mockk()
+        appSettingsRepository = mockk()
+
+        every { photoDoRepo.getCategoriesWithProjectsAndTasks() } returns flowOf(emptyList())
+        every { appSettingsRepository.isAiEnabledFlow } returns flowOf(false)
+        every { appSettingsRepository.animationsEnabledFlow } returns flowOf(true)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is loading`() = runTest {
+        viewModel = HomeViewModel(photoDoRepo, appSettingsRepository)
+        assertThat(viewModel.uiState.value.isLoading).isTrue()
+    }
+
+    @Test
+    fun `when data is loaded, state is updated`() = runTest {
+        val category = CategoryEntity(categoryId = 1, name = "Work")
+        val project = ProjectEntity(projectId = 1, categoryId = 1, name = "Project 1", isUrgent = true)
+        val task = TaskEntity(taskId = 1, projectId = 1, text = "Task 1", isChecked = true)
+        
+        val projectWithTasks = ProjectWithTasks(project, listOf(task))
+        val categoryData = CategoryWithProjectsAndTasks(category, listOf(projectWithTasks))
+        
+        every { photoDoRepo.getCategoriesWithProjectsAndTasks() } returns flowOf(listOf(categoryData))
+        
+        viewModel = HomeViewModel(photoDoRepo, appSettingsRepository)
+        
+        advanceUntilIdle()
+        
+        val state = viewModel.uiState.value
+        assertThat(state.isLoading).isFalse()
+        assertThat(state.categories).hasSize(1)
+        assertThat(state.categories[0].name).isEqualTo("Work")
+        assertThat(state.categories[0].progressPercentage).isEqualTo(1.0f)
+        assertThat(state.urgentProjects).hasSize(1)
+        assertThat(state.urgentProjects[0].title).isEqualTo("Project 1")
+    }
+
+    @Test
+    fun `when category search query changes, state is updated`() = runTest {
+        viewModel = HomeViewModel(photoDoRepo, appSettingsRepository)
+        
+        viewModel.onEvent(HomeEvent.OnCategorySearchQueryChanged("test"))
+        
+        assertThat(viewModel.uiState.value.categorySearchQuery).isEqualTo("test")
+    }
+}

--- a/applications/photodo/apps/mobile/features/settings/build.gradle.kts
+++ b/applications/photodo/apps/mobile/features/settings/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
     // ✅ 2. Required for Type-Safe Navigation & Nav3
     id("composetemplate.kotlin.serialization")
+    id("composetemplate.test")
 }
 
 android {

--- a/applications/photodo/apps/mobile/features/tasks/build.gradle.kts
+++ b/applications/photodo/apps/mobile/features/tasks/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("composetemplate.android.library.compose")
     id("composetemplate.android.hilt")
     id("composetemplate.kotlin.serialization")
+    id("composetemplate.test")
 }
 
 android {

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/ProjectCard.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/ProjectCard.kt
@@ -54,9 +54,8 @@ import java.util.Locale
 fun ProjectCard(
     project: ProjectListUiModel,
     onEvent: (TasksEvent) -> Unit,
-    onDeleteClicked: (ProjectListUiModel) -> Unit,
     navTo: (PhotoTodoRoute?) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val errorColor = MaterialTheme.colorScheme.error
     val financialStatusColor = remember(project.isOverBudget, project.isNearBudgetLimit) {
@@ -125,7 +124,7 @@ fun ProjectCard(
                         )
                         if (project.progressText.isNotEmpty()) {
                             Text(
-                                text = " • ${project.progressText}",
+                                text = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_progress_label, project.progressText),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.padding(start = 4.dp)
@@ -133,13 +132,15 @@ fun ProjectCard(
                         }
                     }
                     // 🚀 The Dynamic "Smart Subtitle"
-                    val subtitleText = remember(project.categoryName, project.dueDateMillis) {
+                    val bulletSeparator = stringResource(R.string.applications_photodo_apps_mobile_features_tasks_bullet_separator)
+                    val subtitleText = remember(project.categoryName, project.dueDateMillis, bulletSeparator) {
                         buildString {
                             append(project.categoryName)
                             project.dueDateMillis?.let { dueDate ->
                                 val formatter = SimpleDateFormat("MMM dd", Locale.getDefault())
                                 val dateStr = formatter.format(Date(dueDate))
-                                append(" • $dateStr")
+                                append(bulletSeparator)
+                                append(dateStr)
                             }
                         }
                     }
@@ -254,7 +255,6 @@ fun ProjectCardPreview() {
                 thumbnailUri = "https://picsum.photos/200" // Added for preview
             ),
             onEvent = {},
-            onDeleteClicked = {},
             navTo = {}
         )
     }
@@ -277,7 +277,6 @@ fun ProjectCardBudgetPreview() {
                 totalTasksCount = 10
             ),
             onEvent = {},
-            onDeleteClicked = {},
             navTo = {}
         )
     }
@@ -300,7 +299,6 @@ fun ProjectCardUrgentOverBudgetPreview() {
                 totalTasksCount = 12
             ),
             onEvent = {},
-            onDeleteClicked = {},
             navTo = {}
         )
     }

--- a/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/TasksListScreen.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/components/TasksListScreen.kt
@@ -158,7 +158,6 @@ fun TasksListScreen(
                         ProjectCard(
                             project = project,
                             onEvent = onEvent, // Pass the channel straight down!
-                            onDeleteClicked = { onEvent(TasksEvent.OnProjectToDeleteChanged(it)) },
                             navTo = navTo
                         )
                     }

--- a/applications/photodo/apps/mobile/features/tasks/src/test/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksViewModelTest.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/test/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/TasksViewModelTest.kt
@@ -1,0 +1,89 @@
+package com.zoewave.probase.photodo.mobile.features.tasks.ui
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.zoewave.probase.applications.photodo.db.entity.CategoryEntity
+import com.zoewave.probase.applications.photodo.db.entity.CategoryWithProjectsAndTasks
+import com.zoewave.probase.applications.photodo.db.entity.ProjectEntity
+import com.zoewave.probase.applications.photodo.db.entity.ProjectWithTasks
+import com.zoewave.probase.applications.photodo.db.repo.PhotoDoRepo
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TasksViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repo: PhotoDoRepo
+    private lateinit var viewModel: TasksViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        repo = mockk()
+        every { repo.getCategoriesWithProjectsAndTasks() } returns flowOf(emptyList())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is loading`() = runTest {
+        viewModel = TasksViewModel(repo, SavedStateHandle())
+        assertThat(viewModel.uiState.value.isLoading).isTrue()
+    }
+
+    @Test
+    fun `when categories exist, first category is selected by default`() = runTest {
+        val category1 = CategoryEntity(categoryId = 1, name = "Cat 1")
+        val category2 = CategoryEntity(categoryId = 2, name = "Cat 2")
+        val data = listOf(
+            CategoryWithProjectsAndTasks(category1, emptyList()),
+            CategoryWithProjectsAndTasks(category2, emptyList())
+        )
+        
+        every { repo.getCategoriesWithProjectsAndTasks() } returns flowOf(data)
+        
+        viewModel = TasksViewModel(repo, SavedStateHandle())
+        
+        advanceUntilIdle()
+        
+        val state = viewModel.uiState.value
+        assertThat(state.isLoading).isFalse()
+        assertThat(state.categoryName).isEqualTo("Cat 1")
+        assertThat(state.categoryId).isEqualTo(1L)
+    }
+
+    @Test
+    fun `when categoryId is requested, that category is selected`() = runTest {
+        val category1 = CategoryEntity(categoryId = 1, name = "Cat 1")
+        val category2 = CategoryEntity(categoryId = 2, name = "Cat 2")
+        val data = listOf(
+            CategoryWithProjectsAndTasks(category1, emptyList()),
+            CategoryWithProjectsAndTasks(category2, emptyList())
+        )
+        
+        every { repo.getCategoriesWithProjectsAndTasks() } returns flowOf(data)
+        
+        viewModel = TasksViewModel(repo, SavedStateHandle(mapOf("categoryId" to 2L)))
+        
+        advanceUntilIdle()
+        
+        val state = viewModel.uiState.value
+        assertThat(state.categoryName).isEqualTo("Cat 2")
+        assertThat(state.categoryId).isEqualTo(2L)
+    }
+}

--- a/applications/photodo/apps/mobile/features/tasks/src/test/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailViewModelTest.kt
+++ b/applications/photodo/apps/mobile/features/tasks/src/test/java/com/zoewave/probase/photodo/mobile/features/tasks/ui/detail/TaskDetailViewModelTest.kt
@@ -1,0 +1,70 @@
+package com.zoewave.probase.photodo.mobile.features.tasks.ui.detail
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.zoewave.probase.applications.photodo.db.entity.ProjectDetails
+import com.zoewave.probase.applications.photodo.db.entity.ProjectEntity
+import com.zoewave.probase.applications.photodo.db.repo.AppSettingsRepository
+import com.zoewave.probase.applications.photodo.db.repo.PhotoDoRepo
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TaskDetailViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var photoDoRepo: PhotoDoRepo
+    private lateinit var appSettingsRepository: AppSettingsRepository
+    private lateinit var viewModel: TaskDetailViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        photoDoRepo = mockk()
+        appSettingsRepository = mockk()
+
+        every { photoDoRepo.getProjectDetails(any()) } returns flowOf(null)
+        every { appSettingsRepository.isAiEnabledFlow } returns flowOf(false)
+        every { appSettingsRepository.animationsEnabledFlow } returns flowOf(true)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `when expense is added, project spent amount is updated`() = runTest {
+        val projectId = 1L
+        val initialProject = ProjectEntity(projectId = projectId, categoryId = 1, name = "Test", currentSpend = 100.0)
+        val projectDetails = ProjectDetails(project = initialProject, tasks = emptyList(), photos = emptyList(), expenses = emptyList())
+        
+        every { photoDoRepo.getProjectDetails(projectId) } returns flowOf(projectDetails)
+        coEvery { photoDoRepo.upsertExpense(any()) } returns 1L
+        coEvery { photoDoRepo.updateProject(any()) } returns Unit
+        
+        viewModel = TaskDetailViewModel(photoDoRepo, appSettingsRepository, SavedStateHandle(mapOf("projectId" to projectId)))
+        advanceUntilIdle()
+        
+        viewModel.onEvent(TaskDetailEvent.OnAddExpenseClicked("New Expense", 50.0))
+        advanceUntilIdle()
+        
+        coVerify {
+            photoDoRepo.updateProject(match { it.currentSpend == 150.0 }) 
+        }
+    }
+}

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/MainActivity.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/MainActivity.kt
@@ -11,24 +11,21 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.firebase.Firebase
 import com.google.firebase.analytics.analytics
-import com.zoewave.probase.applications.photodo.db.repo.AppSettingsRepository
 import com.zoewave.probase.photodo.mobile.core.ui.theme.LocalPaneContrast
 import com.zoewave.probase.photodo.mobile.core.ui.theme.PhotoDoTheme
 import com.zoewave.probase.photodo.mobile.ui.components.PhotoDoMainScreen
+import com.zoewave.probase.photodo.mobile.ui.components.PhotoDoMainViewModel
+import com.zoewave.probase.photodo.mobile.ui.components.PhotoDoMainUiState
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
-    // 1. Inject the repo directly into the Activity to get the root state
-    @Inject
-    lateinit var appSettingsRepository: AppSettingsRepository
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,14 +42,11 @@ class MainActivity : ComponentActivity() {
 
         enableEdgeToEdge()
         setContent {
-
-            // 2. Collect the current theme state
-            val themePreference by appSettingsRepository.themePreferenceFlow.collectAsState(initial = "SYSTEM")
-            val palettePreference by appSettingsRepository.palettePreferenceFlow.collectAsState(initial = "DEFAULT") // NEW
-            val paneContrastPreference by appSettingsRepository.paneContrastFlow.collectAsState(initial = "TINTED")
+            val viewModel: PhotoDoMainViewModel = hiltViewModel()
+            val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
             // 3. Determine true/false for Dark Mode
-            val isDarkTheme = when (themePreference) {
+            val isDarkTheme = when (uiState.theme) {
                 "DARK" -> true
                 "LIGHT" -> false
                 else -> isSystemInDarkTheme() // "SYSTEM" fallback
@@ -61,15 +55,15 @@ class MainActivity : ComponentActivity() {
             // 4. Pass it to your beautiful custom theme!
             PhotoDoTheme(
                 darkTheme = isDarkTheme,
-                palette = palettePreference
+                palette = uiState.palette
             ) {
                 val windowSizeClass = calculateWindowSizeClass(this)
-                CompositionLocalProvider(LocalPaneContrast provides paneContrastPreference) {
+                CompositionLocalProvider(LocalPaneContrast provides uiState.paneContrast) {
                     Surface(
                         modifier = Modifier.fillMaxSize(),
                         color = MaterialTheme.colorScheme.background
                     ) {
-                        PhotoDoMainScreen(windowSizeClass = windowSizeClass)
+                        PhotoDoMainScreen(windowSizeClass = windowSizeClass, viewModel = viewModel)
                     }
                 }
             }

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/PhotoDoMainViewModel.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/ui/components/PhotoDoMainViewModel.kt
@@ -24,10 +24,16 @@ class PhotoDoMainViewModel @Inject constructor(
 
     val uiState: StateFlow<PhotoDoMainUiState> = combine(
         appSettingsRepository.isAiEnabledFlow,
+        appSettingsRepository.themePreferenceFlow,
+        appSettingsRepository.palettePreferenceFlow,
+        appSettingsRepository.paneContrastFlow,
         _backStack
-    ) { isAiEnabled, backStack ->
+    ) { isAiEnabled, theme, palette, contrast, backStack ->
         PhotoDoMainUiState(
             isAiEnabled = isAiEnabled,
+            theme = theme,
+            palette = palette,
+            paneContrast = contrast,
             backStack = backStack,
             currentRoute = backStack.lastOrNull() ?: PhotoTodoRoute.Home
         )
@@ -61,6 +67,9 @@ class PhotoDoMainViewModel @Inject constructor(
 
 data class PhotoDoMainUiState(
     val isAiEnabled: Boolean = false,
+    val theme: String = "SYSTEM",
+    val palette: String = "DEFAULT",
+    val paneContrast: String = "TINTED",
     val backStack: List<PhotoTodoRoute> = listOf(PhotoTodoRoute.Home),
     val currentRoute: PhotoTodoRoute = PhotoTodoRoute.Home
 )

--- a/applications/photodo/apps/wear/features/home/src/main/java/com/zoewave/probase/photodo/wear/features/home/HomeScreen.kt
+++ b/applications/photodo/apps/wear/features/home/src/main/java/com/zoewave/probase/photodo/wear/features/home/HomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
@@ -41,6 +42,7 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TitleCard
 import com.zoewave.probase.photodo.data.util.loadAssetAsBitmap
+import com.zoewave.probase.photodo.wear.features.home.R
 
 @Composable
 fun HomeScreen(
@@ -67,7 +69,7 @@ fun HomeScreen(
                     verticalArrangement = Arrangement.Center
                 ) {
                     Text(
-                        text = "Open PhotoDo on phone to sync",
+                        text = stringResource(R.string.applications_photodo_apps_wear_features_home_sync_phone),
                         textAlign = TextAlign.Center,
                         style = MaterialTheme.typography.bodyMedium
                     )
@@ -82,10 +84,10 @@ fun HomeScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Refresh,
-                            contentDescription = "Sync"
+                            contentDescription = stringResource(R.string.applications_photodo_apps_wear_features_home_sync_now)
                         )
                         Spacer(modifier = Modifier.width(6.dp))
-                        Text("Sync Now")
+                        Text(stringResource(R.string.applications_photodo_apps_wear_features_home_sync_now))
                     }
                 }
             }
@@ -97,7 +99,7 @@ fun HomeScreen(
                 ) {
                     item {
                         ListHeader {
-                            Text("Categories")
+                            Text(stringResource(R.string.applications_photodo_apps_wear_features_home_categories))
                         }
                     }
                     items(uiState.categories) { category ->
@@ -136,7 +138,7 @@ private fun CategoryItem(
         onClick = onClick,
         title = titleBlock,
         subtitle = {
-            Text("${category.completedTasks}/${category.totalTasks} tasks")
+            Text(stringResource(R.string.applications_photodo_apps_wear_features_home_tasks_count_format, category.completedTasks, category.totalTasks))
         },
         modifier = Modifier.fillMaxWidth()
     ) {

--- a/applications/photodo/apps/wear/features/home/src/main/res/values/strings.xml
+++ b/applications/photodo/apps/wear/features/home/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="applications_photodo_apps_wear_features_home_sync_phone">Open PhotoDo on phone to sync</string>
+    <string name="applications_photodo_apps_wear_features_home_sync_now">Sync Now</string>
+    <string name="applications_photodo_apps_wear_features_home_categories">Categories</string>
+    <string name="applications_photodo_apps_wear_features_home_tasks_count_format">%1$d/%2$d tasks</string>
+</resources>

--- a/applications/photodo/apps/wear/features/project/src/main/java/com/zoewave/probase/photodo/wear/features/project/ProjectListScreen.kt
+++ b/applications/photodo/apps/wear/features/project/src/main/java/com/zoewave/probase/photodo/wear/features/project/ProjectListScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
@@ -32,7 +33,7 @@ fun ProjectListScreen(
                 CircularProgressIndicator()
             }
             ProjectListUiState.Empty -> {
-                Text("No Projects Yet")
+                Text(stringResource(R.string.applications_photodo_apps_wear_features_project_no_projects))
             }
             is ProjectListUiState.Success -> {
                 ScalingLazyColumn(

--- a/applications/photodo/apps/wear/features/project/src/main/java/com/zoewave/probase/photodo/wear/features/project/ui/ProjectCard.kt
+++ b/applications/photodo/apps/wear/features/project/src/main/java/com/zoewave/probase/photodo/wear/features/project/ui/ProjectCard.kt
@@ -14,11 +14,13 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TitleCard
 import com.zoewave.probase.photodo.data.util.loadAssetAsBitmap
 import com.zoewave.probase.photodo.wear.features.project.ProjectWearUiModel
+import com.zoewave.probase.photodo.wear.features.project.R
 import java.util.Locale
 
 @Composable
@@ -71,7 +73,12 @@ fun ProjectCard(
                 contentScale = ContentScale.Crop
             )
         }
-        Text("Spent: $${String.format(Locale.getDefault(), "%.2f", project.currentSpend)}")
+        Text(
+            text = stringResource(
+                R.string.applications_photodo_apps_wear_features_project_spent_format, 
+                String.format(Locale.getDefault(), "%.2f", project.currentSpend)
+            )
+        )
     }
 }
 

--- a/applications/photodo/apps/wear/features/project/src/main/res/values/strings.xml
+++ b/applications/photodo/apps/wear/features/project/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="applications_photodo_apps_wear_features_project_no_projects">No Projects Yet</string>
+    <string name="applications_photodo_apps_wear_features_project_spent_format">Spent: $%1$s</string>
+</resources>

--- a/applications/photodo/apps/wear/features/task/src/main/java/com/zoewave/probase/photodo/wear/features/task/TaskDetailScreen.kt
+++ b/applications/photodo/apps/wear/features/task/src/main/java/com/zoewave/probase/photodo/wear/features/task/TaskDetailScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
@@ -68,7 +69,7 @@ fun TaskDetailScreen(
                 CircularProgressIndicator()
             }
             TaskDetailUiState.Empty -> {
-                Text("Project Not Found")
+                Text(stringResource(R.string.applications_photodo_apps_wear_features_task_project_not_found))
             }
             is TaskDetailUiState.Success -> {
                 ScalingLazyColumn(
@@ -93,7 +94,7 @@ fun TaskDetailScreen(
                             ) {
                                 Image(
                                     bitmap = bitmap.asImageBitmap(),
-                                    contentDescription = "Project Thumbnail",
+                                    contentDescription = stringResource(R.string.applications_photodo_apps_wear_features_task_thumbnail_cd),
                                     modifier = Modifier
                                         .size(140.dp)
                                         .rotate(90f)
@@ -108,7 +109,7 @@ fun TaskDetailScreen(
                     if (uiState.photoCount > 0) {
                         item {
                             Text(
-                                "Total Photos: ${uiState.photoCount}",
+                                text = stringResource(R.string.applications_photodo_apps_wear_features_task_photos_count_format, uiState.photoCount),
                                 style = MaterialTheme.typography.labelSmall,
                                 modifier = Modifier.padding(top = 4.dp, bottom = 4.dp)
                             )
@@ -118,7 +119,7 @@ fun TaskDetailScreen(
                     // --- TASKS ---
                     item {
                         Text(
-                            "Tasks",
+                            text = stringResource(R.string.applications_photodo_apps_wear_features_task_tasks),
                             style = MaterialTheme.typography.labelSmall,
                             modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
                         )

--- a/applications/photodo/apps/wear/features/task/src/main/res/values/strings.xml
+++ b/applications/photodo/apps/wear/features/task/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="applications_photodo_apps_wear_features_task_project_not_found">Project Not Found</string>
+    <string name="applications_photodo_apps_wear_features_task_thumbnail_cd">Project Thumbnail</string>
+    <string name="applications_photodo_apps_wear_features_task_photos_count_format">Total Photos: %1$d</string>
+    <string name="applications_photodo_apps_wear_features_task_tasks">Tasks</string>
+</resources>

--- a/build-logic/convention/src/main/kotlin/com/zoewave/probase/convention/FeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/zoewave/probase/convention/FeatureConventionPlugin.kt
@@ -10,6 +10,7 @@ class FeatureConventionPlugin : Plugin<Project> {
             pluginManager.apply {
                 apply("composetemplate.android.library")
                 apply("composetemplate.android.hilt")
+                apply("composetemplate.test")
             }
 
             dependencies {


### PR DESCRIPTION
…nit tests

This commit refactors theme state management, migrates hardcoded strings to resources for localization readiness, and introduces a unit testing suite for core ViewModels.

- **Theme & Main UI**:
    - Migrated theme, palette, and contrast preference logic from `MainActivity` to `PhotoDoMainViewModel`.
    - Updated `MainActivity` to observe UI state using `collectAsStateWithLifecycle` for better lifecycle awareness.
- **Localization & Cleanup**:
    - Replaced hardcoded strings with `stringResource` calls across Wear OS screens (`HomeScreen`, `ProjectListScreen`, `TaskDetailScreen`) and Mobile components (`ProjectCard`).
    - Added comprehensive string resources to Wear OS feature modules.
    - Simplified `ProjectCard` by removing the unused `onDeleteClicked` parameter.
- **Testing**:
    - Integrated the `composetemplate.test` plugin into the base feature convention plugin and individual feature modules.
    - Added `HomeViewModelTest`, `TasksViewModelTest`, and `TaskDetailViewModelTest` to verify initial states and business logic using MockK and Google Truth.