### PR TITLE
feat(gotmind): implement persistent theme and color palette selection

### DIFF
--- a/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/MainActivity.kt
+++ b/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/MainActivity.kt
@@ -125,7 +125,10 @@ class MainActivity : ComponentActivity() {
                                         GotMindRoute.Leaderboard -> {
                                             val memBloxVm: MemBloxViewModel = hiltViewModel()
                                             val scores by memBloxVm.topScores.collectAsState()
-                                            LeaderboardScreen(scores = scores)
+                                            LeaderboardScreen(
+                                                scores = scores,
+                                                onClearAll = { memBloxVm.handleEvent(MemBloxEvent.ClearHallOfFame) }
+                                            )
                                         }
                                         GotMindRoute.Settings -> {
                                             val memBloxVm: MemBloxViewModel = hiltViewModel()

--- a/applications/gotmind/database/src/main/java/com/zoewave/probase/gotmind/database/dao/MemBloxScoreDao.kt
+++ b/applications/gotmind/database/src/main/java/com/zoewave/probase/gotmind/database/dao/MemBloxScoreDao.kt
@@ -8,12 +8,18 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface MemBloxScoreDao {
-    @Query("SELECT * FROM memblox_scores ORDER BY score DESC LIMIT 10")
+    @Query("SELECT * FROM memblox_scores ORDER BY score DESC LIMIT 7")
     fun getTopScores(): Flow<List<MemBloxScoreEntity>>
 
-    @Query("SELECT * FROM memblox_scores ORDER BY score DESC LIMIT 50")
+    @Query("SELECT * FROM memblox_scores ORDER BY score DESC LIMIT 7")
     fun getAllTopScores(): Flow<List<MemBloxScoreEntity>>
 
     @Insert
     suspend fun insertScore(score: MemBloxScoreEntity)
+
+    @Query("DELETE FROM memblox_scores")
+    suspend fun clearAllScores()
+
+    @Query("DELETE FROM memblox_scores WHERE id = :id")
+    suspend fun deleteScoreById(id: String)
 }

--- a/applications/gotmind/features/leaderboard/src/main/java/com/zoewave/probase/gotmind/features/leaderboard/ui/LeaderboardScreen.kt
+++ b/applications/gotmind/features/leaderboard/src/main/java/com/zoewave/probase/gotmind/features/leaderboard/ui/LeaderboardScreen.kt
@@ -23,7 +23,12 @@ import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.TrackChanges
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.HorizontalDivider
@@ -32,6 +37,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -49,8 +58,11 @@ import java.util.Locale
 @Composable
 fun LeaderboardScreen(
     scores: List<MemBloxScoreEntity>,
-    onBack: () -> Unit = {}
+    onBack: () -> Unit = {},
+    onClearAll: () -> Unit = {}
 ) {
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -73,8 +85,15 @@ fun LeaderboardScreen(
                 text = stringResource(R.string.applications_gotmind_features_leaderboard_title),
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Black,
-                color = Color.White
+                color = Color.White,
+                modifier = Modifier.weight(1f)
             )
+            
+            if (scores.isNotEmpty()) {
+                IconButton(onClick = { showDeleteConfirm = true }) {
+                    Icon(Icons.Default.DeleteSweep, contentDescription = null, tint = Color.Gray)
+                }
+            }
         }
 
         Spacer(modifier = Modifier.height(24.dp))
@@ -93,6 +112,30 @@ fun LeaderboardScreen(
                 }
             }
         }
+    }
+
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            containerColor = Color(0xFF1E1E1E),
+            titleContentColor = Color.White,
+            textContentColor = Color.Gray,
+            title = { Text(stringResource(R.string.applications_gotmind_features_leaderboard_clear)) },
+            text = { Text(stringResource(R.string.applications_gotmind_features_leaderboard_clear_confirm)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    onClearAll()
+                    showDeleteConfirm = false
+                }) {
+                    Text("CLEAR ALL", color = Color.Red, fontWeight = FontWeight.Bold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) {
+                    Text("CANCEL", color = Color.Gray)
+                }
+            }
+        )
     }
 }
 

--- a/applications/gotmind/features/leaderboard/src/main/res/values/strings.xml
+++ b/applications/gotmind/features/leaderboard/src/main/res/values/strings.xml
@@ -7,4 +7,6 @@
     <string name="applications_gotmind_features_leaderboard_medal_streak">Streak</string>
     <string name="applications_gotmind_features_leaderboard_medal_pro">Pro</string>
     <string name="applications_gotmind_features_leaderboard_percent_format">%1$d%%</string>
+    <string name="applications_gotmind_features_leaderboard_clear">Clear Hall of Fame</string>
+    <string name="applications_gotmind_features_leaderboard_clear_confirm">Are you sure you want to clear your legendary legacy? This cannot be undone.</string>
 </resources>

--- a/applications/gotmind/features/memblox/src/main/java/com/zoewave/probase/gotmind/features/memblox/MemBloxEvent.kt
+++ b/applications/gotmind/features/memblox/src/main/java/com/zoewave/probase/gotmind/features/memblox/MemBloxEvent.kt
@@ -14,4 +14,5 @@ sealed interface MemBloxEvent {
     data class UpdateDropHeight(val height: Int) : MemBloxEvent
     data class UpdateDropDuration(val durationMillis: Int) : MemBloxEvent
     data class SetEngineType(val type: MemBloxEngineType) : MemBloxEvent
+    data object ClearHallOfFame : MemBloxEvent
 }

--- a/applications/gotmind/features/memblox/src/main/java/com/zoewave/probase/gotmind/features/memblox/MemBloxViewModel.kt
+++ b/applications/gotmind/features/memblox/src/main/java/com/zoewave/probase/gotmind/features/memblox/MemBloxViewModel.kt
@@ -87,6 +87,9 @@ class MemBloxViewModel @Inject constructor(
                 _engineType.value = event.type
                 _engine.value = createEngine(event.type)
             }
+            MemBloxEvent.ClearHallOfFame -> viewModelScope.launch {
+                scoreDao.clearAllScores()
+            }
         }
     }
 


### PR DESCRIPTION
This commit introduces a user-configurable theming system that allows switching between light, dark, and system modes, as well as choosing from multiple color palettes. Settings are persisted across sessions using Jetpack DataStore.

- **Data & Persistence**:
    - **`AppSettingsRepository.kt`**: Created a new repository to manage `ThemeSettings` using `DataStore<Preferences>`.
    - **DI**: Added `DataStoreModule` and `GotMindQualifiers` to provide the DataStore instance via Hilt.
- **Theming**:
    - **`GotMindTheme.kt`**: Updated the core theme wrapper to dynamically apply color schemes based on the selected `AppTheme` and `ColorPalette`.
    - **`Palettes.kt`**: Defined new `ColorScheme` constants for Coral, Forest, and Ocean themes.
    - Added support for Material 3 dynamic color (Expressive) based on the system wallpaper.
- **UI & Settings**:
    - **`SettingsScreen.kt`**: Added dropdown selection items for "App Theme" and "Color Palette."
    - **`SettingsViewModel.kt`**: Introduced a new ViewModel to handle settings events and expose the current theme state.
    - **`MainActivity.kt`**: Integrated `SettingsViewModel` to apply the user's theme preferences at the root of the application.
- **Resources**:
    - **`strings.xml`**: Added localized strings for all new theme and palette options.