### PR TITLE
Seaweed db

### DIFF
--- a/applications/seaweed/apps/mobile/features/transaction/build.gradle.kts
+++ b/applications/seaweed/apps/mobile/features/transaction/build.gradle.kts
@@ -16,7 +16,7 @@ android {
 dependencies {
     implementation(project(":core:util"))
     implementation(project(":core:ui"))
-    implementation(project(":core:util"))
+    implementation(project(":core:data"))
     implementation(project(":applications:seaweed:model"))
     implementation(project(":applications:seaweed:data"))
     implementation(project(":applications:seaweed:features:main"))
@@ -37,4 +37,6 @@ dependencies {
     implementation(libs.androidx.compose.material3.adaptive.navigation)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.google.play.services.location)
+    implementation(libs.google.maps.compose)
 }

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionUiRoute.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.DirectionsBus
 import androidx.compose.material.icons.filled.Fastfood
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LocalHospital
+import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.ShoppingBag
 import androidx.compose.material3.AssistChip
@@ -225,6 +226,19 @@ fun AddTransactionScreen(
                         onClick = { onEvent(AddTransactionUiEvent.ImportanceChanged(SpendingType.WANT)) },
                         label = { Text("Optional") }
                     )
+                    
+                    Spacer(Modifier.weight(1f))
+
+                    IconButton(
+                        onClick = { onEvent(AddTransactionUiEvent.CaptureLocation) },
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.MyLocation,
+                            contentDescription = "Capture Location",
+                            tint = if (uiState.latitude != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
 
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
+++ b/applications/seaweed/apps/mobile/features/transaction/src/main/java/com/zoewave/probase/seaweed/mobile/transaction/ui/AddTransactionViewModel.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zoewave.probase.core.data.repository.travel.LocationRepository
 import com.zoewave.probase.core.util.CurrencyUtils
 import com.zoewave.probase.features.ai.capture.data.ImageLoader
 import com.zoewave.probase.features.ai.configuration.domain.AiConfigurationSettings
@@ -44,7 +45,10 @@ data class AddTransactionUiState(
     val isCategorySuggestionsVisible: Boolean = false,
     val showCaptureTypeSelection: Boolean = false,
     val userContextComment: String = "",
-    val lastAiDebugInfo: AiDebugInfo? = null
+    val lastAiDebugInfo: AiDebugInfo? = null,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val isCapturingLocation: Boolean = false
 )
 
 @Serializable
@@ -77,12 +81,14 @@ sealed interface AddTransactionUiEvent {
     data class UserCommentChanged(val comment: String) : AddTransactionUiEvent
     object CancelCaptureSelection : AddTransactionUiEvent
     object DebugAiClicked : AddTransactionUiEvent
+    object CaptureLocation : AddTransactionUiEvent
 }
 
 @HiltViewModel
 class AddTransactionViewModel @Inject constructor(
     private val repository: TransactionRepository,
     private val budgetRepository: BudgetTargetRepository,
+    private val locationRepository: LocationRepository,
     private val imageLoader: ImageLoader,
     private val orchestrator: ReceiptOrchestrator,
     private val aiSettings: AiConfigurationSettings
@@ -129,6 +135,18 @@ class AddTransactionViewModel @Inject constructor(
             }
             AddTransactionUiEvent.CancelCaptureSelection -> {
                 _uiState.update { it.copy(showCaptureTypeSelection = false, receiptUri = null) }
+            }
+            AddTransactionUiEvent.CaptureLocation -> {
+                viewModelScope.launch {
+                    _uiState.update { it.copy(isCapturingLocation = true) }
+                    locationRepository.updateLocation()
+                    val location = locationRepository.currentLocation.firstOrNull()
+                    _uiState.update { it.copy(
+                        latitude = location?.latitude,
+                        longitude = location?.longitude,
+                        isCapturingLocation = false
+                    ) }
+                }
             }
             AddTransactionUiEvent.DebugAiClicked -> { /* Handled in Route */ }
             AddTransactionUiEvent.SaveTransaction -> saveTransaction()
@@ -232,7 +250,9 @@ class AddTransactionViewModel @Inject constructor(
                 description = _uiState.value.description,
                 timestamp = System.currentTimeMillis(),
                 receiptUri = _uiState.value.receiptUri,
-                defaultType = _uiState.value.importance
+                defaultType = _uiState.value.importance,
+                latitude = _uiState.value.latitude,
+                longitude = _uiState.value.longitude
             )
             try {
                 repository.addTransaction(transaction)

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/CreditCardDao.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/CreditCardDao.kt
@@ -1,0 +1,28 @@
+package com.zoewave.probase.seaweed.database
+
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CreditCardDao {
+    @Query("SELECT * FROM credit_cards")
+    fun getAllCards(): Flow<List<CreditCardEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCard(card: CreditCardEntity)
+
+    @Query("DELETE FROM credit_cards WHERE id = :id")
+    suspend fun deleteCard(id: String)
+    
+    @Query("SELECT * FROM credit_cards WHERE id = :id")
+    suspend fun getCardById(id: String): CreditCardEntity?
+
+    @Query("SELECT * FROM card_rewards WHERE cardId = :cardId")
+    fun getRewardsForCard(cardId: String): Flow<List<CardRewardEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertReward(reward: CardRewardEntity)
+}

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/CreditCardEntity.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/CreditCardEntity.kt
@@ -1,0 +1,77 @@
+package com.zoewave.probase.seaweed.database
+
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
+import com.zoewave.probase.seaweed.model.CardReward
+import com.zoewave.probase.seaweed.model.CreditCard
+
+@Entity(tableName = "credit_cards")
+data class CreditCardEntity(
+    @PrimaryKey val id: String,
+    val name: String,
+    val bankName: String,
+    val lastFourDigits: String,
+    val creditLimitCents: Long,
+    val interestRateApr: Double,
+    val statementDay: Int,
+    val dueDay: Int,
+    val isFrozen: Boolean,
+    val colorHex: String?,
+    val cardPurposeContext: String?,
+    val dailyTransactionLimitCents: Long?,
+    val maxSingleTransactionCents: Long?
+)
+
+@Entity(tableName = "card_rewards", primaryKeys = ["cardId", "categoryId"])
+data class CardRewardEntity(
+    val cardId: String,
+    val categoryId: String,
+    val multiplier: Double,
+    val rewardType: String?
+)
+
+fun CreditCardEntity.toDomain() = CreditCard(
+    id = id,
+    name = name,
+    bankName = bankName,
+    lastFourDigits = lastFourDigits,
+    creditLimitCents = creditLimitCents,
+    interestRateApr = interestRateApr,
+    statementDay = statementDay,
+    dueDay = dueDay,
+    isFrozen = isFrozen,
+    colorHex = colorHex,
+    cardPurposeContext = cardPurposeContext,
+    dailyTransactionLimitCents = dailyTransactionLimitCents,
+    maxSingleTransactionCents = maxSingleTransactionCents
+)
+
+fun CreditCard.toEntity() = CreditCardEntity(
+    id = id,
+    name = name,
+    bankName = bankName,
+    lastFourDigits = lastFourDigits,
+    creditLimitCents = creditLimitCents,
+    interestRateApr = interestRateApr,
+    statementDay = statementDay,
+    dueDay = dueDay,
+    isFrozen = isFrozen,
+    colorHex = colorHex,
+    cardPurposeContext = cardPurposeContext,
+    dailyTransactionLimitCents = dailyTransactionLimitCents,
+    maxSingleTransactionCents = maxSingleTransactionCents
+)
+
+fun CardRewardEntity.toDomain() = CardReward(
+    cardId = cardId,
+    categoryId = categoryId,
+    multiplier = multiplier,
+    rewardType = rewardType
+)
+
+fun CardReward.toEntity() = CardRewardEntity(
+    cardId = cardId,
+    categoryId = categoryId,
+    multiplier = multiplier,
+    rewardType = rewardType
+)

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/RecurringExpenseEntity.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/RecurringExpenseEntity.kt
@@ -15,7 +15,8 @@ data class RecurringExpenseEntity(
     val categoryId: String,
     val isDefault: Boolean,
     val nextBillingDate: Long?,
-    val defaultType: SpendingType = SpendingType.NEED
+    val defaultType: SpendingType = SpendingType.NEED,
+    val cardId: String? = null
 )
 
 fun RecurringExpenseEntity.toDomain() = RecurringExpense(
@@ -26,7 +27,8 @@ fun RecurringExpenseEntity.toDomain() = RecurringExpense(
     categoryId = categoryId,
     isDefault = isDefault,
     nextBillingDate = nextBillingDate,
-    defaultType = defaultType
+    defaultType = defaultType,
+    cardId = cardId
 )
 
 fun RecurringExpense.toEntity() = RecurringExpenseEntity(
@@ -37,5 +39,6 @@ fun RecurringExpense.toEntity() = RecurringExpenseEntity(
     categoryId = categoryId,
     isDefault = isDefault,
     nextBillingDate = nextBillingDate,
-    defaultType = defaultType
+    defaultType = defaultType,
+    cardId = cardId
 )

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/SeaweedDatabase.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/SeaweedDatabase.kt
@@ -11,9 +11,11 @@ import com.zoewave.probase.seaweed.database.converter.ExpenseConverters
         RecurringExpenseEntity::class,
         UserSettingsEntity::class,
         BudgetTargetEntity::class,
-        CategoryEntity::class
+        CategoryEntity::class,
+        CreditCardEntity::class,
+        CardRewardEntity::class
     ],
-    version = 5,
+    version = 1,
     exportSchema = false
 )
 @TypeConverters(ExpenseConverters::class)
@@ -24,6 +26,7 @@ abstract class SeaweedDatabase : RoomDatabase() {
     abstract val userSettingsDao: UserSettingsDao
     abstract val budgetTargetDao: BudgetTargetDao
     abstract val categoryDao: CategoryDao
+    abstract val creditCardDao: CreditCardDao
 
     companion object {
         const val DATABASE_NAME = "seaweed_db"

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/TransactionEntity.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/TransactionEntity.kt
@@ -17,7 +17,8 @@ data class TransactionEntity(
     val userOverrideType: SpendingType? = null,
     val recurringId: String? = null,
     val latitude: Double? = null,
-    val longitude: Double? = null
+    val longitude: Double? = null,
+    val cardId: String? = null
 )
 
 fun TransactionEntity.toDomain() = Transaction(
@@ -31,7 +32,8 @@ fun TransactionEntity.toDomain() = Transaction(
     userOverrideType = userOverrideType,
     recurringId = recurringId,
     latitude = latitude,
-    longitude = longitude
+    longitude = longitude,
+    cardId = cardId
 )
 
 fun Transaction.toEntity() = TransactionEntity(
@@ -45,5 +47,6 @@ fun Transaction.toEntity() = TransactionEntity(
     userOverrideType = userOverrideType,
     recurringId = recurringId,
     latitude = latitude,
-    longitude = longitude
+    longitude = longitude,
+    cardId = cardId
 )

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/TransactionEntity.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/TransactionEntity.kt
@@ -15,7 +15,9 @@ data class TransactionEntity(
     val receiptUri: String? = null,
     val defaultType: SpendingType,
     val userOverrideType: SpendingType? = null,
-    val recurringId: String? = null
+    val recurringId: String? = null,
+    val latitude: Double? = null,
+    val longitude: Double? = null
 )
 
 fun TransactionEntity.toDomain() = Transaction(
@@ -27,7 +29,9 @@ fun TransactionEntity.toDomain() = Transaction(
     receiptUri = receiptUri,
     defaultType = defaultType,
     userOverrideType = userOverrideType,
-    recurringId = recurringId
+    recurringId = recurringId,
+    latitude = latitude,
+    longitude = longitude
 )
 
 fun Transaction.toEntity() = TransactionEntity(
@@ -39,5 +43,7 @@ fun Transaction.toEntity() = TransactionEntity(
     receiptUri = receiptUri,
     defaultType = defaultType,
     userOverrideType = userOverrideType,
-    recurringId = recurringId
+    recurringId = recurringId,
+    latitude = latitude,
+    longitude = longitude
 )

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/di/DatabaseModule.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/di/DatabaseModule.kt
@@ -44,4 +44,8 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun provideCategoryDao(db: SeaweedDatabase) = db.categoryDao
+
+    @Provides
+    @Singleton
+    fun provideCreditCardDao(db: SeaweedDatabase) = db.creditCardDao
 }

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/CreditCard.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/CreditCard.kt
@@ -1,0 +1,33 @@
+package com.zoewave.probase.seaweed.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreditCard(
+    val id: String,
+    val name: String,
+    val bankName: String,
+    val lastFourDigits: String,
+    
+    val creditLimitCents: Long,
+    val interestRateApr: Double,
+    
+    val statementDay: Int, // 1 to 31
+    val dueDay: Int,       // 1 to 31
+    
+    val isFrozen: Boolean = false,
+    val colorHex: String? = null,
+    
+    // Future-proofing for AI guidance
+    val cardPurposeContext: String? = null, // e.g. "Primary for travel"
+    val dailyTransactionLimitCents: Long? = null,
+    val maxSingleTransactionCents: Long? = null
+)
+
+@Serializable
+data class CardReward(
+    val cardId: String,
+    val categoryId: String,
+    val multiplier: Double, // e.g. 3.0 for 3x points
+    val rewardType: String? = null // e.g. "Cashback", "Points"
+)

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/RecurringExpense.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/RecurringExpense.kt
@@ -29,7 +29,8 @@ data class RecurringExpense(
     val categoryId: String,
     val isDefault: Boolean = false,
     val nextBillingDate: Long? = null,
-    val defaultType: SpendingType = SpendingType.NEED
+    val defaultType: SpendingType = SpendingType.NEED,
+    val cardId: String? = null
 ) {
     val monthlyImpactCents: Long
         get() = when (frequency) {

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/Transaction.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/Transaction.kt
@@ -20,7 +20,10 @@ data class Transaction(
 
     // Location data
     val latitude: Double? = null,
-    val longitude: Double? = null
+    val longitude: Double? = null,
+    
+    // Future-proofing for Credit Card Linkage
+    val cardId: String? = null
 ) {
     val effectiveType: SpendingType
         get() = userOverrideType ?: defaultType

--- a/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/Transaction.kt
+++ b/applications/seaweed/model/src/main/java/com/zoewave/probase/seaweed/model/Transaction.kt
@@ -16,7 +16,11 @@ data class Transaction(
     val userOverrideType: SpendingType? = null,
     
     // Recurring detection / grouping
-    val recurringId: String? = null
+    val recurringId: String? = null,
+
+    // Location data
+    val latitude: Double? = null,
+    val longitude: Double? = null
 ) {
     val effectiveType: SpendingType
         get() = userOverrideType ?: defaultType


### PR DESCRIPTION
feat(database): implement credit card support and transaction linkage

This commit adds the infrastructure to manage credit cards and reward structures. It introduces new database entities and domain models, while updating existing transaction and recurring expense schemas to support card association.

- **Models & Entities**:
    - Introduced `CreditCard` and `CardReward` domain models in the `:model` module.
    - Created corresponding `CreditCardEntity` and `CardRewardEntity` Room entities with mapping functions for the database layer.
    - Added `cardId` to `Transaction` and `RecurringExpense` (both domain and entity layers) to enable linking expenses to specific payment methods.
- **Database Components**:
    - **`CreditCardDao`**: Added a new DAO to handle CRUD operations for credit cards and their associated rewards.
    - **`SeaweedDatabase`**: Updated the database configuration to include the new entities and DAO.
    - **`DatabaseModule`**: Registered the `CreditCardDao` in the dependency injection module.
- **AI Readiness**:
    - Included future-proofing fields in the credit card models, such as `cardPurposeContext` and transaction limits, to support upcoming AI-driven guidance features.