### PR TITLE
Seaweed

### DIFF
--- a/applications/photodo/docs/GenAI/Nav/implementation_card.md
+++ b/applications/photodo/docs/GenAI/Nav/implementation_card.md
@@ -1,0 +1,26 @@
+# Spending Analytics Visibility Promotion
+
+Promote Spending Analytics by adding a major, high-visibility entry point on the Home screen while maintaining the existing access point on the Transactions screen.
+
+## Proposed Changes
+
+### [Home Feature]
+
+#### [HomeUiRoute.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt)
+
+- **New "Analytics Highlight" Card**: Add a prominent card at the top of the Home screen (just below the Hero card) that summarizes recent trends and provides a large, clear button to "Explore Full Analytics".
+- **Visual Call-to-Action**: The card will use the `primary` color scheme to draw attention and include an icon (like `Icons.Default.Analytics`) to reinforce its purpose.
+- **Dynamic Content**: If possible, show a small snippet of information (e.g., "You've spent X this week, see patterns") to entice the user to click.
+
+### [Transaction Feature]
+
+- **No Changes Required**: The existing `Analytics` icon in the `TransactionsListPane` top app bar will be preserved as requested.
+
+## Verification Plan
+
+### Manual Verification
+1.  **Home Screen Check**: Launch the app and confirm the new **"Explore Spending Analytics"** card is highly visible and placed logically within the dashboard.
+2.  **Navigation Flow**:
+    - Click the new card on the **Home** screen -> Confirm it navigates to the **Spending Analytics** tabbed view.
+    - Go to the **Transactions** tab -> Click the analytics icon in the top bar -> Confirm it also navigates to the **Spending Analytics** view.
+3.  **Visual Consistency**: Ensure the new card follows the app's design language and doesn't clutter the compact mobile view.

--- a/applications/photodo/docs/GenAI/Nav/walkthrough_Front.md
+++ b/applications/photodo/docs/GenAI/Nav/walkthrough_Front.md
@@ -1,0 +1,55 @@
+# Seaweed Financial App Enhancements Walkthrough
+
+I have implemented several major features and UI/UX improvements to the Seaweed finance app, focusing on data visualization, consistency, and intuitive budget management.
+
+## Key Changes
+
+### 1. Spending Heatmap & Analytics
+- **Interactive Calendar Grid**: A new calendar visualization in the "Analytics" screen that shows daily spending intensity over the last 3 months.
+- **Horizontal Navigation**: Heatmap months are arranged in a horizontally scrollable carousel for easy browsing.
+- **Deep Drill-Down**: Clicking any day in the heatmap highlights it and displays a detailed list of transactions for that specific day.
+- **Tabbed Layout**: Organized the analytics screen into **"Trends"** (charts) and **"Heatmap"** tabs to reduce clutter while keeping filters accessible.
+
+### 2. Category-Based Filtering
+- **Dynamic Dashboard**: Users can click on any "Spending Habit" card at the top of the Analytics screen to filter all charts and the heatmap for that specific category.
+- **Visual Feedback**: Active filters are clearly highlighted, making it easy to analyze specific spending patterns (e.g., "Food" or "Shopping").
+
+### 3. Budget Management Overhaul
+- **Summary Overview**: Added a high-level card showing total budgeted amount vs. real starting balance (income minus fixed costs).
+- **Modern Editing**: Replaced basic dialogs with a `ModalBottomSheet` for setting and updating category limits.
+- **Budget vs. Reality Overlay**: Habit cards now include a progress bar that turns **red** if spending exceeds 90% of the category budget.
+
+### 4. Data Consistency & Reliability
+- **Recent Transactions**: Fixed an issue where the main page showed no data; it now correctly displays the 10 most recent transactions.
+- **Accurate Analytics**: Refined the logic to ensure that only **Expenses** (amounts < 0) are used for "spending" visualizations, preventing income from skewing the charts.
+- **Inclusive Spending Habits**: Fixed an issue where new categories were missing from the Analytics screen. The "Spending Habits" section now includes **all categories** you've created (from your budgets), even if they have no transactions yet. This ensures they are always available for filtering.
+
+### 5. Developer Tools & Clean Up
+- **Centralized Mock Data**: Created a new `TestDataGenerator` class that centralizes the creation of test transactions and budgets.
+- **Improved Generation Logic**: Updated the generator to always use **negative amounts for expenses**. This ensures all generated data works perfectly with the "expenses-only" analytics and budget logic.
+- **Home Screen Alignment**: Updated the **[+]** button on the home screen to use the new centralized generator, ensuring that quick-add data is consistent with the full dataset generation.
+- **Code Clean-Up**: Removed redundant generation code from `SettingsViewModel` and `HomeViewModel`, significantly cleaning up the codebase.
+
+### 6. Consolidate App Navigation
+- **Simplified Bottom Bar**: Reduced the navigation to three essential tabs: **Main**, **Transactions**, and **Settings**.
+- **Contextual Selection**: The bottom bar now intelligently highlights the primary tab even when browsing sub-features.
+- **Prominent Analytics Access**: Added a high-visibility **"Spending Insights" card** to the Home screen dashboard. This provides a direct, major entry point to the tabbed analytics and heatmap views, ensuring users don't miss these critical insights.
+- **Persistent Access**: Kept the secondary analytics icon in the Transactions top bar for convenience.
+
+## Verification Summary
+
+### Automated Tests
+- Successfully ran Gradle builds for all affected modules:
+    - `:applications:seaweed:apps:mobile:features:home:assembleDebug`
+    - `:applications:seaweed:apps:mobile:features:transaction:assembleDebug`
+    - `:applications:seaweed:apps:mobile:features:budget:assembleDebug`
+    - `:applications:seaweed:apps:mobile:features:settings:assembleDebug`
+
+### Manual Verification
+1.  **Generate Data**: Go to **Settings** > **Developer Options** and click **Generate 3 Months of Random Data**.
+2.  **Home Screen**: Confirm that **Recent Transactions** appear at the bottom.
+3.  **Budget Screen**: Confirm the **Total Monthly Budget** summary and individual category progress bars.
+4.  **Analytics Screen**:
+    - Verify that **Spending Habits** are at the top and clickable.
+    - Switch between **Trends** and **Heatmap** tabs.
+    - Click a day in the heatmap and confirm the transaction list appears below.

