### PR TITLE
feat(photodo): externalize calendar strings and update home module de…

### DIFF
--- a/applications/photodo/apps/mobile/features/home/build.gradle.kts
+++ b/applications/photodo/apps/mobile/features/home/build.gradle.kts
@@ -15,7 +15,7 @@ android {
 dependencies {
     // --- Shared Core Projects ---
     // implementation(project(":core:model"))
-    // implementation(project(":core:ui"))
+    implementation(project(":core:ui"))
     // implementation(project(":core:network"))
     // implementation(project(":core:data"))
     implementation(project(":applications:photodo:db"))

--- a/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/OverviewSummaryCard.kt
+++ b/applications/photodo/apps/mobile/features/home/src/main/java/com/zoewave/probase/photodo/mobile/features/home/ui/components/home/OverviewSummaryCard.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.unit.dp
 import com.zoewave.probase.photodo.mobile.core.ui.theme.PhotoDoTheme
 import com.zoewave.probase.photodo.mobile.features.home.R
 import com.zoewave.probase.photodo.mobile.features.home.ui.components.categories.CategoryOverviewUiModel
-
 import com.zoewave.probase.core.ui.R as CoreUiR
 
 /**

--- a/applications/photodo/apps/mobile/features/tasks/src/main/res/values/strings.xml
+++ b/applications/photodo/apps/mobile/features/tasks/src/main/res/values/strings.xml
@@ -88,4 +88,6 @@
     <string name="applications_photodo_apps_mobile_features_tasks_category_template_home">Home</string>
     <string name="applications_photodo_apps_mobile_features_tasks_category_template_shopping">Shopping</string>
     <string name="applications_photodo_apps_mobile_features_tasks_category_template_travel">Travel</string>
+    <string name="applications_photodo_apps_mobile_features_tasks_progress_label"> • %1$s</string>
+    <string name="applications_photodo_apps_mobile_features_tasks_bullet_separator"> • </string>
 </resources>

--- a/applications/photodo/features/calendar/src/main/java/com/zoewave/probase/photodo/features/calendar/ui/PhotoDoCalendarScreen.kt
+++ b/applications/photodo/features/calendar/src/main/java/com/zoewave/probase/photodo/features/calendar/ui/PhotoDoCalendarScreen.kt
@@ -10,7 +10,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.zoewave.probase.photodo.features.calendar.R
 
 @Composable
 internal fun PhotoDoCalendarScreen(
@@ -23,7 +25,7 @@ internal fun PhotoDoCalendarScreen(
         modifier = modifier.fillMaxSize(),
         topBar = {
             Text(
-                text = "PhotoDo Calendar Sync",
+                text = stringResource(R.string.applications_photodo_features_calendar_title),
                 style = MaterialTheme.typography.headlineMedium,
                 modifier = Modifier.padding(16.dp)
             )
@@ -31,9 +33,15 @@ internal fun PhotoDoCalendarScreen(
     ) { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
             if (uiState.isLoading) {
-                Text("Loading sync status...", modifier = Modifier.padding(16.dp))
+                Text(
+                    text = stringResource(R.string.applications_photodo_features_calendar_loading), 
+                    modifier = Modifier.padding(16.dp)
+                )
             } else {
-                Text("Task synchronization logic coming soon.", modifier = Modifier.padding(16.dp))
+                Text(
+                    text = stringResource(R.string.applications_photodo_features_calendar_coming_soon), 
+                    modifier = Modifier.padding(16.dp)
+                )
             }
         }
     }

--- a/applications/photodo/features/calendar/src/main/res/values/strings.xml
+++ b/applications/photodo/features/calendar/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="applications_photodo_features_calendar_title">PhotoDo Calendar Sync</string>
+    <string name="applications_photodo_features_calendar_loading">Loading sync status&#8230;</string>
+    <string name="applications_photodo_features_calendar_coming_soon">Task synchronization logic coming soon.</string>
+</resources>


### PR DESCRIPTION
…pendencies

This commit moves hardcoded strings in the calendar feature to resource files and enables the `:core:ui` dependency for the home feature module.

- **`build.gradle.kts` (home)**:
    - Enabled the dependency on the `:core:ui` project.
- **`PhotoDoCalendarScreen.kt`**:
    - Replaced hardcoded text for the screen title, loading state, and placeholder content with `stringResource` lookups.
- **Resources**:
    - **Calendar**: Created `strings.xml` and defined keys for the sync title, loading status, and "coming soon" message.
    - **Tasks**: Added new string resources for task progress labels and bullet separators to support upcoming UI updates.
- **`OverviewSummaryCard.kt`**:
    - Performed minor code cleanup by removing unnecessary whitespace.