### PR TITLE
refactor(mindwave): remove constellation path visualization

### DIFF
--- a/core/util/src/main/java/com/zoewave/probase/core/util/audio/WaveSynthesizer.kt
+++ b/core/util/src/main/java/com/zoewave/probase/core/util/audio/WaveSynthesizer.kt
@@ -4,6 +4,8 @@ import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -13,32 +15,39 @@ import kotlin.math.sin
 @Singleton
 class WaveSynthesizer @Inject constructor() {
     private val sampleRate = 44100
-    private val bufferSize = AudioTrack.getMinBufferSize(
+    private val minBufferSize = AudioTrack.getMinBufferSize(
         sampleRate,
         AudioFormat.CHANNEL_OUT_MONO,
         AudioFormat.ENCODING_PCM_16BIT
     )
+    // Use a much larger buffer (3x min) to prevent underruns during calculation
+    private val bufferSize = (minBufferSize * 3).coerceAtLeast(8192)
+    
+    private val writeMutex = Mutex()
 
-    private val audioTrack = AudioTrack.Builder()
-        .setAudioAttributes(
-            AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_GAME)
-                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                .build()
-        )
-        .setAudioFormat(
-            AudioFormat.Builder()
-                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                .setSampleRate(sampleRate)
-                .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
-                .build()
-        )
-        .setBufferSizeInBytes(bufferSize)
-        .setTransferMode(AudioTrack.MODE_STREAM)
-        .build()
+    private var audioTrack: AudioTrack? = createAudioTrack()
 
-    init {
-        audioTrack.play()
+    private fun createAudioTrack(): AudioTrack {
+        val track = AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_GAME)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build()
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                    .setSampleRate(sampleRate)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build()
+            )
+            .setBufferSizeInBytes(bufferSize)
+            .setTransferMode(AudioTrack.MODE_STREAM)
+            .build()
+        
+        track.play()
+        return track
     }
 
     enum class Waveform { SINE, SQUARE, TRIANGLE }
@@ -51,11 +60,11 @@ class WaveSynthesizer @Inject constructor() {
         val numSamples = (durationMillis * sampleRate / 1000).toInt()
         val samples = ShortArray(numSamples)
         
+        // 1. Calculate the wave data in parallel (before locking the track)
         for (i in 0 until numSamples) {
             val t = i.toDouble() / sampleRate
             val angle = 2.0 * PI * frequency * t
             
-            // Generate raw waveform
             val rawValue = when (waveform) {
                 Waveform.SINE -> sin(angle)
                 Waveform.SQUARE -> if (sin(angle) >= 0) 1.0 else -1.0
@@ -69,7 +78,6 @@ class WaveSynthesizer @Inject constructor() {
                 }
             }
 
-            // Apply a slight fade-in/out to avoid clicking
             val envelope = when {
                 i < 441 -> i / 441.0 // 10ms fade in
                 i > numSamples - 441 -> (numSamples - i) / 441.0 // 10ms fade out
@@ -78,11 +86,29 @@ class WaveSynthesizer @Inject constructor() {
             samples[i] = (rawValue * Short.MAX_VALUE * 0.4 * envelope).toInt().toShort()
         }
         
-        audioTrack.write(samples, 0, numSamples, AudioTrack.WRITE_BLOCKING)
+        // 2. Safely write to the audio track one tone at a time
+        writeMutex.withLock {
+            try {
+                val track = audioTrack ?: return@withLock
+                
+                // If track was disabled or underrun happened, ensure it's in playing state
+                if (track.state == AudioTrack.STATE_INITIALIZED) {
+                    if (track.playState != AudioTrack.PLAYSTATE_PLAYING) {
+                        track.play()
+                    }
+                    track.write(samples, 0, numSamples, AudioTrack.WRITE_BLOCKING)
+                }
+            } catch (e: Exception) {
+                // Recover from native errors or state changes
+                audioTrack = createAudioTrack()
+            }
+        }
     }
 
     fun stop() {
-        audioTrack.stop()
-        audioTrack.release()
+        writeMutex.tryLock() // Try to prevent mid-write release
+        audioTrack?.stop()
+        audioTrack?.release()
+        audioTrack = null
     }
 }


### PR DESCRIPTION
This commit removes the `ConstellationPath` component and its associated drawing logic from the MindWave screen.

- **`MindWaveScreen.kt`**:
    - Deleted the `ConstellationPath` composable function, which handled canvas-based drawing of paths for different `MindWaveMode` states.
    - Removed the conditional rendering logic for `ConstellationPath` within the main `MindWaveScreen` layout.
    - Cleaned up the unused `StrokeCap` import.