--- a/applications/photodo/docs/GenAI/Nav/walkthrough_NavCard.md
+++ b/applications/photodo/docs/GenAI/Nav/walkthrough_NavCard.md
@@ -1,0 +1,55 @@
+# Seaweed Financial App Enhancements Walkthrough
+
+I have implemented several major features and UI/UX improvements to the Seaweed finance app, focusing on data visualization, consistency, and intuitive budget management.
+
+## Key Changes
+
+### 1. Spending Heatmap & Analytics
+- **Interactive Calendar Grid**: A new calendar visualization in the "Analytics" screen that shows daily spending intensity over the last 3 months.
+- **Horizontal Navigation**: Heatmap months are arranged in a horizontally scrollable carousel for easy browsing.
+- **Deep Drill-Down**: Clicking any day in the heatmap highlights it and displays a detailed list of transactions for that specific day.
+- **Tabbed Layout**: Organized the analytics screen into **"Trends"** (charts) and **"Heatmap"** tabs to reduce clutter while keeping filters accessible.
+
+### 2. Category-Based Filtering
+- **Dynamic Dashboard**: Users can click on any "Spending Habit" card at the top of the Analytics screen to filter all charts and the heatmap for that specific category.
+- **Visual Feedback**: Active filters are clearly highlighted, making it easy to analyze specific spending patterns (e.g., "Food" or "Shopping").
+
+### 3. Budget Management Overhaul
+- **Summary Overview**: Added a high-level card showing total budgeted amount vs. real starting balance (income minus fixed costs).
+- **Modern Editing**: Replaced basic dialogs with a `ModalBottomSheet` for setting and updating category limits.
+- **Budget vs. Reality Overlay**: Habit cards now include a progress bar that turns **red** if spending exceeds 90% of the category budget.
+
+### 4. Data Consistency & Reliability
+- **Recent Transactions**: Fixed an issue where the main page showed no data; it now correctly displays the 10 most recent transactions.
+- **Accurate Analytics**: Refined the logic to ensure that only **Expenses** (amounts < 0) are used for "spending" visualizations, preventing income from skewing the charts.
+- **Inclusive Spending Habits**: Fixed an issue where new categories were missing from the Analytics screen. The "Spending Habits" section now includes **all categories** you've created (from your budgets), even if they have no transactions yet. This ensures they are always available for filtering.
+
+### 5. Developer Tools & Clean Up
+- **Centralized Mock Data**: Created a new `TestDataGenerator` class that centralizes the creation of test transactions and budgets.
+- **Improved Generation Logic**: Updated the generator to always use **negative amounts for expenses**. This ensures all generated data works perfectly with the "expenses-only" analytics and budget logic.
+- **Home Screen Alignment**: Updated the **[+]** button on the home screen to use the new centralized generator, ensuring that quick-add data is consistent with the full dataset generation.
+- **Code Clean-Up**: Removed redundant generation code from `SettingsViewModel` and `HomeViewModel`, significantly cleaning up the codebase.
+
+### 6. Consolidate App Navigation
+- **Simplified Bottom Bar**: Reduced the navigation to three essential tabs: **Main**, **Transactions**, and **Settings**.
+- **Contextual Selection**: The bottom bar now intelligently highlights the primary tab even when browsing sub-features.
+- **Prominent Analytics Access**: Integrated a compact, pink **"Analytics" mini-card** directly into the top-right corner of the **"Flexible Money Remaining"** card on the Home screen. This provides a high-visibility, branded entry point with a clear text label, ensuring users can easily identify and access their spending insights.
+- **Persistent Access**: Kept the secondary analytics icon in the Transactions top bar for convenience.
+
+## Verification Summary
+
+### Automated Tests
+- Successfully ran Gradle builds for all affected modules:
+    - `:applications:seaweed:apps:mobile:features:home:assembleDebug`
+    - `:applications:seaweed:apps:mobile:features:transaction:assembleDebug`
+    - `:applications:seaweed:apps:mobile:features:budget:assembleDebug`
+    - `:applications:seaweed:apps:mobile:features:settings:assembleDebug`
+
+### Manual Verification
+1.  **Generate Data**: Go to **Settings** > **Developer Options** and click **Generate 3 Months of Random Data**.
+2.  **Home Screen**: Confirm that **Recent Transactions** appear at the bottom.
+3.  **Budget Screen**: Confirm the **Total Monthly Budget** summary and individual category progress bars.
+4.  **Analytics Screen**:
+    - Verify that **Spending Habits** are at the top and clickable.
+    - Switch between **Trends** and **Heatmap** tabs.
+    - Click a day in the heatmap and confirm the transaction list appears below.

