### PR TITLE
Mind wave

### DIFF
--- a/applications/gotmind/Docs/GenAI/MindWave/ToneGame/walkthrough_staff.md
+++ b/applications/gotmind/Docs/GenAI/MindWave/ToneGame/walkthrough_staff.md
@@ -1,0 +1,49 @@
+# GotMind: MemBlox Arcade Walkthrough
+
+### 1. High-Performance Core
+- **Architecture**: MAD Gold Standards with `IMemBloxEngine` interface for dynamic hot-swapping between mechanics.
+- **Engines**: Support for "Falling" (physics-based) and "Static" (classic timed reveal) gameplay.
+
+### 2. Centralized Configuration
+- **Settings Hub**: All game-specific settings (Speed, Drop Height, Drop Duration, Engine Mode) are consolidated in the main Settings tab.
+- **Persistence**: Powered by Jetpack DataStore for 100% reliable preference storage across app restarts.
+
+### 3. Visual Identity & Branding
+- **Games Hub**: Branded home screen with high-impact logo and scrollable roadmap for upcoming titles (MindWave, NeuroLogic, PulseCheck).
+- **VFX Suite**: 7-star polish including nebula backgrounds, FRENZY mode, 3D card flips, and particle confetti.
+
+### 4. Privacy & Compliance
+- **Firebase ID Exposure**: Unique Device ID displayed in Settings > About for data management requests.
+- **Right to Erasure**: Explicit data deletion instructions integrated into the app for transparency.
+
+### 33. Absolute Persistence & State Integrity
+- **🛡️ Single Source of Truth**: Fixed a critical issue where gameplay settings would reset during transitions. DataStore is now the absolute authority.
+- **🔄 Transition Safeguards**: Captures and re-applies user configurations whenever a new game or difficulty level starts.
+
+### 34. Release & Production Readiness
+- **🛡️ Proguard/R8 Stabilization**: Fixed a critical release-blocking issue by ensuring all library modules have a valid `consumer-rules.pro` and the app module has a proper `proguard-rules.pro`.
+- **🚀 Verified Build Pipeline**: Confirmed that the entire project now compiles successfully for release, clearing the way for Google Play Store deployment.
+
+### 36. MindWave: Modular Sequence Arcade
+- **🧠 Modular Game Engine**: Re-engineered **MindWave** with a sophisticated modular architecture. Using the `IMindWaveEngine` interface, the game logic is now decoupled from the UI, allowing for instant hot-swapping between different memory mechanics.
+- **🎼 Symphony Mode Evolution**: Launched the **Symphony** version, which leverages the new engine structure to provide a harmonic grid layout. High notes/warm colors reside at the top, and low notes/cool colors at the bottom, creating a physical "instrument" feel.
+- **🏗️ Strategy-Driven Design**: Implemented `ClassicMindWaveEngine` and `SymphonyMindWaveEngine`, both inheriting from a robust `BaseMindWaveEngine`. This structure ensures that core loop logic (playback, timing, validation) is shared while visual/auditory mappings are uniquely specialized.
+- **🔄 Dynamic Setting Synchronization**: The `MindWaveViewModel` now reactively swaps the active engine whenever the mode is changed in Settings, providing a frictionless transition between classic pattern-matching and the multi-sensory symphony experience.
+
+### 37. MindWave: Symphony & Music Education
+- **🎹 Real-Time Audio Synthesis**: Launched a high-performance **Audio Synthesizer** that generates pure sine wave tones for every note in the grid. MindWave is now a multi-sensory education tool where pitch, color, and location are perfectly synchronized.
+- **🎼 Scientific Pitch Alignment**: Each node is precisely tuned to its scientific frequency (e.g., C4 = 261.63Hz, D#5 = 622.25Hz), allowing users to develop perfect pitch and melodic memory while they play.
+- **🧠 Cognitive Reinforcement**: By playing the exact tone when a node flashes or is clicked, the app reinforces auditory-visual associations, turning a simple memory game into an immersive ear-training environment.
+- **🏗️ Low-Latency Architecture**: Built a custom `WaveSynthesizer` using Android's `AudioTrack` API, ensuring that audio feedback is instantaneous and "click-free" via intelligent envelope shaping.
+
+### 37. MindWave: Symphony Mode
+- **🎼 Multi-Sensory Matching**: Introduced the **Symphony** version of MindWave, allowing players to key on three distinct aspects: **Location**, **Pastel Color**, and **Musical Note**.
+- **🎨 Visual-Auditory Fusion**: Each node in Symphony mode is assigned a unique, soft pastel color and a specific musical note label (e.g., C4, D#5), providing multiple layers of memory reinforcement.
+- **🎹 Harmonic Grid Layout**: Organized nodes into a logical scale—high notes and "warm" colors (Reds/Oranges) are positioned at the top, while low notes and "cool" colors (Purples/Pinks) reside at the bottom. This alignment creates a highly intuitive multi-sensory map for the player.
+- **⚙️ Dynamic Version Switching**: Added a dedicated "MindWave Settings" section in the main Settings tab, allowing players to instantly toggle between "Classic" and "Symphony" versions.
+- **🎼 Musical Staff Visualization**: Integrated a real-time musical staff at the top of the Symphony screen. As nodes flash or are clicked, the corresponding note head appears on a formal 5-line staff (including ledger lines for C4), providing a visual link to formal music theory.
+- **🏗️ Unified Game Settings**: Refactored the data architecture to use a consolidated `GameSettings` model, ensuring all arcade preferences are centrally managed and persisted.
+
+### 35. Final Quality & Lint Assurance
+- **🛡️ Android 13 Compliance**: Resolved a critical lint error regarding `NotificationPermission` by correctly declaring the `POST_NOTIFICATIONS` permission in the manifest. This ensures the app adheres to modern Android security standards and functions correctly on the latest devices.
+- **🧹 Zero-Error Build**: Successfully validated the entire codebase with the final lint pass, ensuring that all code quality and resource issues have been addressed for a 7-star premium release.

--- a/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/MainActivity.kt
+++ b/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/MainActivity.kt
@@ -56,7 +56,7 @@ sealed interface GotMindRoute {
     // Fullscreen Game Screens
     @Serializable data object GotMindClassic : GotMindRoute
     @Serializable data object MemBlox : GotMindRoute
-    @Serializable data object MindWave : GotMindRoute
+    @Serializable data object SoundMind : GotMindRoute
 }
 
 data class TopLevelDestination(
@@ -92,7 +92,8 @@ class MainActivity : ComponentActivity() {
                 // Keep tabs visible for games to maintain consistent app structure
                 val shouldShowBottomBar = currentRoute in topLevelDestinations.map { it.route } || 
                                         currentRoute == GotMindRoute.MemBlox || 
-                                        currentRoute == GotMindRoute.GotMindClassic
+                                        currentRoute == GotMindRoute.GotMindClassic ||
+                                        currentRoute == GotMindRoute.SoundMind
 
                 Scaffold(
                     bottomBar = {
@@ -130,7 +131,7 @@ class MainActivity : ComponentActivity() {
                                                 when (dest) {
                                                     "CLASSIC" -> backStack.add(GotMindRoute.GotMindClassic)
                                                     "MEMBLOX" -> backStack.add(GotMindRoute.MemBlox)
-                                                    "MINDWAVE" -> backStack.add(GotMindRoute.MindWave)
+                                                    "SOUNDMIND" -> backStack.add(GotMindRoute.SoundMind)
                                                 }
                                             }
                                         )
@@ -176,7 +177,7 @@ class MainActivity : ComponentActivity() {
                                                 onEvent = { event -> viewModel.handleEvent(event) }
                                             )
                                         }
-                                        GotMindRoute.MindWave -> {
+                                        GotMindRoute.SoundMind -> {
                                             val viewModel: MindWaveViewModel = hiltViewModel()
                                             val state by viewModel.uiState.collectAsState()
                                             MindWaveScreen(
@@ -203,7 +204,7 @@ fun GotMindBottomBar(
 ) {
     // Map sub-routes back to their parent tabs for highlighting
     val selectedRoute = when (currentRoute) {
-        GotMindRoute.MemBlox, GotMindRoute.GotMindClassic -> GotMindRoute.Games
+        GotMindRoute.MemBlox, GotMindRoute.GotMindClassic, GotMindRoute.SoundMind -> GotMindRoute.Games
         else -> currentRoute
     }
 

--- a/applications/gotmind/data/src/main/java/com/zoewave/probase/gotmind/data/repository/AppSettingsRepository.kt
+++ b/applications/gotmind/data/src/main/java/com/zoewave/probase/gotmind/data/repository/AppSettingsRepository.kt
@@ -13,6 +13,7 @@ import com.zoewave.probase.gotmind.model.ThemeSettings
 import com.zoewave.probase.gotmind.model.GameSettings
 import com.zoewave.probase.gotmind.model.MemBloxEngineType
 import com.zoewave.probase.gotmind.model.MindWaveMode
+import com.zoewave.probase.gotmind.model.InstrumentType
 import com.zoewave.probase.gotmind.data.di.GotMindDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -33,6 +34,8 @@ interface AppSettingsRepository {
     suspend fun saveHapticsEnabled(enabled: Boolean)
     suspend fun saveSoundEnabled(enabled: Boolean)
     suspend fun saveMindWaveMode(mode: MindWaveMode)
+    suspend fun saveInstrumentType(type: InstrumentType)
+    suspend fun saveSongMasterEnabled(enabled: Boolean)
 }
 
 @Singleton
@@ -50,6 +53,8 @@ class AppSettingsRepositoryImpl @Inject constructor(
     private val HAPTICS_KEY = booleanPreferencesKey("haptics_enabled")
     private val SOUND_KEY = booleanPreferencesKey("sound_enabled")
     private val MW_MODE_KEY = stringPreferencesKey("mw_mode")
+    private val MW_INSTRUMENT_KEY = stringPreferencesKey("mw_instrument")
+    private val MW_SONG_MASTER_KEY = booleanPreferencesKey("mw_song_master")
 
     override val themeSettingsFlow: Flow<ThemeSettings> = dataStore.data.map { preferences ->
         ThemeSettings(
@@ -66,7 +71,9 @@ class AppSettingsRepositoryImpl @Inject constructor(
             dropDurationMillis = preferences[MB_DURATION_KEY] ?: 3000,
             hapticsEnabled = preferences[HAPTICS_KEY] ?: true,
             soundEnabled = preferences[SOUND_KEY] ?: true,
-            mindWaveMode = MindWaveMode.valueOf(preferences[MW_MODE_KEY] ?: MindWaveMode.CLASSIC.name)
+            mindWaveMode = MindWaveMode.valueOf(preferences[MW_MODE_KEY] ?: MindWaveMode.CLASSIC.name),
+            instrumentType = InstrumentType.valueOf(preferences[MW_INSTRUMENT_KEY] ?: InstrumentType.CLEAN_SYNTH.name),
+            songMasterEnabled = preferences[MW_SONG_MASTER_KEY] ?: false
         )
     }
 
@@ -121,6 +128,18 @@ class AppSettingsRepositoryImpl @Inject constructor(
     override suspend fun saveMindWaveMode(mode: MindWaveMode) {
         dataStore.edit { preferences ->
             preferences[MW_MODE_KEY] = mode.name
+        }
+    }
+
+    override suspend fun saveInstrumentType(type: InstrumentType) {
+        dataStore.edit { preferences ->
+            preferences[MW_INSTRUMENT_KEY] = type.name
+        }
+    }
+
+    override suspend fun saveSongMasterEnabled(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[MW_SONG_MASTER_KEY] = enabled
         }
     }
 }

--- a/applications/gotmind/data/src/main/java/com/zoewave/probase/gotmind/data/repository/AppSettingsRepository.kt
+++ b/applications/gotmind/data/src/main/java/com/zoewave/probase/gotmind/data/repository/AppSettingsRepository.kt
@@ -13,6 +13,7 @@ import com.zoewave.probase.gotmind.model.ThemeSettings
 import com.zoewave.probase.gotmind.model.GameSettings
 import com.zoewave.probase.gotmind.model.MemBloxEngineType
 import com.zoewave.probase.gotmind.model.MindWaveMode
+import com.zoewave.probase.gotmind.model.NodeShape
 import com.zoewave.probase.gotmind.model.InstrumentType
 import com.zoewave.probase.gotmind.data.di.GotMindDataStore
 import kotlinx.coroutines.flow.Flow
@@ -34,6 +35,7 @@ interface AppSettingsRepository {
     suspend fun saveHapticsEnabled(enabled: Boolean)
     suspend fun saveSoundEnabled(enabled: Boolean)
     suspend fun saveMindWaveMode(mode: MindWaveMode)
+    suspend fun saveMindWaveNodeShape(shape: NodeShape)
     suspend fun saveInstrumentType(type: InstrumentType)
     suspend fun saveSongMasterEnabled(enabled: Boolean)
 }
@@ -53,6 +55,7 @@ class AppSettingsRepositoryImpl @Inject constructor(
     private val HAPTICS_KEY = booleanPreferencesKey("haptics_enabled")
     private val SOUND_KEY = booleanPreferencesKey("sound_enabled")
     private val MW_MODE_KEY = stringPreferencesKey("mw_mode")
+    private val MW_SHAPE_KEY = stringPreferencesKey("mw_node_shape")
     private val MW_INSTRUMENT_KEY = stringPreferencesKey("mw_instrument")
     private val MW_SONG_MASTER_KEY = booleanPreferencesKey("mw_song_master")
 
@@ -72,6 +75,7 @@ class AppSettingsRepositoryImpl @Inject constructor(
             hapticsEnabled = preferences[HAPTICS_KEY] ?: true,
             soundEnabled = preferences[SOUND_KEY] ?: true,
             mindWaveMode = MindWaveMode.valueOf(preferences[MW_MODE_KEY] ?: MindWaveMode.CLASSIC.name),
+            mindWaveNodeShape = NodeShape.valueOf(preferences[MW_SHAPE_KEY] ?: NodeShape.CIRCLE.name),
             instrumentType = InstrumentType.valueOf(preferences[MW_INSTRUMENT_KEY] ?: InstrumentType.CLEAN_SYNTH.name),
             songMasterEnabled = preferences[MW_SONG_MASTER_KEY] ?: false
         )
@@ -128,6 +132,12 @@ class AppSettingsRepositoryImpl @Inject constructor(
     override suspend fun saveMindWaveMode(mode: MindWaveMode) {
         dataStore.edit { preferences ->
             preferences[MW_MODE_KEY] = mode.name
+        }
+    }
+
+    override suspend fun saveMindWaveNodeShape(shape: NodeShape) {
+        dataStore.edit { preferences ->
+            preferences[MW_SHAPE_KEY] = shape.name
         }
     }
 

--- a/applications/gotmind/features/games/src/main/java/com/zoewave/probase/gotmind/features/games/GamesScreen.kt
+++ b/applications/gotmind/features/games/src/main/java/com/zoewave/probase/gotmind/features/games/GamesScreen.kt
@@ -68,6 +68,23 @@ fun GamesScreen(
             )
         }
 
+        // --- SoundMind (Active) ---
+        Button(
+            onClick = { onNav("SOUNDMIND") },
+            modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.secondary
+            )
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = stringResource(R.string.applications_gotmind_features_games_placeholder_1),
+                    style = MaterialTheme.typography.titleLarge
+                )
+            }
+        }
+
         // --- GotMind Classic (Grayed Out) ---
         Button(
             onClick = { },
@@ -82,23 +99,6 @@ fun GamesScreen(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = stringResource(R.string.applications_gotmind_features_games_classic),
-                    style = MaterialTheme.typography.titleLarge
-                )
-            }
-        }
-
-        // --- MindWave (Active) ---
-        Button(
-            onClick = { onNav("MINDWAVE") },
-            modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
-            shape = RoundedCornerShape(16.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.secondary
-            )
-        ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(
-                    text = stringResource(R.string.applications_gotmind_features_games_placeholder_1),
                     style = MaterialTheme.typography.titleLarge
                 )
             }

--- a/applications/gotmind/features/games/src/main/res/values/strings.xml
+++ b/applications/gotmind/features/games/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
     <string name="applications_gotmind_features_games_title">GotMind Games</string>
     <string name="applications_gotmind_features_games_classic">GotMind Classic</string>
     <string name="applications_gotmind_features_games_memblox">MemBlox</string>
-    <string name="applications_gotmind_features_games_placeholder_1">MindWave</string>
+    <string name="applications_gotmind_features_games_placeholder_1">SoundMind</string>
     <string name="applications_gotmind_features_games_placeholder_2">NeuroLogic</string>
     <string name="applications_gotmind_features_games_placeholder_3">PulseCheck</string>
     <string name="applications_gotmind_features_games_coming_soon">COMING SOON</string>

--- a/applications/gotmind/features/leaderboard/src/main/java/com/zoewave/probase/gotmind/features/leaderboard/ui/LeaderboardScreen.kt
+++ b/applications/gotmind/features/leaderboard/src/main/java/com/zoewave/probase/gotmind/features/leaderboard/ui/LeaderboardScreen.kt
@@ -119,7 +119,7 @@ fun LeaderboardScreen(
             Tab(
                 selected = selectedTab == 1,
                 onClick = { selectedTab = 1 },
-                text = { Text("MINDWAVE", fontWeight = FontWeight.Bold) }
+                text = { Text("SOUNDMIND", fontWeight = FontWeight.Bold) }
             )
         }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/BaseMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/BaseMindWaveEngine.kt
@@ -172,10 +172,15 @@ abstract class BaseMindWaveEngine(
         _state.update { it.copy(soundEnabled = enabled) }
     }
 
-    override fun updateSymphonySettings(waveform: com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform, songMaster: Boolean) {
+    override fun updateSymphonySettings(
+        waveform: com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform, 
+        songMaster: Boolean,
+        nodeShape: com.zoewave.probase.gotmind.model.NodeShape
+    ) {
         _state.update { it.copy(
             activeWaveform = waveform,
-            currentSongTitle = if (songMaster) "Ready for Melody" else null
+            currentSongTitle = if (songMaster) "Ready for Melody" else null,
+            nodeShape = nodeShape
         ) }
     }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/BaseMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/BaseMindWaveEngine.kt
@@ -34,7 +34,8 @@ abstract class BaseMindWaveEngine(
             isGameOver = false, 
             feedbackMessage = null, 
             grid = createInitialGrid(),
-            mode = mode // Ensure mode is preserved
+            mode = mode,
+            sequencePath = emptyList() // Reset path on start
         ) }
         generateNewSequence(1)
     }
@@ -42,9 +43,18 @@ abstract class BaseMindWaveEngine(
     protected abstract fun createInitialGrid(): List<Node>
 
     protected fun generateNewSequence(level: Int) {
-        val sequenceLength = 1 + level // Start with 2 nodes
-        val newSequence = List(sequenceLength) { Random.nextInt(0, 16) }
-        _state.update { it.copy(sequence = newSequence, userInput = emptyList(), isPlayingSequence = true) }
+        val isSongMaster = _state.value.currentSongTitle != null // We'll set this based on settings
+        
+        val newSequence = if (isSongMaster) {
+            val melody = MelodyLibrary.getForLevel(level)
+            _state.update { it.copy(currentSongTitle = melody.title) }
+            melody.sequence
+        } else {
+            val sequenceLength = 1 + level // Start with 2 nodes
+            List(sequenceLength) { Random.nextInt(0, 16) }
+        }
+
+        _state.update { it.copy(sequence = newSequence, userInput = emptyList(), isPlayingSequence = true, sequencePath = emptyList()) }
         playSequence(newSequence)
     }
 
@@ -52,17 +62,20 @@ abstract class BaseMindWaveEngine(
         gameJob?.cancel()
         gameJob = scope.launch {
             delay(1000)
+            val path = mutableListOf<Int>()
             sequence.forEach { nodeId ->
                 if (_state.value.isPaused) {
                     while (_state.value.isPaused) { delay(100) }
                 }
                 
+                path.add(nodeId)
                 _state.update { state ->
                     state.copy(
                         grid = state.grid.map { node ->
                             if (node.id == nodeId) node.copy(isFlashing = true) else node
                         },
-                        activeNodeId = nodeId
+                        activeNodeId = nodeId,
+                        sequencePath = path.toList()
                     )
                 }
                 triggerHaptic(HapticSignal.LIGHT)
@@ -159,6 +172,13 @@ abstract class BaseMindWaveEngine(
         _state.update { it.copy(soundEnabled = enabled) }
     }
 
+    override fun updateSymphonySettings(waveform: com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform, songMaster: Boolean) {
+        _state.update { it.copy(
+            activeWaveform = waveform,
+            currentSongTitle = if (songMaster) "Ready for Melody" else null
+        ) }
+    }
+
     protected fun triggerHaptic(signal: HapticSignal) {
         if (_state.value.hapticsEnabled) {
             _state.update { it.copy(lastHapticSignal = signal) }
@@ -170,7 +190,7 @@ abstract class BaseMindWaveEngine(
         val synth = synthesizer ?: return
         val frequency = nodeFrequencies[nodeId] ?: 440.0
         scope.launch {
-            synth.playTone(frequency, 400)
+            synth.playTone(frequency, 400, _state.value.activeWaveform)
         }
     }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/BaseMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/BaseMindWaveEngine.kt
@@ -11,11 +11,12 @@ import kotlinx.coroutines.launch
 import kotlin.random.Random
 
 abstract class BaseMindWaveEngine(
+    protected val mode: com.zoewave.probase.gotmind.model.MindWaveMode,
     protected val scope: CoroutineScope,
     protected val onGameOver: (Int, Int) -> Unit
 ) : IMindWaveEngine {
 
-    protected val _state = MutableStateFlow(MindWaveState())
+    protected val _state = MutableStateFlow(MindWaveState(mode = mode))
     override val state: StateFlow<MindWaveState> = _state.asStateFlow()
 
     protected var gameJob: Job? = null
@@ -26,7 +27,15 @@ abstract class BaseMindWaveEngine(
     }
 
     override fun start() {
-        _state.update { it.copy(isStarted = true, score = 0, level = 1, isGameOver = false, feedbackMessage = null, grid = createInitialGrid()) }
+        _state.update { it.copy(
+            isStarted = true, 
+            score = 0, 
+            level = 1, 
+            isGameOver = false, 
+            feedbackMessage = null, 
+            grid = createInitialGrid(),
+            mode = mode // Ensure mode is preserved
+        ) }
         generateNewSequence(1)
     }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/BaseMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/BaseMindWaveEngine.kt
@@ -49,9 +49,12 @@ abstract class BaseMindWaveEngine(
                 }
                 
                 _state.update { state ->
-                    state.copy(grid = state.grid.map { node ->
-                        if (node.id == nodeId) node.copy(isFlashing = true) else node
-                    })
+                    state.copy(
+                        grid = state.grid.map { node ->
+                            if (node.id == nodeId) node.copy(isFlashing = true) else node
+                        },
+                        activeNodeId = nodeId
+                    )
                 }
                 triggerHaptic(HapticSignal.LIGHT)
                 playNodeSound(nodeId)
@@ -60,9 +63,12 @@ abstract class BaseMindWaveEngine(
                 delay(flashDuration)
                 
                 _state.update { state ->
-                    state.copy(grid = state.grid.map { node ->
-                        if (node.id == nodeId) node.copy(isFlashing = false) else node
-                    })
+                    state.copy(
+                        grid = state.grid.map { node ->
+                            if (node.id == nodeId) node.copy(isFlashing = false) else node
+                        },
+                        activeNodeId = null
+                    )
                 }
                 delay(150)
             }
@@ -81,6 +87,12 @@ abstract class BaseMindWaveEngine(
             triggerHaptic(HapticSignal.LIGHT)
             playNodeSound(nodeId)
             val newUserInput = state.userInput + nodeId
+            _state.update { it.copy(activeNodeId = nodeId) }
+            scope.launch {
+                delay(400)
+                _state.update { it.copy(activeNodeId = null) }
+            }
+
             if (newUserInput.size == state.sequence.size) {
                 // Level Complete
                 _state.update { it.copy(

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ClassicMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ClassicMindWaveEngine.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.CoroutineScope
 class ClassicMindWaveEngine(
     scope: CoroutineScope,
     onGameOver: (Int, Int) -> Unit
-) : BaseMindWaveEngine(scope, onGameOver) {
+) : BaseMindWaveEngine(com.zoewave.probase.gotmind.model.MindWaveMode.CLASSIC, scope, onGameOver) {
 
     override fun createInitialGrid(): List<Node> {
         return List(16) { Node(id = it) }

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/HarmonicArcMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/HarmonicArcMindWaveEngine.kt
@@ -1,0 +1,33 @@
+package com.zoewave.probase.gotmind.features.mindwave
+
+import kotlinx.coroutines.CoroutineScope
+
+class HarmonicArcMindWaveEngine(
+    scope: CoroutineScope,
+    onGameOver: (Int, Int) -> Unit
+) : BaseMindWaveEngine(com.zoewave.probase.gotmind.model.MindWaveMode.HARMONIC_ARC, scope, onGameOver) {
+
+    private val pastelColors = listOf(
+        0xFFFFB7B2L, 0xFFFFC8B2L, 0xFFFFDAC1L, 0xFFFFE5C1L,
+        0xFFFFF9C4L, 0xFFF1F8E9L, 0xFFE2F0CBL, 0xFFD4E157L,
+        0xFFB5EAD7L, 0xFFB2EBF2L, 0xFF81D4FAL, 0xFFC5CAE9L,
+        0xFFD1C4E9L, 0xFFE1BEE7L, 0xFFF3E5F5L, 0xFFF8BBD0L
+    )
+
+    private val musicNotes = listOf(
+        "D#5", "D5", "C#5", "C5",
+        "B4", "A#4", "A4", "G#4",
+        "G4", "F#4", "F4", "E4",
+        "D#4", "D4", "C#4", "C4"
+    )
+
+    override fun createInitialGrid(): List<Node> {
+        return List(16) { i ->
+            Node(
+                id = i,
+                color = pastelColors[i % pastelColors.size],
+                note = musicNotes[i % musicNotes.size]
+            )
+        }
+    }
+}

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/HarmonicRingMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/HarmonicRingMindWaveEngine.kt
@@ -1,0 +1,33 @@
+package com.zoewave.probase.gotmind.features.mindwave
+
+import kotlinx.coroutines.CoroutineScope
+
+class HarmonicRingMindWaveEngine(
+    scope: CoroutineScope,
+    onGameOver: (Int, Int) -> Unit
+) : BaseMindWaveEngine(com.zoewave.probase.gotmind.model.MindWaveMode.HARMONIC_RING, scope, onGameOver) {
+
+    private val pastelColors = listOf(
+        0xFFFFB7B2L, 0xFFFFC8B2L, 0xFFFFDAC1L, 0xFFFFE5C1L,
+        0xFFFFF9C4L, 0xFFF1F8E9L, 0xFFE2F0CBL, 0xFFD4E157L,
+        0xFFB5EAD7L, 0xFFB2EBF2L, 0xFF81D4FAL, 0xFFC5CAE9L,
+        0xFFD1C4E9L, 0xFFE1BEE7L, 0xFFF3E5F5L, 0xFFF8BBD0L
+    )
+
+    private val musicNotes = listOf(
+        "D#5", "D5", "C#5", "C5",
+        "B4", "A#4", "A4", "G#4",
+        "G4", "F#4", "F4", "E4",
+        "D#4", "D4", "C#4", "C4"
+    )
+
+    override fun createInitialGrid(): List<Node> {
+        return List(16) { i ->
+            Node(
+                id = i,
+                color = pastelColors[i % pastelColors.size],
+                note = musicNotes[i % musicNotes.size]
+            )
+        }
+    }
+}

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/IMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/IMindWaveEngine.kt
@@ -14,5 +14,9 @@ interface IMindWaveEngine {
     fun setHapticsEnabled(enabled: Boolean)
     fun setSoundEnabled(enabled: Boolean)
     fun setAudioSynthesizer(synthesizer: com.zoewave.probase.core.util.audio.WaveSynthesizer?)
-    fun updateSymphonySettings(waveform: com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform, songMaster: Boolean)
+    fun updateSymphonySettings(
+        waveform: com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform, 
+        songMaster: Boolean,
+        nodeShape: com.zoewave.probase.gotmind.model.NodeShape
+    )
 }

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/IMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/IMindWaveEngine.kt
@@ -14,4 +14,5 @@ interface IMindWaveEngine {
     fun setHapticsEnabled(enabled: Boolean)
     fun setSoundEnabled(enabled: Boolean)
     fun setAudioSynthesizer(synthesizer: com.zoewave.probase.core.util.audio.WaveSynthesizer?)
+    fun updateSymphonySettings(waveform: com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform, songMaster: Boolean)
 }

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MelodyLibrary.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MelodyLibrary.kt
@@ -1,0 +1,45 @@
+package com.zoewave.probase.gotmind.features.mindwave
+
+data class Melody(
+    val title: String,
+    val sequence: List<Int> // Node IDs 0..15
+)
+
+object MelodyLibrary {
+    // 4x4 Grid Mapping (for reference):
+    // Row 0: 0,  1,  2,  3   (High D#5..C5)
+    // Row 1: 4,  5,  6,  7   (B4..G#4)
+    // Row 2: 8,  9,  10, 11  (G4..E4)
+    // Row 3: 12, 13, 14, 15  (D#4..C4)
+
+    val melodies = listOf(
+        Melody(
+            title = "Ode to Joy (Snippet)",
+            sequence = listOf(11, 11, 10, 8, 8, 10, 11, 12)
+        ),
+        Melody(
+            title = "Major Arpeggio",
+            sequence = listOf(15, 11, 8, 3)
+        ),
+        Melody(
+            title = "Star Path",
+            sequence = listOf(15, 15, 8, 8, 6, 6, 8)
+        ),
+        Melody(
+            title = "Chromatic Wave",
+            sequence = listOf(15, 14, 13, 12, 11, 10, 9, 8)
+        ),
+        Melody(
+            title = "Midnight Call",
+            sequence = listOf(4, 6, 4, 11, 15)
+        ),
+        Melody(
+            title = "High Peak",
+            sequence = listOf(15, 12, 8, 4, 1, 0)
+        )
+    )
+
+    fun getForLevel(level: Int): Melody {
+        return melodies[(level - 1) % melodies.size]
+    }
+}

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveState.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveState.kt
@@ -1,6 +1,7 @@
 package com.zoewave.probase.gotmind.features.mindwave
 
 import com.zoewave.probase.gotmind.model.MindWaveMode
+import com.zoewave.probase.gotmind.model.NodeShape
 import java.util.UUID
 
 data class Node(
@@ -28,6 +29,7 @@ data class MindWaveState(
     val lastHapticSignal: HapticSignal? = null,
     val isPaused: Boolean = false,
     val mode: MindWaveMode = MindWaveMode.CLASSIC,
+    val nodeShape: NodeShape = NodeShape.CIRCLE,
     val activeNodeId: Int? = null, // For visual staff notation
     val sequencePath: List<Int> = emptyList(), // Path of the sequence for constellation drawing
     val currentSongTitle: String? = null,

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveState.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveState.kt
@@ -28,7 +28,10 @@ data class MindWaveState(
     val lastHapticSignal: HapticSignal? = null,
     val isPaused: Boolean = false,
     val mode: MindWaveMode = MindWaveMode.CLASSIC,
-    val activeNodeId: Int? = null // For visual staff notation
+    val activeNodeId: Int? = null, // For visual staff notation
+    val sequencePath: List<Int> = emptyList(), // Path of the sequence for constellation drawing
+    val currentSongTitle: String? = null,
+    val activeWaveform: com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform = com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.SINE
 )
 
 enum class HapticSignal { LIGHT, MEDIUM, HEAVY }
@@ -43,4 +46,6 @@ sealed interface MindWaveEvent {
     data class SetHapticsEnabled(val enabled: Boolean) : MindWaveEvent
     data class SetSoundEnabled(val enabled: Boolean) : MindWaveEvent
     data object ClearHallOfFame : MindWaveEvent
+    data class SetInstrument(val instrument: com.zoewave.probase.gotmind.model.InstrumentType) : MindWaveEvent
+    data class SetSongMaster(val enabled: Boolean) : MindWaveEvent
 }

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveState.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveState.kt
@@ -27,7 +27,8 @@ data class MindWaveState(
     val soundEnabled: Boolean = true,
     val lastHapticSignal: HapticSignal? = null,
     val isPaused: Boolean = false,
-    val mode: MindWaveMode = MindWaveMode.CLASSIC
+    val mode: MindWaveMode = MindWaveMode.CLASSIC,
+    val activeNodeId: Int? = null // For visual staff notation
 )
 
 enum class HapticSignal { LIGHT, MEDIUM, HEAVY }

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveViewModel.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveViewModel.kt
@@ -2,17 +2,16 @@ package com.zoewave.probase.gotmind.features.mindwave
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.zoewave.probase.gotmind.analytics.AnalyticsHelper
+import com.zoewave.probase.core.util.audio.WaveSynthesizer
 import com.zoewave.probase.gotmind.analytics.AnalyticsEvent
+import com.zoewave.probase.gotmind.analytics.AnalyticsHelper
 import com.zoewave.probase.gotmind.analytics.AnalyticsParam
 import com.zoewave.probase.gotmind.data.repository.AppSettingsRepository
 import com.zoewave.probase.gotmind.database.MindWaveScoreEntity
 import com.zoewave.probase.gotmind.database.dao.MindWaveScoreDao
 import com.zoewave.probase.gotmind.model.MindWaveMode
-import com.zoewave.probase.core.util.audio.WaveSynthesizer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -21,10 +20,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.random.Random
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
@@ -57,6 +54,13 @@ class MindWaveViewModel @Inject constructor(
                 engine.setHapticsEnabled(settings.hapticsEnabled)
                 engine.setSoundEnabled(settings.soundEnabled)
                 engine.setAudioSynthesizer(waveSynthesizer)
+                
+                val waveform = when (settings.instrumentType) {
+                    com.zoewave.probase.gotmind.model.InstrumentType.CLEAN_SYNTH -> com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.SINE
+                    com.zoewave.probase.gotmind.model.InstrumentType.RETRO_8BIT -> com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.SQUARE
+                    com.zoewave.probase.gotmind.model.InstrumentType.ZEN_TRIANGLE -> com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.TRIANGLE
+                }
+                engine.updateSymphonySettings(waveform, settings.songMasterEnabled)
             }
             .launchIn(viewModelScope)
     }
@@ -82,6 +86,12 @@ class MindWaveViewModel @Inject constructor(
             }
             is MindWaveEvent.SetSoundEnabled -> viewModelScope.launch {
                 appSettingsRepository.saveSoundEnabled(event.enabled)
+            }
+            is MindWaveEvent.SetInstrument -> viewModelScope.launch {
+                appSettingsRepository.saveInstrumentType(event.instrument)
+            }
+            is MindWaveEvent.SetSongMaster -> viewModelScope.launch {
+                appSettingsRepository.saveSongMasterEnabled(event.enabled)
             }
             MindWaveEvent.ClearHallOfFame -> viewModelScope.launch {
                 scoreDao.clearAllScores()

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveViewModel.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveViewModel.kt
@@ -55,12 +55,18 @@ class MindWaveViewModel @Inject constructor(
                 engine.setSoundEnabled(settings.soundEnabled)
                 engine.setAudioSynthesizer(waveSynthesizer)
                 
-                val waveform = when (settings.instrumentType) {
-                    com.zoewave.probase.gotmind.model.InstrumentType.CLEAN_SYNTH -> com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.SINE
-                    com.zoewave.probase.gotmind.model.InstrumentType.RETRO_8BIT -> com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.SQUARE
-                    com.zoewave.probase.gotmind.model.InstrumentType.ZEN_TRIANGLE -> com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.TRIANGLE
+                // New: Sync node shape
+                _engine.value.state.value.let { 
+                    engine.updateSymphonySettings(
+                        waveform = when (settings.instrumentType) {
+                            com.zoewave.probase.gotmind.model.InstrumentType.CLEAN_SYNTH -> com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.SINE
+                            com.zoewave.probase.gotmind.model.InstrumentType.RETRO_8BIT -> com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.SQUARE
+                            com.zoewave.probase.gotmind.model.InstrumentType.ZEN_TRIANGLE -> com.zoewave.probase.core.util.audio.WaveSynthesizer.Waveform.TRIANGLE
+                        },
+                        songMaster = settings.songMasterEnabled,
+                        nodeShape = settings.mindWaveNodeShape
+                    )
                 }
-                engine.updateSymphonySettings(waveform, settings.songMasterEnabled)
             }
             .launchIn(viewModelScope)
     }
@@ -70,6 +76,7 @@ class MindWaveViewModel @Inject constructor(
             MindWaveMode.CLASSIC -> ClassicMindWaveEngine(viewModelScope) { score, level -> saveScore(score, level) }
             MindWaveMode.SYMPHONY -> SymphonyMindWaveEngine(viewModelScope) { score, level -> saveScore(score, level) }
             MindWaveMode.HARMONIC_ARC -> HarmonicArcMindWaveEngine(viewModelScope) { score, level -> saveScore(score, level) }
+            MindWaveMode.HARMONIC_RING -> HarmonicRingMindWaveEngine(viewModelScope) { score, level -> saveScore(score, level) }
         }
     }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveViewModel.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/MindWaveViewModel.kt
@@ -69,6 +69,7 @@ class MindWaveViewModel @Inject constructor(
         return when (mode) {
             MindWaveMode.CLASSIC -> ClassicMindWaveEngine(viewModelScope) { score, level -> saveScore(score, level) }
             MindWaveMode.SYMPHONY -> SymphonyMindWaveEngine(viewModelScope) { score, level -> saveScore(score, level) }
+            MindWaveMode.HARMONIC_ARC -> HarmonicArcMindWaveEngine(viewModelScope) { score, level -> saveScore(score, level) }
         }
     }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/SymphonyMindWaveEngine.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/SymphonyMindWaveEngine.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.CoroutineScope
 class SymphonyMindWaveEngine(
     scope: CoroutineScope,
     onGameOver: (Int, Int) -> Unit
-) : BaseMindWaveEngine(scope, onGameOver) {
+) : BaseMindWaveEngine(com.zoewave.probase.gotmind.model.MindWaveMode.SYMPHONY, scope, onGameOver) {
 
     private val pastelColors = listOf(
         // Row 0: High Notes (Red/Orange Pastels)

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -110,7 +110,7 @@ fun MindWaveScreen(
         MindWaveBackground()
         
         if (uiState.sequencePath.size >= 2) {
-            ConstellationPath(path = uiState.sequencePath)
+            ConstellationPath(path = uiState.sequencePath, mode = uiState.mode)
         }
 
         Column(
@@ -207,7 +207,7 @@ fun MindWaveScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            if (uiState.mode == MindWaveMode.SYMPHONY) {
+            if (uiState.mode == MindWaveMode.SYMPHONY || uiState.mode == MindWaveMode.HARMONIC_ARC) {
                 MusicalStaff(activeNodeId = uiState.activeNodeId)
                 Spacer(modifier = Modifier.height(12.dp))
                 if (uiState.currentSongTitle != null) {
@@ -236,29 +236,58 @@ fun MindWaveScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            // Game Grid (4x4)
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(1f)
-                    .clip(RoundedCornerShape(24.dp))
-                    .background(Color.White.copy(alpha = 0.05f))
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                for (row in 0..3) {
-                    Row(
-                        modifier = Modifier.weight(1f),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        for (col in 0..3) {
-                            val index = row * 4 + col
-                            val node = uiState.grid[index]
+            // Game Grid or Arc
+            if (uiState.mode == MindWaveMode.HARMONIC_ARC) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(300.dp) // Fixed height for arc
+                        .padding(horizontal = 16.dp),
+                    contentAlignment = Alignment.BottomCenter
+                ) {
+                    val radius = 240.dp
+                    uiState.grid.forEachIndexed { index, node ->
+                        // Spread 16 nodes across a 180-degree arc (half circle)
+                        // Angle from 180 to 0 (Left to Right)
+                        val angle = 180f - (index.toFloat() / (uiState.grid.size - 1) * 180f)
+                        val angleRad = Math.toRadians(angle.toDouble())
+                        val x = (Math.cos(angleRad) * 150).dp // Scale for width
+                        val y = (Math.sin(angleRad) * -150).dp // Scale for height (negative for Up)
+                        
+                        Box(modifier = Modifier.offset(x = x, y = y)) {
                             MindWaveNode(
                                 node = node,
                                 isClickable = !uiState.isPlayingSequence && !uiState.isGameOver && uiState.isStarted && !uiState.isPaused,
                                 onClick = { onEvent(MindWaveEvent.NodeClick(index)) }
                             )
+                        }
+                    }
+                }
+            } else {
+                // Standard Grid
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(1f)
+                        .clip(RoundedCornerShape(24.dp))
+                        .background(Color.White.copy(alpha = 0.05f))
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    for (row in 0..3) {
+                        Row(
+                            modifier = Modifier.weight(1f),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            for (col in 0..3) {
+                                val index = row * 4 + col
+                                val node = uiState.grid[index]
+                                MindWaveNode(
+                                    node = node,
+                                    isClickable = !uiState.isPlayingSequence && !uiState.isGameOver && uiState.isStarted && !uiState.isPaused,
+                                    onClick = { onEvent(MindWaveEvent.NodeClick(index)) }
+                                )
+                            }
                         }
                     }
                 }
@@ -318,21 +347,34 @@ fun MindWaveScreen(
 }
 
 @Composable
-fun ConstellationPath(path: List<Int>) {
+fun ConstellationPath(path: List<Int>, mode: MindWaveMode) {
     Canvas(modifier = Modifier.fillMaxSize()) {
         val width = size.width
         val padding = 24.dp.toPx()
-        val topOffset = 360.dp.toPx() // Adjusted to match grid start below staff
         val gridWidth = width - (padding * 2)
         val nodeSize = gridWidth / 4f
         
+        // Grid top offset
+        val gridTopOffset = 360.dp.toPx()
+        
+        // Arc top offset (matched to Box height and padding)
+        val arcBaseY = 560.dp.toPx() // BottomCenter of the 300dp arc box + header/staff
+
         val points = path.map { index ->
-            val row = index / 4
-            val col = index % 4
-            androidx.compose.ui.geometry.Offset(
-                x = padding + (col * nodeSize) + (nodeSize / 2f),
-                y = topOffset + (row * nodeSize) + (nodeSize / 2f)
-            )
+            if (mode == MindWaveMode.HARMONIC_ARC) {
+                val angle = 180f - (index.toFloat() / 15f * 180f)
+                val angleRad = Math.toRadians(angle.toDouble())
+                val x = (Math.cos(angleRad) * 150.dp.toPx()) + (width / 2f)
+                val y = arcBaseY + (Math.sin(angleRad) * -150.dp.toPx())
+                androidx.compose.ui.geometry.Offset(x.toFloat(), y.toFloat())
+            } else {
+                val row = index / 4
+                val col = index % 4
+                androidx.compose.ui.geometry.Offset(
+                    x = padding + (col * nodeSize) + (nodeSize / 2f),
+                    y = gridTopOffset + (row * nodeSize) + (nodeSize / 2f)
+                )
+            }
         }
 
         if (points.size >= 2) {

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.GenericShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -208,7 +209,7 @@ fun MindWaveScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            if (uiState.mode == MindWaveMode.SYMPHONY || uiState.mode == MindWaveMode.HARMONIC_ARC || uiState.mode == MindWaveMode.HARMONIC_RING) {
+            if (uiState.mode == MindWaveMode.SYMPHONY || uiState.mode == MindWaveMode.HARMONIC_ARC) {
                 MusicalStaff(activeNodeId = uiState.activeNodeId)
                 Spacer(modifier = Modifier.height(12.dp))
                 if (uiState.currentSongTitle != null) {
@@ -239,14 +240,28 @@ fun MindWaveScreen(
 
             // Game Grid or Arc or Ring
             if (uiState.mode == MindWaveMode.HARMONIC_ARC || uiState.mode == MindWaveMode.HARMONIC_RING) {
+                val isFullCircle = uiState.mode == MindWaveMode.HARMONIC_RING
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(300.dp) 
+                        .height(if (isFullCircle) 450.dp else 300.dp) 
                         .padding(horizontal = 16.dp),
-                    contentAlignment = Alignment.BottomCenter
+                    contentAlignment = Alignment.Center
                 ) {
-                    val isFullCircle = uiState.mode == MindWaveMode.HARMONIC_RING
+                    if (isFullCircle) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            MusicalStaff(activeNodeId = uiState.activeNodeId)
+                            if (uiState.currentSongTitle != null) {
+                                Text(
+                                    text = uiState.currentSongTitle,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.secondary,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                        }
+                    }
+
                     val sweepAngle = if (isFullCircle) 360f else 180f
                     val startAngle = if (isFullCircle) 270f else 180f // Start from top for circle
                     
@@ -254,13 +269,13 @@ fun MindWaveScreen(
                         val angle = startAngle - (index.toFloat() / uiState.grid.size * sweepAngle)
                         val angleRad = Math.toRadians(angle.toDouble())
                         
-                        val radiusPx = if (uiState.nodeShape == com.zoewave.probase.gotmind.model.NodeShape.PIANO_KEY) 180 else 150
+                        val radiusPx = if (uiState.nodeShape == com.zoewave.probase.gotmind.model.NodeShape.PIANO_KEY) 180 else 140
                         val x = (Math.cos(angleRad) * radiusPx).dp
                         val y = (Math.sin(angleRad) * -radiusPx).dp
                         
                         Box(
                             modifier = Modifier
-                                .offset(x = x, y = if (isFullCircle) y - 150.dp else y) // Shift circle up
+                                .offset(x = x, y = if (isFullCircle) y else y + 150.dp) // Align arc relative to center
                                 .graphicsLayer {
                                     if (uiState.nodeShape == com.zoewave.probase.gotmind.model.NodeShape.PIANO_KEY) {
                                         rotationZ = angle + 90f // Rotate key to face center
@@ -377,8 +392,8 @@ fun ConstellationPath(path: List<Int>, mode: MindWaveMode) {
         // Grid top offset
         val gridTopOffset = 360.dp.toPx()
         
-        // Arc/Ring top offset
-        val arcBaseY = if (mode == MindWaveMode.HARMONIC_RING) 500.dp.toPx() else 560.dp.toPx()
+        // Arc/Ring center offset
+        val centerY = 560.dp.toPx() // Estimated center for Arc/Ring
 
         val points = path.map { index ->
             if (mode == MindWaveMode.HARMONIC_ARC || mode == MindWaveMode.HARMONIC_RING) {
@@ -390,7 +405,7 @@ fun ConstellationPath(path: List<Int>, mode: MindWaveMode) {
                 val angleRad = Math.toRadians(angle.toDouble())
                 val radiusPx = 150.dp.toPx()
                 val x = (Math.cos(angleRad) * radiusPx) + (width / 2f)
-                val y = arcBaseY + (Math.sin(angleRad) * -radiusPx) - (if (isFullCircle) 150.dp.toPx() else 0f)
+                val y = centerY + (Math.sin(angleRad) * -radiusPx)
                 androidx.compose.ui.geometry.Offset(x.toFloat(), y.toFloat())
             } else {
                 val row = index / 4
@@ -588,13 +603,24 @@ fun PianoKeyNode(
         label = "Color"
     )
 
+    // Tapered "Long Triangle" shape
+    val keyShape = remember {
+        GenericShape { size, _ ->
+            moveTo(size.width * 0.35f, 0f) // Inner top (narrow)
+            lineTo(size.width * 0.65f, 0f) 
+            lineTo(size.width, size.height) // Outer bottom (wide)
+            lineTo(0f, size.height)
+            close()
+        }
+    }
+
     Box(
         modifier = Modifier
-            .size(width = 40.dp, height = 80.dp) // Piano key shape
+            .size(width = 50.dp, height = 100.dp) // Taller for the "long" look
             .scale(scale * pressScale)
-            .clip(RoundedCornerShape(bottomStart = 8.dp, bottomEnd = 8.dp, topStart = 2.dp, topEnd = 2.dp))
+            .clip(keyShape)
             .background(color)
-            .border(1.dp, if (node.isFlashing || isPressed) Color.White else Color.Black.copy(alpha = 0.2f), RoundedCornerShape(bottomStart = 8.dp, bottomEnd = 8.dp))
+            .border(1.dp, if (node.isFlashing || isPressed) Color.White else Color.Black.copy(alpha = 0.3f), keyShape)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
@@ -608,7 +634,9 @@ fun PianoKeyNode(
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.ExtraBold,
                 color = Color.Black.copy(alpha = 0.7f),
-                modifier = Modifier.graphicsLayer { rotationZ = -90f } // Counter-rotate text to stay upright
+                modifier = Modifier
+                    .offset(y = 20.dp) // Position text towards the wider end
+                    .graphicsLayer { rotationZ = -90f }
             )
         }
     }

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -269,13 +269,13 @@ fun MindWaveScreen(
 
 @Composable
 fun MusicalStaff(activeNodeId: Int?) {
-    val lineSpacing = 10.dp
+    val lineSpacing = 12.dp
     val staffHeight = lineSpacing * 8
     
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(staffHeight + 20.dp)
+            .height(staffHeight + 40.dp)
             .padding(horizontal = 48.dp),
         contentAlignment = Alignment.Center
     ) {
@@ -288,8 +288,8 @@ fun MusicalStaff(activeNodeId: Int?) {
             // Draw Treble Clef Symbol (Stylized using text for precision)
             drawContext.canvas.nativeCanvas.apply {
                 val paint = android.graphics.Paint().apply {
-                    color = Color.White.copy(alpha = 0.5f).toArgb()
-                    textSize = spacing * 5f
+                    color = Color.White.copy(alpha = 0.8f).toArgb() // Increase alpha for visibility
+                    textSize = spacing * 6f
                     typeface = android.graphics.Typeface.DEFAULT_BOLD
                 }
                 // Clef placement
@@ -300,10 +300,10 @@ fun MusicalStaff(activeNodeId: Int?) {
             for (i in -2..2) {
                 val y = centerY + i * spacing
                 drawLine(
-                    color = Color.White.copy(alpha = 0.2f),
+                    color = Color.White.copy(alpha = 0.4f), // More visible lines
                     start = androidx.compose.ui.geometry.Offset(60f, y),
                     end = androidx.compose.ui.geometry.Offset(width, y),
-                    strokeWidth = 2f
+                    strokeWidth = 3f
                 )
             }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -539,9 +539,9 @@ fun MindWaveNode(
         if (node.note != null) {
             Text(
                 text = node.note,
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.Black,
-                color = if (node.isFlashing) Color.Black else Color.White.copy(alpha = 0.6f)
+                style = MaterialTheme.typography.titleMedium, // Larger font
+                fontWeight = FontWeight.ExtraBold, // Bolder
+                color = Color.Black.copy(alpha = 0.8f) // Dark text for high contrast on pastels
             )
         }
         

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -43,6 +44,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.AlertDialog
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -55,8 +58,12 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -64,6 +71,7 @@ import com.zoewave.probase.gotmind.features.mindwave.HapticSignal
 import com.zoewave.probase.gotmind.features.mindwave.MindWaveEvent
 import com.zoewave.probase.gotmind.features.mindwave.MindWaveState
 import com.zoewave.probase.gotmind.features.mindwave.Node
+import com.zoewave.probase.gotmind.model.MindWaveMode
 import kotlin.random.Random
 
 @Composable
@@ -183,14 +191,25 @@ fun MindWaveScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            Text(
-                text = if (uiState.isPlayingSequence) "Watch the Wave..." else "Repeat the Pattern",
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Black,
-                color = if (uiState.isPlayingSequence) MaterialTheme.colorScheme.secondary else Color.White
-            )
+            if (uiState.mode == MindWaveMode.SYMPHONY) {
+                MusicalStaff(activeNodeId = uiState.activeNodeId)
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = if (uiState.isPlayingSequence) "Watch & Listen..." else "Repeat the Melody",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = if (uiState.isPlayingSequence) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
+                )
+            } else {
+                Text(
+                    text = if (uiState.isPlayingSequence) "Watch the Wave..." else "Repeat the Pattern",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Black,
+                    color = if (uiState.isPlayingSequence) MaterialTheme.colorScheme.secondary else Color.White
+                )
+            }
 
-            Spacer(modifier = Modifier.height(48.dp))
+            Spacer(modifier = Modifier.height(32.dp))
 
             // Game Grid (4x4)
             Column(
@@ -242,6 +261,111 @@ fun MindWaveScreen(
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) {
                     Text(if (uiState.isGameOver) "TRY AGAIN" else "START GAME", fontWeight = FontWeight.Black)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun MusicalStaff(activeNodeId: Int?) {
+    val lineSpacing = 10.dp
+    val staffHeight = lineSpacing * 8
+    
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(staffHeight + 20.dp)
+            .padding(horizontal = 48.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val width = size.width
+            val height = size.height
+            val centerY = height / 2f
+            val spacing = lineSpacing.toPx()
+            
+            // Draw Treble Clef Symbol (Stylized using text for precision)
+            drawContext.canvas.nativeCanvas.apply {
+                val paint = android.graphics.Paint().apply {
+                    color = Color.White.copy(alpha = 0.5f).toArgb()
+                    textSize = spacing * 5f
+                    typeface = android.graphics.Typeface.DEFAULT_BOLD
+                }
+                // Clef placement
+                drawText("𝄞", 0f, centerY + spacing * 1.5f, paint)
+            }
+
+            // Draw 5 staff lines
+            for (i in -2..2) {
+                val y = centerY + i * spacing
+                drawLine(
+                    color = Color.White.copy(alpha = 0.2f),
+                    start = androidx.compose.ui.geometry.Offset(60f, y),
+                    end = androidx.compose.ui.geometry.Offset(width, y),
+                    strokeWidth = 2f
+                )
+            }
+
+            // Note mapping (Treble Clef)
+            val noteOffsets = mapOf(
+                0 to -2.5f, // D#5
+                1 to -1.0f, // D5
+                2 to -0.5f, // C#5
+                3 to -0.5f, // C5
+                4 to 0.0f,  // B4
+                5 to 0.5f,  // A#4
+                6 to 0.5f,  // A4
+                7 to 1.0f,  // G#4
+                8 to 1.0f,  // G4
+                9 to 1.5f,  // F#4
+                10 to 1.5f, // F4
+                11 to 2.0f, // E4
+                12 to 2.5f, // D#4
+                13 to 2.5f, // D4
+                14 to 3.0f, // C#4
+                15 to 3.0f  // C4
+            )
+
+            activeNodeId?.let { id ->
+                val offsetMultiplier = noteOffsets[id] ?: 0f
+                val noteY = centerY + offsetMultiplier * spacing
+                
+                // Draw Ledger line for C4
+                if (offsetMultiplier >= 3.0f) {
+                    drawLine(
+                        color = Color.White.copy(alpha = 0.6f),
+                        start = androidx.compose.ui.geometry.Offset(width/2f - 25f, centerY + 3f * spacing),
+                        end = androidx.compose.ui.geometry.Offset(width/2f + 25f, centerY + 3f * spacing),
+                        strokeWidth = 3f
+                    )
+                }
+
+                // Note Head Glow
+                drawCircle(
+                    color = Color(0xFF00E5FF).copy(alpha = 0.3f),
+                    radius = spacing * 0.6f,
+                    center = androidx.compose.ui.geometry.Offset(width / 2f, noteY)
+                )
+
+                // Main Note Head
+                drawCircle(
+                    color = Color.White,
+                    radius = spacing * 0.4f,
+                    center = androidx.compose.ui.geometry.Offset(width / 2f, noteY)
+                )
+                
+                // Sharp symbol (#) logic
+                val isSharp = id in listOf(0, 2, 5, 7, 9, 12, 14)
+                if (isSharp) {
+                    drawContext.canvas.nativeCanvas.apply {
+                        val p = android.graphics.Paint().apply {
+                            color = Color(0xFF00E5FF).toArgb()
+                            textSize = spacing * 1.5f
+                            typeface = android.graphics.Typeface.DEFAULT_BOLD
+                        }
+                        drawText("#", width/2f + spacing * 0.6f, noteY + spacing * 0.4f, p)
+                    }
                 }
             }
         }
@@ -316,7 +440,6 @@ fun MindWaveNode(
             )
         }
         
-        // Futuristic ripple inside
         if (node.isFlashing && node.color == null) {
             Box(
                 modifier = Modifier

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -207,7 +208,7 @@ fun MindWaveScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            if (uiState.mode == MindWaveMode.SYMPHONY || uiState.mode == MindWaveMode.HARMONIC_ARC) {
+            if (uiState.mode == MindWaveMode.SYMPHONY || uiState.mode == MindWaveMode.HARMONIC_ARC || uiState.mode == MindWaveMode.HARMONIC_RING) {
                 MusicalStaff(activeNodeId = uiState.activeNodeId)
                 Spacer(modifier = Modifier.height(12.dp))
                 if (uiState.currentSongTitle != null) {
@@ -236,30 +237,49 @@ fun MindWaveScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            // Game Grid or Arc
-            if (uiState.mode == MindWaveMode.HARMONIC_ARC) {
+            // Game Grid or Arc or Ring
+            if (uiState.mode == MindWaveMode.HARMONIC_ARC || uiState.mode == MindWaveMode.HARMONIC_RING) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(300.dp) // Fixed height for arc
+                        .height(300.dp) 
                         .padding(horizontal = 16.dp),
                     contentAlignment = Alignment.BottomCenter
                 ) {
-                    val radius = 240.dp
+                    val isFullCircle = uiState.mode == MindWaveMode.HARMONIC_RING
+                    val sweepAngle = if (isFullCircle) 360f else 180f
+                    val startAngle = if (isFullCircle) 270f else 180f // Start from top for circle
+                    
                     uiState.grid.forEachIndexed { index, node ->
-                        // Spread 16 nodes across a 180-degree arc (half circle)
-                        // Angle from 180 to 0 (Left to Right)
-                        val angle = 180f - (index.toFloat() / (uiState.grid.size - 1) * 180f)
+                        val angle = startAngle - (index.toFloat() / uiState.grid.size * sweepAngle)
                         val angleRad = Math.toRadians(angle.toDouble())
-                        val x = (Math.cos(angleRad) * 150).dp // Scale for width
-                        val y = (Math.sin(angleRad) * -150).dp // Scale for height (negative for Up)
                         
-                        Box(modifier = Modifier.offset(x = x, y = y)) {
-                            MindWaveNode(
-                                node = node,
-                                isClickable = !uiState.isPlayingSequence && !uiState.isGameOver && uiState.isStarted && !uiState.isPaused,
-                                onClick = { onEvent(MindWaveEvent.NodeClick(index)) }
-                            )
+                        val radiusPx = if (uiState.nodeShape == com.zoewave.probase.gotmind.model.NodeShape.PIANO_KEY) 180 else 150
+                        val x = (Math.cos(angleRad) * radiusPx).dp
+                        val y = (Math.sin(angleRad) * -radiusPx).dp
+                        
+                        Box(
+                            modifier = Modifier
+                                .offset(x = x, y = if (isFullCircle) y - 150.dp else y) // Shift circle up
+                                .graphicsLayer {
+                                    if (uiState.nodeShape == com.zoewave.probase.gotmind.model.NodeShape.PIANO_KEY) {
+                                        rotationZ = angle + 90f // Rotate key to face center
+                                    }
+                                }
+                        ) {
+                            if (uiState.nodeShape == com.zoewave.probase.gotmind.model.NodeShape.PIANO_KEY) {
+                                PianoKeyNode(
+                                    node = node,
+                                    isClickable = !uiState.isPlayingSequence && !uiState.isGameOver && uiState.isStarted && !uiState.isPaused,
+                                    onClick = { onEvent(MindWaveEvent.NodeClick(index)) }
+                                )
+                            } else {
+                                MindWaveNode(
+                                    node = node,
+                                    isClickable = !uiState.isPlayingSequence && !uiState.isGameOver && uiState.isStarted && !uiState.isPaused,
+                                    onClick = { onEvent(MindWaveEvent.NodeClick(index)) }
+                                )
+                            }
                         }
                     }
                 }
@@ -357,15 +377,20 @@ fun ConstellationPath(path: List<Int>, mode: MindWaveMode) {
         // Grid top offset
         val gridTopOffset = 360.dp.toPx()
         
-        // Arc top offset (matched to Box height and padding)
-        val arcBaseY = 560.dp.toPx() // BottomCenter of the 300dp arc box + header/staff
+        // Arc/Ring top offset
+        val arcBaseY = if (mode == MindWaveMode.HARMONIC_RING) 500.dp.toPx() else 560.dp.toPx()
 
         val points = path.map { index ->
-            if (mode == MindWaveMode.HARMONIC_ARC) {
-                val angle = 180f - (index.toFloat() / 15f * 180f)
+            if (mode == MindWaveMode.HARMONIC_ARC || mode == MindWaveMode.HARMONIC_RING) {
+                val isFullCircle = mode == MindWaveMode.HARMONIC_RING
+                val sweepAngle = if (isFullCircle) 360f else 180f
+                val startAngle = if (isFullCircle) 270f else 180f
+                
+                val angle = startAngle - (index.toFloat() / 16f * sweepAngle)
                 val angleRad = Math.toRadians(angle.toDouble())
-                val x = (Math.cos(angleRad) * 150.dp.toPx()) + (width / 2f)
-                val y = arcBaseY + (Math.sin(angleRad) * -150.dp.toPx())
+                val radiusPx = 150.dp.toPx()
+                val x = (Math.cos(angleRad) * radiusPx) + (width / 2f)
+                val y = arcBaseY + (Math.sin(angleRad) * -radiusPx) - (if (isFullCircle) 150.dp.toPx() else 0f)
                 androidx.compose.ui.geometry.Offset(x.toFloat(), y.toFloat())
             } else {
                 val row = index / 4
@@ -529,6 +554,63 @@ fun MindWaveBackground() {
                 .alpha(alpha)
                 .background(p.color, CircleShape)
         )
+    }
+}
+
+@Composable
+fun PianoKeyNode(
+    node: Node,
+    isClickable: Boolean,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    
+    val pressScale by animateFloatAsState(
+        targetValue = if (isPressed) 0.95f else 1.0f,
+        animationSpec = spring(dampingRatio = 0.4f, stiffness = Spring.StiffnessMedium),
+        label = "PressScale"
+    )
+
+    val scale by animateFloatAsState(
+        targetValue = if (node.isFlashing) 1.1f else 1.0f,
+        animationSpec = spring(dampingRatio = 0.5f, stiffness = Spring.StiffnessLow),
+        label = "Pulse"
+    )
+
+    val baseColor = if (node.color != null) Color(node.color) else Color.White.copy(alpha = 0.1f)
+    val color by animateColorAsState(
+        targetValue = when {
+            node.isFlashing || isPressed -> if (node.color != null) Color.White else Color(0xFF00E5FF)
+            else -> baseColor
+        },
+        animationSpec = tween(if (node.isFlashing || isPressed) 100 else 300),
+        label = "Color"
+    )
+
+    Box(
+        modifier = Modifier
+            .size(width = 40.dp, height = 80.dp) // Piano key shape
+            .scale(scale * pressScale)
+            .clip(RoundedCornerShape(bottomStart = 8.dp, bottomEnd = 8.dp, topStart = 2.dp, topEnd = 2.dp))
+            .background(color)
+            .border(1.dp, if (node.isFlashing || isPressed) Color.White else Color.Black.copy(alpha = 0.2f), RoundedCornerShape(bottomStart = 8.dp, bottomEnd = 8.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = isClickable
+            ) { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        if (node.note != null) {
+            Text(
+                text = node.note,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.ExtraBold,
+                color = Color.Black.copy(alpha = 0.7f),
+                modifier = Modifier.graphicsLayer { rotationZ = -90f } // Counter-rotate text to stay upright
+            )
+        }
     }
 }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -83,6 +85,14 @@ fun MindWaveScreen(
 ) {
     var showControls by remember { mutableStateOf(false) }
     val haptic = LocalHapticFeedback.current
+    
+    val startButtonInteractionSource = remember { MutableInteractionSource() }
+    val startButtonPressed by startButtonInteractionSource.collectIsPressedAsState()
+    val startButtonScale by animateFloatAsState(
+        targetValue = if (startButtonPressed) 0.95f else 1.0f,
+        animationSpec = spring(dampingRatio = 0.4f, stiffness = Spring.StiffnessMedium),
+        label = "StartPress"
+    )
 
     // Haptic Feedback Observer
     LaunchedEffect(uiState.lastHapticSignal) {
@@ -271,8 +281,12 @@ fun MindWaveScreen(
             if (!uiState.isStarted || uiState.isGameOver) {
                 Button(
                     onClick = { onEvent(MindWaveEvent.StartGame) },
-                    modifier = Modifier.fillMaxWidth().height(56.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .scale(startButtonScale),
                     shape = RoundedCornerShape(16.dp),
+                    interactionSource = startButtonInteractionSource,
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) {
                     Text(if (uiState.isGameOver) "TRY AGAIN" else "START GAME", fontWeight = FontWeight.Black)
@@ -482,6 +496,15 @@ fun MindWaveNode(
     isClickable: Boolean,
     onClick: () -> Unit
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    
+    val pressScale by animateFloatAsState(
+        targetValue = if (isPressed) 0.92f else 1.0f,
+        animationSpec = spring(dampingRatio = 0.4f, stiffness = Spring.StiffnessMedium),
+        label = "PressScale"
+    )
+
     val scale by animateFloatAsState(
         targetValue = if (node.isFlashing) 1.2f else 1.0f,
         animationSpec = spring(dampingRatio = 0.5f, stiffness = Spring.StiffnessLow),
@@ -492,21 +515,25 @@ fun MindWaveNode(
     
     val color by animateColorAsState(
         targetValue = when {
-            node.isFlashing -> if (node.color != null) Color.White else Color(0xFF00E5FF)
+            node.isFlashing || isPressed -> if (node.color != null) Color.White else Color(0xFF00E5FF)
             else -> baseColor
         },
-        animationSpec = tween(if (node.isFlashing) 100 else 300),
+        animationSpec = tween(if (node.isFlashing || isPressed) 100 else 300),
         label = "Color"
     )
 
     Box(
         modifier = Modifier
             .size(64.dp)
-            .scale(scale)
+            .scale(scale * pressScale)
             .clip(CircleShape)
             .background(color)
-            .border(2.dp, if (node.isFlashing) Color.White.copy(alpha = 0.5f) else Color.Transparent, CircleShape)
-            .clickable(enabled = isClickable) { onClick() },
+            .border(2.dp, if (node.isFlashing || isPressed) Color.White.copy(alpha = 0.5f) else Color.Transparent, CircleShape)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = isClickable
+            ) { onClick() },
         contentAlignment = Alignment.Center
     ) {
         if (node.note != null) {

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Analytics
@@ -106,7 +107,8 @@ fun MindWaveScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .statusBarsPadding()
-                .padding(24.dp),
+                .padding(24.dp)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // Header

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -62,7 +62,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.nativeCanvas
@@ -111,10 +110,6 @@ fun MindWaveScreen(
     Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F0F0F))) {
         MindWaveBackground()
         
-        if (uiState.sequencePath.size >= 2) {
-            ConstellationPath(path = uiState.sequencePath, mode = uiState.mode)
-        }
-
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -378,67 +373,6 @@ fun MindWaveScreen(
                 }
             }
         )
-    }
-}
-
-@Composable
-fun ConstellationPath(path: List<Int>, mode: MindWaveMode) {
-    Canvas(modifier = Modifier.fillMaxSize()) {
-        val width = size.width
-        val padding = 24.dp.toPx()
-        val gridWidth = width - (padding * 2)
-        val nodeSize = gridWidth / 4f
-        
-        // Grid top offset
-        val gridTopOffset = 360.dp.toPx()
-        
-        // Arc/Ring center offset
-        val centerY = 560.dp.toPx() // Estimated center for Arc/Ring
-
-        val points = path.map { index ->
-            if (mode == MindWaveMode.HARMONIC_ARC || mode == MindWaveMode.HARMONIC_RING) {
-                val isFullCircle = mode == MindWaveMode.HARMONIC_RING
-                val sweepAngle = if (isFullCircle) 360f else 180f
-                val startAngle = if (isFullCircle) 270f else 180f
-                
-                val angle = startAngle - (index.toFloat() / 16f * sweepAngle)
-                val angleRad = Math.toRadians(angle.toDouble())
-                val radiusPx = 150.dp.toPx()
-                val x = (Math.cos(angleRad) * radiusPx) + (width / 2f)
-                val y = centerY + (Math.sin(angleRad) * -radiusPx)
-                androidx.compose.ui.geometry.Offset(x.toFloat(), y.toFloat())
-            } else {
-                val row = index / 4
-                val col = index % 4
-                androidx.compose.ui.geometry.Offset(
-                    x = padding + (col * nodeSize) + (nodeSize / 2f),
-                    y = gridTopOffset + (row * nodeSize) + (nodeSize / 2f)
-                )
-            }
-        }
-
-        if (points.size >= 2) {
-            val drawPath = androidx.compose.ui.graphics.Path().apply {
-                moveTo(points[0].x, points[0].y)
-                for (i in 1 until points.size) {
-                    lineTo(points[i].x, points[i].y)
-                }
-            }
-            
-            // Outer Glow
-            drawPath(
-                path = drawPath,
-                color = Color(0xFF00E5FF).copy(alpha = 0.15f),
-                style = Stroke(width = 16f, cap = StrokeCap.Round)
-            )
-            
-            // Core Line
-            drawPath(
-                path = drawPath,
-                color = Color(0xFF00E5FF).copy(alpha = 0.5f),
-                style = Stroke(width = 4f, cap = StrokeCap.Round)
-            )
-        }
     }
 }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -58,12 +58,12 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -97,6 +97,10 @@ fun MindWaveScreen(
 
     Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F0F0F))) {
         MindWaveBackground()
+        
+        if (uiState.sequencePath.size >= 2) {
+            ConstellationPath(path = uiState.sequencePath)
+        }
 
         Column(
             modifier = Modifier
@@ -193,9 +197,18 @@ fun MindWaveScreen(
 
             if (uiState.mode == MindWaveMode.SYMPHONY) {
                 MusicalStaff(activeNodeId = uiState.activeNodeId)
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(12.dp))
+                if (uiState.currentSongTitle != null) {
+                    Text(
+                        text = "Melody: ${uiState.currentSongTitle}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.secondary,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = if (uiState.isPlayingSequence) "Watch & Listen..." else "Repeat the Melody",
+                    text = if (uiState.isPlayingSequence) "Listen carefully..." else "Repeat the Melody",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     color = if (uiState.isPlayingSequence) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.8f)
@@ -265,17 +278,81 @@ fun MindWaveScreen(
             }
         }
     }
+
+    if (uiState.isGameOver) {
+        AlertDialog(
+            onDismissRequest = { /* No-op */ },
+            containerColor = Color(0xFF1E1E1E),
+            titleContentColor = Color.White,
+            textContentColor = Color.Gray,
+            title = { Text("Sequence Broken") },
+            text = { Text("The melody has drifted away. Keep training your sensory memory!") },
+            confirmButton = {
+                TextButton(onClick = { onEvent(MindWaveEvent.StartGame) }) {
+                    Text("RETRY WAVE", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { onNav("BACK") }) {
+                    Text("BACK TO HUB", color = Color.Gray)
+                }
+            }
+        )
+    }
+}
+
+@Composable
+fun ConstellationPath(path: List<Int>) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        val width = size.width
+        val padding = 24.dp.toPx()
+        val topOffset = 360.dp.toPx() // Adjusted to match grid start below staff
+        val gridWidth = width - (padding * 2)
+        val nodeSize = gridWidth / 4f
+        
+        val points = path.map { index ->
+            val row = index / 4
+            val col = index % 4
+            androidx.compose.ui.geometry.Offset(
+                x = padding + (col * nodeSize) + (nodeSize / 2f),
+                y = topOffset + (row * nodeSize) + (nodeSize / 2f)
+            )
+        }
+
+        if (points.size >= 2) {
+            val drawPath = androidx.compose.ui.graphics.Path().apply {
+                moveTo(points[0].x, points[0].y)
+                for (i in 1 until points.size) {
+                    lineTo(points[i].x, points[i].y)
+                }
+            }
+            
+            // Outer Glow
+            drawPath(
+                path = drawPath,
+                color = Color(0xFF00E5FF).copy(alpha = 0.15f),
+                style = Stroke(width = 16f, cap = StrokeCap.Round)
+            )
+            
+            // Core Line
+            drawPath(
+                path = drawPath,
+                color = Color(0xFF00E5FF).copy(alpha = 0.5f),
+                style = Stroke(width = 4f, cap = StrokeCap.Round)
+            )
+        }
+    }
 }
 
 @Composable
 fun MusicalStaff(activeNodeId: Int?) {
-    val lineSpacing = 12.dp
+    val lineSpacing = 10.dp
     val staffHeight = lineSpacing * 8
     
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(staffHeight + 40.dp)
+            .height(staffHeight + 20.dp)
             .padding(horizontal = 48.dp),
         contentAlignment = Alignment.Center
     ) {
@@ -285,14 +362,13 @@ fun MusicalStaff(activeNodeId: Int?) {
             val centerY = height / 2f
             val spacing = lineSpacing.toPx()
             
-            // Draw Treble Clef Symbol (Stylized using text for precision)
+            // Draw Treble Clef Symbol
             drawContext.canvas.nativeCanvas.apply {
                 val paint = android.graphics.Paint().apply {
-                    color = Color.White.copy(alpha = 0.8f).toArgb() // Increase alpha for visibility
-                    textSize = spacing * 6f
+                    color = Color.White.copy(alpha = 0.7f).toArgb()
+                    textSize = spacing * 5f
                     typeface = android.graphics.Typeface.DEFAULT_BOLD
                 }
-                // Clef placement
                 drawText("𝄞", 0f, centerY + spacing * 1.5f, paint)
             }
 
@@ -300,10 +376,10 @@ fun MusicalStaff(activeNodeId: Int?) {
             for (i in -2..2) {
                 val y = centerY + i * spacing
                 drawLine(
-                    color = Color.White.copy(alpha = 0.4f), // More visible lines
+                    color = Color.White.copy(alpha = 0.25f),
                     start = androidx.compose.ui.geometry.Offset(60f, y),
                     end = androidx.compose.ui.geometry.Offset(width, y),
-                    strokeWidth = 3f
+                    strokeWidth = 2f
                 )
             }
 
@@ -355,7 +431,7 @@ fun MusicalStaff(activeNodeId: Int?) {
                     center = androidx.compose.ui.geometry.Offset(width / 2f, noteY)
                 )
                 
-                // Sharp symbol (#) logic
+                // Sharp symbol (#)
                 val isSharp = id in listOf(0, 2, 5, 7, 9, 12, 14)
                 if (isSharp) {
                     drawContext.canvas.nativeCanvas.apply {

--- a/applications/gotmind/features/mindwave/src/main/res/values/strings.xml
+++ b/applications/gotmind/features/mindwave/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="applications_gotmind_features_mindwave_title">MindWave</string>
+    <string name="applications_gotmind_features_mindwave_title">SoundMind</string>
     <string name="applications_gotmind_features_mindwave_subtitle">The Synapse Pulse</string>
     <string name="applications_gotmind_features_mindwave_watch">Watch the Wave…</string>
     <string name="applications_gotmind_features_mindwave_repeat">Repeat the Pattern</string>

--- a/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsScreen.kt
+++ b/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsScreen.kt
@@ -58,6 +58,7 @@ import com.zoewave.probase.gotmind.model.ColorPalette
 import com.zoewave.probase.gotmind.model.ThemeSettings
 import com.zoewave.probase.gotmind.model.MemBloxEngineType
 import com.zoewave.probase.gotmind.model.MindWaveMode
+import com.zoewave.probase.gotmind.model.InstrumentType
 import com.zoewave.probase.gotmind.model.GameSettings
 import java.util.Locale
 
@@ -250,6 +251,27 @@ fun SettingsScreen(
                 MindWaveMode.SYMPHONY to stringResource(R.string.applications_gotmind_features_settings_mindwave_symphony)
             ),
             onSelected = { onSettingsEvent(SettingsEvent.SetMindWaveMode(it)) }
+        )
+
+        SettingsDropdownItem(
+            icon = Icons.Default.VolumeUp,
+            title = stringResource(R.string.applications_gotmind_features_settings_mw_instrument),
+            currentValue = gameSettings.instrumentType,
+            options = InstrumentType.entries,
+            optionLabels = mapOf(
+                InstrumentType.CLEAN_SYNTH to stringResource(R.string.applications_gotmind_features_settings_mw_instrument_clean),
+                InstrumentType.RETRO_8BIT to stringResource(R.string.applications_gotmind_features_settings_mw_instrument_retro),
+                InstrumentType.ZEN_TRIANGLE to stringResource(R.string.applications_gotmind_features_settings_mw_instrument_zen)
+            ),
+            onSelected = { onSettingsEvent(SettingsEvent.SetInstrument(it)) }
+        )
+
+        SettingItem(
+            icon = Icons.Default.Info,
+            title = stringResource(R.string.applications_gotmind_features_settings_mw_song_master),
+            subtitle = stringResource(R.string.applications_gotmind_features_settings_mw_song_master_desc),
+            checked = gameSettings.songMasterEnabled,
+            onCheckedChange = { onSettingsEvent(SettingsEvent.SetSongMaster(it)) }
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsScreen.kt
+++ b/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsScreen.kt
@@ -248,7 +248,8 @@ fun SettingsScreen(
             options = MindWaveMode.entries,
             optionLabels = mapOf(
                 MindWaveMode.CLASSIC to stringResource(R.string.applications_gotmind_features_settings_mindwave_classic),
-                MindWaveMode.SYMPHONY to stringResource(R.string.applications_gotmind_features_settings_mindwave_symphony)
+                MindWaveMode.SYMPHONY to stringResource(R.string.applications_gotmind_features_settings_mindwave_symphony),
+                MindWaveMode.HARMONIC_ARC to stringResource(R.string.applications_gotmind_features_settings_mindwave_arc)
             ),
             onSelected = { onSettingsEvent(SettingsEvent.SetMindWaveMode(it)) }
         )

--- a/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsScreen.kt
+++ b/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsScreen.kt
@@ -58,6 +58,7 @@ import com.zoewave.probase.gotmind.model.ColorPalette
 import com.zoewave.probase.gotmind.model.ThemeSettings
 import com.zoewave.probase.gotmind.model.MemBloxEngineType
 import com.zoewave.probase.gotmind.model.MindWaveMode
+import com.zoewave.probase.gotmind.model.NodeShape
 import com.zoewave.probase.gotmind.model.InstrumentType
 import com.zoewave.probase.gotmind.model.GameSettings
 import java.util.Locale
@@ -249,9 +250,22 @@ fun SettingsScreen(
             optionLabels = mapOf(
                 MindWaveMode.CLASSIC to stringResource(R.string.applications_gotmind_features_settings_mindwave_classic),
                 MindWaveMode.SYMPHONY to stringResource(R.string.applications_gotmind_features_settings_mindwave_symphony),
-                MindWaveMode.HARMONIC_ARC to stringResource(R.string.applications_gotmind_features_settings_mindwave_arc)
+                MindWaveMode.HARMONIC_ARC to stringResource(R.string.applications_gotmind_features_settings_mindwave_arc),
+                MindWaveMode.HARMONIC_RING to stringResource(R.string.applications_gotmind_features_settings_mindwave_ring)
             ),
             onSelected = { onSettingsEvent(SettingsEvent.SetMindWaveMode(it)) }
+        )
+
+        SettingsDropdownItem(
+            icon = Icons.Default.Palette,
+            title = stringResource(R.string.applications_gotmind_features_settings_mw_node_shape),
+            currentValue = gameSettings.mindWaveNodeShape,
+            options = NodeShape.entries,
+            optionLabels = mapOf(
+                NodeShape.CIRCLE to stringResource(R.string.applications_gotmind_features_settings_mw_node_shape_circle),
+                NodeShape.PIANO_KEY to stringResource(R.string.applications_gotmind_features_settings_mw_node_shape_piano)
+            ),
+            onSelected = { onSettingsEvent(SettingsEvent.SetMindWaveNodeShape(it)) }
         )
 
         SettingsDropdownItem(

--- a/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsViewModel.kt
+++ b/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import com.zoewave.probase.gotmind.analytics.AnalyticsHelper
 import com.zoewave.probase.gotmind.model.AppTheme
 import com.zoewave.probase.gotmind.model.ColorPalette
 import com.zoewave.probase.gotmind.model.MindWaveMode
+import com.zoewave.probase.gotmind.model.InstrumentType
 import com.zoewave.probase.gotmind.model.ThemeSettings
 import com.zoewave.probase.gotmind.model.GameSettings
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,6 +23,8 @@ sealed interface SettingsEvent {
     data class SetTheme(val theme: AppTheme) : SettingsEvent
     data class SetPalette(val palette: ColorPalette) : SettingsEvent
     data class SetMindWaveMode(val mode: MindWaveMode) : SettingsEvent
+    data class SetInstrument(val instrument: InstrumentType) : SettingsEvent
+    data class SetSongMaster(val enabled: Boolean) : SettingsEvent
 }
 
 @HiltViewModel
@@ -55,6 +58,12 @@ class SettingsViewModel @Inject constructor(
             }
             is SettingsEvent.SetMindWaveMode -> viewModelScope.launch {
                 appSettingsRepository.saveMindWaveMode(event.mode)
+            }
+            is SettingsEvent.SetInstrument -> viewModelScope.launch {
+                appSettingsRepository.saveInstrumentType(event.instrument)
+            }
+            is SettingsEvent.SetSongMaster -> viewModelScope.launch {
+                appSettingsRepository.saveSongMasterEnabled(event.enabled)
             }
         }
     }

--- a/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsViewModel.kt
+++ b/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import com.zoewave.probase.gotmind.analytics.AnalyticsHelper
 import com.zoewave.probase.gotmind.model.AppTheme
 import com.zoewave.probase.gotmind.model.ColorPalette
 import com.zoewave.probase.gotmind.model.MindWaveMode
+import com.zoewave.probase.gotmind.model.NodeShape
 import com.zoewave.probase.gotmind.model.InstrumentType
 import com.zoewave.probase.gotmind.model.ThemeSettings
 import com.zoewave.probase.gotmind.model.GameSettings
@@ -23,6 +24,7 @@ sealed interface SettingsEvent {
     data class SetTheme(val theme: AppTheme) : SettingsEvent
     data class SetPalette(val palette: ColorPalette) : SettingsEvent
     data class SetMindWaveMode(val mode: MindWaveMode) : SettingsEvent
+    data class SetMindWaveNodeShape(val shape: NodeShape) : SettingsEvent
     data class SetInstrument(val instrument: InstrumentType) : SettingsEvent
     data class SetSongMaster(val enabled: Boolean) : SettingsEvent
 }
@@ -58,6 +60,9 @@ class SettingsViewModel @Inject constructor(
             }
             is SettingsEvent.SetMindWaveMode -> viewModelScope.launch {
                 appSettingsRepository.saveMindWaveMode(event.mode)
+            }
+            is SettingsEvent.SetMindWaveNodeShape -> viewModelScope.launch {
+                appSettingsRepository.saveMindWaveNodeShape(event.shape)
             }
             is SettingsEvent.SetInstrument -> viewModelScope.launch {
                 appSettingsRepository.saveInstrumentType(event.instrument)

--- a/applications/gotmind/features/settings/src/main/res/values/strings.xml
+++ b/applications/gotmind/features/settings/src/main/res/values/strings.xml
@@ -30,8 +30,8 @@
     <string name="applications_gotmind_features_settings_palette_ocean">Ocean Theme</string>
     <string name="applications_gotmind_features_settings_palette_expressive">Material 3 Expressive (Wallpaper)</string>
 
-    <!-- MindWave Settings -->
-    <string name="applications_gotmind_features_settings_mindwave_section">MindWave Settings</string>
+    <!-- SoundMind Settings -->
+    <string name="applications_gotmind_features_settings_mindwave_section">SoundMind Settings</string>
     <string name="applications_gotmind_features_settings_mindwave_version">Game Version</string>
     <string name="applications_gotmind_features_settings_mindwave_classic">Classic</string>
     <string name="applications_gotmind_features_settings_mindwave_symphony">Symphony (Colors + Notes)</string>

--- a/applications/gotmind/features/settings/src/main/res/values/strings.xml
+++ b/applications/gotmind/features/settings/src/main/res/values/strings.xml
@@ -35,4 +35,12 @@
     <string name="applications_gotmind_features_settings_mindwave_version">Game Version</string>
     <string name="applications_gotmind_features_settings_mindwave_classic">Classic</string>
     <string name="applications_gotmind_features_settings_mindwave_symphony">Symphony (Colors + Notes)</string>
+
+    <string name="applications_gotmind_features_settings_mw_instrument">Instrument Skin</string>
+    <string name="applications_gotmind_features_settings_mw_instrument_clean">Clean Synth (Sine)</string>
+    <string name="applications_gotmind_features_settings_mw_instrument_retro">Retro 8-Bit (Square)</string>
+    <string name="applications_gotmind_features_settings_mw_instrument_zen">Zen Flute (Triangle)</string>
+
+    <string name="applications_gotmind_features_settings_mw_song_master">Song Master Mode</string>
+    <string name="applications_gotmind_features_settings_mw_song_master_desc">Learn famous melodies through play</string>
 </resources>

--- a/applications/gotmind/features/settings/src/main/res/values/strings.xml
+++ b/applications/gotmind/features/settings/src/main/res/values/strings.xml
@@ -33,8 +33,9 @@
     <!-- SoundMind Settings -->
     <string name="applications_gotmind_features_settings_mindwave_section">SoundMind Settings</string>
     <string name="applications_gotmind_features_settings_mindwave_version">Game Version</string>
-    <string name="applications_gotmind_features_settings_mindwave_classic">Classic</string>
-    <string name="applications_gotmind_features_settings_mindwave_symphony">Symphony (Colors + Notes)</string>
+    <string name="applications_gotmind_features_settings_mindwave_classic">Classic Grid</string>
+    <string name="applications_gotmind_features_settings_mindwave_symphony">Symphony Grid</string>
+    <string name="applications_gotmind_features_settings_mindwave_arc">Harmonic Arc (Half Ring)</string>
 
     <string name="applications_gotmind_features_settings_mw_instrument">Instrument Skin</string>
     <string name="applications_gotmind_features_settings_mw_instrument_clean">Clean Synth (Sine)</string>

--- a/applications/gotmind/features/settings/src/main/res/values/strings.xml
+++ b/applications/gotmind/features/settings/src/main/res/values/strings.xml
@@ -36,6 +36,11 @@
     <string name="applications_gotmind_features_settings_mindwave_classic">Classic Grid</string>
     <string name="applications_gotmind_features_settings_mindwave_symphony">Symphony Grid</string>
     <string name="applications_gotmind_features_settings_mindwave_arc">Harmonic Arc (Half Ring)</string>
+    <string name="applications_gotmind_features_settings_mindwave_ring">Harmonic Ring (Full Circle)</string>
+
+    <string name="applications_gotmind_features_settings_mw_node_shape">Memory Key Style</string>
+    <string name="applications_gotmind_features_settings_mw_node_shape_circle">Orbital Spheres (Original)</string>
+    <string name="applications_gotmind_features_settings_mw_node_shape_piano">Rainbow Piano Keys</string>
 
     <string name="applications_gotmind_features_settings_mw_instrument">Instrument Skin</string>
     <string name="applications_gotmind_features_settings_mw_instrument_clean">Clean Synth (Sine)</string>

--- a/applications/gotmind/model/src/main/java/com/zoewave/probase/gotmind/model/GameSettings.kt
+++ b/applications/gotmind/model/src/main/java/com/zoewave/probase/gotmind/model/GameSettings.kt
@@ -9,7 +9,7 @@ enum class MemBloxEngineType {
 
 @Serializable
 enum class MindWaveMode {
-    CLASSIC, SYMPHONY
+    CLASSIC, SYMPHONY, HARMONIC_ARC
 }
 
 @Serializable

--- a/applications/gotmind/model/src/main/java/com/zoewave/probase/gotmind/model/GameSettings.kt
+++ b/applications/gotmind/model/src/main/java/com/zoewave/probase/gotmind/model/GameSettings.kt
@@ -12,6 +12,11 @@ enum class MindWaveMode {
     CLASSIC, SYMPHONY
 }
 
+@Serializable
+enum class InstrumentType {
+    CLEAN_SYNTH, RETRO_8BIT, ZEN_TRIANGLE
+}
+
 data class GameSettings(
     val engineType: MemBloxEngineType = MemBloxEngineType.STATIC,
     val gameSpeed: Float = 1.0f,
@@ -19,5 +24,7 @@ data class GameSettings(
     val dropDurationMillis: Int = 3000,
     val hapticsEnabled: Boolean = true,
     val soundEnabled: Boolean = true,
-    val mindWaveMode: MindWaveMode = MindWaveMode.CLASSIC
+    val mindWaveMode: MindWaveMode = MindWaveMode.CLASSIC,
+    val instrumentType: InstrumentType = InstrumentType.CLEAN_SYNTH,
+    val songMasterEnabled: Boolean = false
 )

--- a/applications/gotmind/model/src/main/java/com/zoewave/probase/gotmind/model/GameSettings.kt
+++ b/applications/gotmind/model/src/main/java/com/zoewave/probase/gotmind/model/GameSettings.kt
@@ -9,7 +9,12 @@ enum class MemBloxEngineType {
 
 @Serializable
 enum class MindWaveMode {
-    CLASSIC, SYMPHONY, HARMONIC_ARC
+    CLASSIC, SYMPHONY, HARMONIC_ARC, HARMONIC_RING
+}
+
+@Serializable
+enum class NodeShape {
+    CIRCLE, PIANO_KEY
 }
 
 @Serializable
@@ -25,6 +30,7 @@ data class GameSettings(
     val hapticsEnabled: Boolean = true,
     val soundEnabled: Boolean = true,
     val mindWaveMode: MindWaveMode = MindWaveMode.CLASSIC,
+    val mindWaveNodeShape: NodeShape = NodeShape.CIRCLE,
     val instrumentType: InstrumentType = InstrumentType.CLEAN_SYNTH,
     val songMasterEnabled: Boolean = false
 )

--- a/core/util/src/main/java/com/zoewave/probase/core/util/audio/WaveSynthesizer.kt
+++ b/core/util/src/main/java/com/zoewave/probase/core/util/audio/WaveSynthesizer.kt
@@ -41,20 +41,41 @@ class WaveSynthesizer @Inject constructor() {
         audioTrack.play()
     }
 
-    suspend fun playTone(frequency: Double, durationMillis: Long) = withContext(Dispatchers.Default) {
+    enum class Waveform { SINE, SQUARE, TRIANGLE }
+
+    suspend fun playTone(
+        frequency: Double, 
+        durationMillis: Long, 
+        waveform: Waveform = Waveform.SINE
+    ) = withContext(Dispatchers.Default) {
         val numSamples = (durationMillis * sampleRate / 1000).toInt()
         val samples = ShortArray(numSamples)
         
         for (i in 0 until numSamples) {
-            // Sine wave generation
-            val angle = 2.0 * PI * i / (sampleRate / frequency)
+            val t = i.toDouble() / sampleRate
+            val angle = 2.0 * PI * frequency * t
+            
+            // Generate raw waveform
+            val rawValue = when (waveform) {
+                Waveform.SINE -> sin(angle)
+                Waveform.SQUARE -> if (sin(angle) >= 0) 1.0 else -1.0
+                Waveform.TRIANGLE -> {
+                    val period = 1.0 / frequency
+                    val relativeT = t % period
+                    val fraction = relativeT / period
+                    if (fraction < 0.25) 4.0 * fraction
+                    else if (fraction < 0.75) 2.0 - 4.0 * fraction
+                    else 4.0 * fraction - 4.0
+                }
+            }
+
             // Apply a slight fade-in/out to avoid clicking
             val envelope = when {
                 i < 441 -> i / 441.0 // 10ms fade in
                 i > numSamples - 441 -> (numSamples - i) / 441.0 // 10ms fade out
                 else -> 1.0
             }
-            samples[i] = (sin(angle) * Short.MAX_VALUE * 0.5 * envelope).toInt().toShort()
+            samples[i] = (rawValue * Short.MAX_VALUE * 0.4 * envelope).toInt().toShort()
         }
         
         audioTrack.write(samples, 0, numSamples, AudioTrack.WRITE_BLOCKING)


### PR DESCRIPTION
refactor(mindwave): remove constellation path visualization

This commit removes the `ConstellationPath` component and its associated drawing logic from the MindWave screen.

- **`MindWaveScreen.kt`**:
    - Deleted the `ConstellationPath` composable function, which handled canvas-based drawing of paths for different `MindWaveMode` states.
    - Removed the conditional rendering logic for `ConstellationPath` within the main `MindWaveScreen` layout.
    - Cleaned up the unused `StrokeCap` import.