--- a/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/FinancialProfileComponents.kt
+++ b/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/FinancialProfileComponents.kt
@@ -1,12 +1,16 @@
 package com.zoewave.probase.seaweed.mobile.core.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -17,7 +21,8 @@ import java.util.Locale
 fun RealMoneyHeroCard(
     flexibleRemaining: Double,
     monthProgress: Float,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onAnalyticsClick: (() -> Unit)? = null
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -26,31 +31,52 @@ fun RealMoneyHeroCard(
             contentColor = MaterialTheme.colorScheme.onPrimaryContainer
         )
     ) {
-        Column(modifier = Modifier.padding(24.dp)) {
-            Text(
-                text = "Flexible Money Remaining",
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "$${String.format(Locale.getDefault(), "%.2f", flexibleRemaining)}",
-                style = MaterialTheme.typography.displayMedium,
-                fontWeight = FontWeight.Black
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            
-            Text(
-                text = "Month Progress",
-                style = MaterialTheme.typography.labelSmall,
-                modifier = Modifier.padding(bottom = 4.dp)
-            )
-            LinearProgressIndicator(
-                progress = { monthProgress },
-                modifier = Modifier.fillMaxWidth().height(8.dp),
-                color = MaterialTheme.colorScheme.primary,
-                trackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.1f)
-            )
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(24.dp)) {
+                Text(
+                    text = "Flexible Money Remaining",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "$${String.format(Locale.getDefault(), "%.2f", flexibleRemaining)}",
+                    style = MaterialTheme.typography.displayMedium,
+                    fontWeight = FontWeight.Black
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                
+                Text(
+                    text = "Month Progress",
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(bottom = 4.dp)
+                )
+                LinearProgressIndicator(
+                    progress = { monthProgress },
+                    modifier = Modifier.fillMaxWidth().height(8.dp).clip(CircleShape),
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.1f)
+                )
+            }
+
+            if (onAnalyticsClick != null) {
+                IconButton(
+                    onClick = onAnalyticsClick,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+                            shape = CircleShape
+                        )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Analytics,
+                        contentDescription = "Spending Analytics",
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
         }
     }
 }

--- a/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/FinancialProfileComponents.kt
+++ b/applications/seaweed/apps/mobile/core/src/main/java/com/zoewave/probase/seaweed/mobile/core/ui/components/FinancialProfileComponents.kt
@@ -22,7 +22,7 @@ fun RealMoneyHeroCard(
     flexibleRemaining: Double,
     monthProgress: Float,
     modifier: Modifier = Modifier,
-    onAnalyticsClick: (() -> Unit)? = null
+    trailingContent: @Composable (BoxScope.() -> Unit)? = null
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -59,22 +59,11 @@ fun RealMoneyHeroCard(
                 )
             }
 
-            if (onAnalyticsClick != null) {
-                IconButton(
-                    onClick = onAnalyticsClick,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(8.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
-                            shape = CircleShape
-                        )
+            if (trailingContent != null) {
+                Box(
+                    modifier = Modifier.align(Alignment.TopEnd)
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Analytics,
-                        contentDescription = "Spending Analytics",
-                        tint = MaterialTheme.colorScheme.primary
-                    )
+                    trailingContent()
                 }
             }
         }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
@@ -1,5 +1,6 @@
 package com.zoewave.probase.seaweed.mobile.home.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,9 +15,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -36,6 +39,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -146,6 +150,7 @@ private fun HomeExpandedContent(
                 flexibleRemaining = uiState.flexibleMoneyRemaining,
                 monthProgress = uiState.monthProgress
             )
+            AnalyticsPromotionCard(navTo = navTo)
             OverviewSummaryCard(
                 categories = uiState.categoriesSummary,
                 navTo = navTo
@@ -211,6 +216,9 @@ private fun HomeCompactContent(
             )
         }
         item {
+            AnalyticsPromotionCard(navTo = navTo)
+        }
+        item {
             FixedCostsSummaryCard(
                 totalFixedCosts = uiState.totalFixedCosts,
                 income = uiState.monthlyIncome,
@@ -246,6 +254,62 @@ private fun HomeCompactContent(
                 transaction = transaction,
                 onDelete = { onEvent(HomeUiEvent.DeleteTransaction(transaction.id)) },
                 onClick = { navTo(SeaweedDestination.Transactions(category = null, transactionId = transaction.id)) }
+            )
+        }
+    }
+}
+
+@Composable
+fun AnalyticsPromotionCard(
+    navTo: (SeaweedDestination) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = { navTo(SeaweedDestination.Analytics) },
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer
+        ),
+        shape = RoundedCornerShape(24.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.tertiary),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Default.Analytics,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onTertiary,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+            
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Spending Insights",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = "See trends and habits over the last 3 months",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f)
+                )
+            }
+            
+            Icon(
+                Icons.Default.ChevronRight,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp)
             )
         }
     }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
@@ -148,7 +148,12 @@ private fun HomeExpandedContent(
             RealMoneyHeroCard(
                 flexibleRemaining = uiState.flexibleMoneyRemaining,
                 monthProgress = uiState.monthProgress,
-                onAnalyticsClick = { navTo(SeaweedDestination.Analytics) }
+                trailingContent = {
+                    AnalyticsPromotionCard(
+                        onClick = { navTo(SeaweedDestination.Analytics) },
+                        modifier = Modifier.padding(12.dp)
+                    )
+                }
             )
             OverviewSummaryCard(
                 categories = uiState.categoriesSummary,
@@ -212,7 +217,12 @@ private fun HomeCompactContent(
             RealMoneyHeroCard(
                 flexibleRemaining = uiState.flexibleMoneyRemaining,
                 monthProgress = uiState.monthProgress,
-                onAnalyticsClick = { navTo(SeaweedDestination.Analytics) }
+                trailingContent = {
+                    AnalyticsPromotionCard(
+                        onClick = { navTo(SeaweedDestination.Analytics) },
+                        modifier = Modifier.padding(12.dp)
+                    )
+                }
             )
         }
         item {
@@ -251,6 +261,35 @@ private fun HomeCompactContent(
                 transaction = transaction,
                 onDelete = { onEvent(HomeUiEvent.DeleteTransaction(transaction.id)) },
                 onClick = { navTo(SeaweedDestination.Transactions(category = null, transactionId = transaction.id)) }
+            )
+        }
+    }
+}
+
+@Composable
+fun AnalyticsPromotionCard(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.size(48.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer
+        ),
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Analytics,
+                contentDescription = "Spending Insights",
+                modifier = Modifier.size(24.dp),
+                tint = MaterialTheme.colorScheme.tertiary
             )
         }
     }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -43,6 +44,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.seaweed.mobile.home.R
@@ -273,7 +275,7 @@ fun AnalyticsPromotionCard(
 ) {
     Card(
         onClick = onClick,
-        modifier = modifier.size(48.dp),
+        modifier = modifier.width(64.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.tertiaryContainer,
             contentColor = MaterialTheme.colorScheme.onTertiaryContainer
@@ -281,15 +283,25 @@ fun AnalyticsPromotionCard(
         shape = RoundedCornerShape(12.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp, horizontal = 4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
             Icon(
                 imageVector = Icons.Default.Analytics,
                 contentDescription = "Spending Insights",
                 modifier = Modifier.size(24.dp),
                 tint = MaterialTheme.colorScheme.tertiary
+            )
+            Text(
+                text = "Analytics",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                fontSize = 10.sp,
+                color = MaterialTheme.colorScheme.tertiary
             )
         }
     }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
@@ -1,6 +1,5 @@
 package com.zoewave.probase.seaweed.mobile.home.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -148,9 +147,9 @@ private fun HomeExpandedContent(
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(24.dp)) {
             RealMoneyHeroCard(
                 flexibleRemaining = uiState.flexibleMoneyRemaining,
-                monthProgress = uiState.monthProgress
+                monthProgress = uiState.monthProgress,
+                onAnalyticsClick = { navTo(SeaweedDestination.Analytics) }
             )
-            AnalyticsPromotionCard(navTo = navTo)
             OverviewSummaryCard(
                 categories = uiState.categoriesSummary,
                 navTo = navTo
@@ -212,11 +211,9 @@ private fun HomeCompactContent(
         item {
             RealMoneyHeroCard(
                 flexibleRemaining = uiState.flexibleMoneyRemaining,
-                monthProgress = uiState.monthProgress
+                monthProgress = uiState.monthProgress,
+                onAnalyticsClick = { navTo(SeaweedDestination.Analytics) }
             )
-        }
-        item {
-            AnalyticsPromotionCard(navTo = navTo)
         }
         item {
             FixedCostsSummaryCard(
@@ -254,62 +251,6 @@ private fun HomeCompactContent(
                 transaction = transaction,
                 onDelete = { onEvent(HomeUiEvent.DeleteTransaction(transaction.id)) },
                 onClick = { navTo(SeaweedDestination.Transactions(category = null, transactionId = transaction.id)) }
-            )
-        }
-    }
-}
-
-@Composable
-fun AnalyticsPromotionCard(
-    navTo: (SeaweedDestination) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        onClick = { navTo(SeaweedDestination.Analytics) },
-        modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-            contentColor = MaterialTheme.colorScheme.onTertiaryContainer
-        ),
-        shape = RoundedCornerShape(24.dp)
-    ) {
-        Row(
-            modifier = Modifier.padding(20.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.tertiary),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    Icons.Default.Analytics,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onTertiary,
-                    modifier = Modifier.size(24.dp)
-                )
-            }
-            
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = "Spending Insights",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
-                )
-                Text(
-                    text = "See trends and habits over the last 3 months",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f)
-                )
-            }
-            
-            Icon(
-                Icons.Default.ChevronRight,
-                contentDescription = null,
-                modifier = Modifier.size(20.dp)
             )
         }
     }

--- a/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/home/src/main/java/com/zoewave/probase/seaweed/mobile/home/ui/HomeUiRoute.kt
@@ -281,7 +281,12 @@ fun AnalyticsPromotionCard(
             contentColor = MaterialTheme.colorScheme.onTertiaryContainer
         ),
         shape = RoundedCornerShape(12.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 6.dp,
+            pressedElevation = 2.dp,
+            focusedElevation = 8.dp,
+            hoveredElevation = 8.dp
+        )
     ) {
         Column(
             modifier = Modifier
@@ -294,14 +299,14 @@ fun AnalyticsPromotionCard(
                 imageVector = Icons.Default.Analytics,
                 contentDescription = "Spending Insights",
                 modifier = Modifier.size(24.dp),
-                tint = MaterialTheme.colorScheme.tertiary
+                tint = MaterialTheme.colorScheme.onTertiaryContainer
             )
             Text(
                 text = "Analytics",
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Bold,
                 fontSize = 10.sp,
-                color = MaterialTheme.colorScheme.tertiary
+                color = MaterialTheme.colorScheme.onTertiaryContainer
             )
         }
     }


### PR DESCRIPTION
ui(home): update analytics card elevation and color scheme

This commit refines the Analytics card UI by increasing its default elevation and adding state-specific elevation values. It also updates the icon and text colors to ensure better contrast and consistency within the tertiary container.

- **`HomeUiRoute.kt`**:
    - Updated `Card` elevation to use a default of `6.dp`, with specific values for `pressed`, `focused`, and `hovered` states.
    - Changed the `tint` of the Analytics icon and the `color` of the label text from `tertiary` to `onTertiaryContainer`.