### PR TITLE
Ko color

### DIFF
--- a/applications/kocolor/Docs/PrivacyPolicy.md
+++ b/applications/kocolor/Docs/PrivacyPolicy.md
@@ -1,0 +1,56 @@
+# Privacy Policy for KoColor
+
+**Effective Date:** April 21, 2026
+
+**ZoeWave LLC** ("we", "us", or "our") provides the KoColor application as a Commercial service. This application is intended for use as is.
+
+### 1. Information Collection and Use: The Zero-Footprint Mandate
+KoColor is engineered with a "Zero-Footprint" mandate.
+* **Local Storage Only:** All data created within the app—including style profiles, analysis history, saved color palettes, and photographs—is stored exclusively in a secure local database on your device.
+* **No Central Servers:** We do not own, operate, or utilize central servers to store your fashion data. We have no access to your personal information, and your data is never synchronized to external servers by ZoeWave LLC.
+* **No Account Required:** You are not required to create an account, log in, or provide an email address to use the service.
+
+### 2. Generative AI and Data Processing (BYOK Model)
+KoColor provides an interface for advanced style and color analysis using Generative AI (Gemini Flash).
+* **Bring Your Own Key:** Intelligence is not a native component of the software. Users may optionally provide their own API Key generated via Google AI Studio.
+* **Ephemeral Processing:** When using analysis features, visual data (Face, Hair, Shoes, Clothes) is transmitted to the service provider (Google) for processing. This data is handled in-memory and is not retained, viewed, or stored by ZoeWave LLC.
+* **Liability Boundary:** The contract for the use of AI intelligence exists between the User and the API provider. ZoeWave LLC acts as the tool manufacturer (the "Vehicle") and is not responsible for the issuance or governance of the "Fuel" (the API Key) provided by the user.
+
+### 3. Device Permissions
+To provide core functionality, KoColor requires the following permissions:
+* **Camera:** Used solely to capture photos of your face, hair, shoes, and clothing for style coordination and AR preview features.
+* **Storage / Media:** Used to save your fashion-associated photos locally on your device and to allow you to select images from your gallery.
+* **Location (GPS):** Used optionally to provide fashion recommendations tailored to your current location (e.g., local weather or cultural trends). You may manually override or disable this at any time.
+
+### 4. Advertising and Tracking
+* **No Advertising ID:** KoColor does not use the Google Advertising ID (AD_ID) for tracking or profiling. This permission is explicitly removed from our application artifacts.
+* **No Third-Party Ads:** We do not show advertisements within the app.
+
+### **5. Third-Party Services and API Integration**
+KoColor utilizes a limited number of third-party services to ensure application stability and provide optional advanced features. These services fall into two categories:
+
+#### **A. Stability and Analytics (Standard)**
+The app uses industry-standard SDKs to monitor performance and anonymized usage trends. These services may collect information used to identify your device type and software version to help us maintain a crash-free experience:
+* [Google Play Services](https://policies.google.com/privacy)
+* [Firebase Crashlytics](https://firebase.google.com/support/privacy/) (For stability and bug reporting)
+* [Google Analytics for Firebase](https://firebase.google.com/policies/analytics) (For anonymized usage metrics)
+
+#### **B. User-Provided Intelligence (Optional)**
+To enable advanced style analysis features, users may optionally provide their own **Google Gemini API Key**.
+* **Local Storage of Keys:** If provided, your API Key is stored exclusively in your device's secure local storage. ZoeWave LLC does not transmit, store, or have access to this key on any external servers.
+* **Governing Policies:** When an API Key is provided, your interactions with the Gemini engine are governed directly by your individual agreement with Google. The data processed during these interactions is subject to the [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy) and the [Google Privacy Policy](https://policies.google.com/privacy).
+* **Liability Boundary:** ZoeWave LLC acts solely as a client-side interface (the "Vehicle"). The issuance, security, and governance of the API Key (the "Fuel") are the sole responsibility of the User and the service provider (Google).
+
+### 6. Children’s Privacy
+KoColor is a personal style utility rated **13+**. We do not knowingly collect personally identifiable information from children. Because the application operates locally and lacks peer-to-peer communication or social features, it provides a secure environment for users aged 13 and older. High-fidelity Generative AI features are subject to the age restrictions and verification protocols of the API provider (Google).
+
+### 7. Data Deletion and Security
+Since all data resides on your device, you maintain absolute sovereignty over your information.
+* **Data Deletion:** Deleting the KoColor application instantly and permanently removes all local databases, profiles, and stored images. ZoeWave LLC cannot recover this data once the application is uninstalled.
+* **Security Recommendation:** We recommend utilizing device-level security, such as biometrics or passcodes, to protect the data stored within the KoColor enclave.
+
+### 8. Changes to This Privacy Policy
+We may update our Privacy Policy periodically to reflect technical or regulatory changes. You are encouraged to review this page for updates.
+
+### 9. Contact Us
+If you have questions regarding our privacy architecture, please contact us at: **Developer@ZoeWave.com**.

--- a/applications/kocolor/apps/mobile/.gitignore
+++ b/applications/kocolor/apps/mobile/.gitignore
@@ -1,1 +1,11 @@
-/build
+/build/
+*.iml
+.gradle
+/local.properties
+/.idea/caches
+/.idea/libraries
+/.idea/modules.xml
+/.idea/workspace.xml
+/.idea/navEditor.xml
+/.idea/assetWizardSettings.xml
+/release

--- a/applications/kocolor/apps/mobile/core/src/main/res/values/strings.xml
+++ b/applications/kocolor/apps/mobile/core/src/main/res/values/strings.xml
@@ -11,4 +11,6 @@
     <string name="applications_kocolor_apps_mobile_core_palette_dynamic">Dynamic (Android 12+)</string>
     <string name="applications_kocolor_apps_mobile_core_settings_theme_title">App Theme</string>
     <string name="applications_kocolor_apps_mobile_core_settings_palette_title">Color Palette</string>
+    <string name="applications_kocolor_apps_mobile_core_settings_about_privacy_policy">Privacy Policy</string>
+    <string name="applications_kocolor_apps_mobile_core_privacy_policy_url">https://github.com/your-org/probase/blob/main/applications/kocolor/Docs/PrivacyPolicy.md</string>
 </resources>

--- a/applications/kocolor/apps/mobile/features/settings/src/main/java/com/zoewave/probase/kocolor/mobile/features/settings/ui/components/SettingsScreen.kt
+++ b/applications/kocolor/apps/mobile/features/settings/src/main/java/com/zoewave/probase/kocolor/mobile/features/settings/ui/components/SettingsScreen.kt
@@ -8,12 +8,16 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.zoewave.probase.features.ai.configuration.ui.AiConfigurationCard
+import com.zoewave.probase.kocolor.mobile.core.R
 import com.zoewave.probase.kocolor.mobile.features.settings.ui.SettingsEvent
 import com.zoewave.probase.kocolor.mobile.features.settings.ui.SettingsUiState
 import com.zoewave.probase.kocolor.mobile.features.settings.ui.SettingsViewModel
@@ -43,6 +47,9 @@ fun SettingsScreen(
     navTo: (KoColorRoute?) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val uriHandler = LocalUriHandler.current
+    val privacyPolicyUrl = stringResource(R.string.applications_kocolor_apps_mobile_core_privacy_policy_url)
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -91,6 +98,20 @@ fun SettingsScreen(
                     Spacer(modifier = Modifier.height(8.dp))
                     Text("KoColor Fashion App v0.1.0")
                     Text("Powered by Gemini AI")
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    TextButton(
+                        onClick = { uriHandler.openUri(privacyPolicyUrl) },
+                        modifier = Modifier.align(Alignment.Start),
+                        contentPadding = PaddingValues(0.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.applications_kocolor_apps_mobile_core_settings_about_privacy_policy),
+                            color = MaterialTheme.colorScheme.primary,
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
                 }
             }
         }

--- a/applications/kocolor/apps/mobile/src/main/AndroidManifest.xml
+++ b/applications/kocolor/apps/mobile/src/main/AndroidManifest.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:name=".KoColorApp"

--- a/applications/kocolor/features/analyzer/build.gradle.kts
+++ b/applications/kocolor/features/analyzer/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 
 dependencies {
     implementation(project(":core:model"))
+    implementation(project(":core:data"))
     implementation(project(":core:ui"))
     implementation(project(":core:util"))
     implementation(project(":applications:kocolor:model"))
@@ -19,6 +20,7 @@ dependencies {
     implementation(project(":features:camera"))
 
     implementation(libs.google.generative.ai)
+    implementation(libs.google.play.services.maps)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/data/AnalyzerEngine.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/data/AnalyzerEngine.kt
@@ -23,6 +23,7 @@ class AnalyzerEngine @Inject constructor() {
         shoes: Bitmap?,
         clothes: Bitmap?,
         occasion: String,
+        location: String?,
         apiKey: String,
         modelName: String = "gemini-1.5-flash"
     ): FashionAdvice {
@@ -43,6 +44,7 @@ class AnalyzerEngine @Inject constructor() {
             text("""
                 You are a professional personal color analyst and style consultant. 
                 The user is preparing for a specific occasion: $occasion.
+                ${if (location != null) "Current Location Context: $location. Take local climate and fashion trends for this area into account." else ""}
                 
                 I have provided up to 4 images:
                 1. Face selfie
@@ -63,7 +65,7 @@ class AnalyzerEngine @Inject constructor() {
                 1. Identify the Seasonal Type (SPRING, SUMMER, AUTUMN, WINTER) of the face.
                 2. Identify the Undertone (WARM, COOL, NEUTRAL) of the face.
                 3. Analyze how the hair and shoe colors (if provided) interact with the skin tone and clothing.
-                4. Provide a cohesive summary explaining the coordination strategy for the $occasion.
+                4. Provide a cohesive summary explaining the coordination strategy for the $occasion ${if (location != null) "in $location" else ""}.
                 5. Give specific makeup suggestions (Foundation, Lip, Eye, Blush) appropriate for $occasion.
                 6. Give a specific recommendation for NAIL POLISH color and finish that ties the whole look together for $occasion. Ensure this is categorized as "Nail Polish" in your response.
                 7. Recommend a makeup color palette (HEX codes).

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/ui/AnalyzerScreen.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/ui/AnalyzerScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -204,6 +205,13 @@ fun StyleCaptureState(
             onOccasionSelected = { onEvent(AnalyzerEvent.OnOccasionSelected(it)) }
         )
 
+        LocationInput(
+            locationName = uiState.locationName,
+            isLocating = uiState.isLocating,
+            onLocationChanged = { onEvent(AnalyzerEvent.OnLocationChanged(it)) },
+            onDetectLocation = { onEvent(AnalyzerEvent.OnDetectLocationClicked) }
+        )
+
         Button(
             onClick = onAnalyze,
             enabled = uiState.faceUri != null || uiState.hairUri != null || uiState.shoesUri != null || uiState.clothesUri != null,
@@ -241,6 +249,48 @@ fun OccasionFilter(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun LocationInput(
+    locationName: String?,
+    isLocating: Boolean,
+    onLocationChanged: (String?) -> Unit,
+    onDetectLocation: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text("Style Location", style = MaterialTheme.typography.labelMedium)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedTextField(
+                value = locationName ?: "",
+                onValueChange = { onLocationChanged(it.takeIf { it.isNotBlank() }) },
+                modifier = Modifier.weight(1f),
+                placeholder = { Text("City, Style Capital...") },
+                label = { Text("Local Context") },
+                singleLine = true,
+                trailingIcon = {
+                    if (isLocating) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                    } else {
+                        IconButton(onClick = onDetectLocation) {
+                            Icon(Icons.Default.MyLocation, contentDescription = "Detect Location")
+                        }
+                    }
+                }
+            )
+        }
+        Text(
+            "AI will tailor your palette to local fashion trends.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/ui/AnalyzerViewModel.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/ui/AnalyzerViewModel.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.features.ai.configuration.domain.AiConfigurationSettings
+import com.zoewave.probase.core.data.repository.travel.LocationRepository
 import com.zoewave.probase.kocolor.data.FashionRepository
 import com.zoewave.probase.kocolor.data.repository.FashionSessionRepository
 import com.zoewave.probase.kocolor.features.analyzer.data.AnalyzerEngine
@@ -31,7 +32,9 @@ data class AnalyzerScreenUiState(
     val hairUri: String? = null,
     val shoesUri: String? = null,
     val clothesUri: String? = null,
-    val selectedOccasion: String = "Work"
+    val selectedOccasion: String = "Work",
+    val locationName: String? = null,
+    val isLocating: Boolean = false
 )
 
 sealed class AnalyzerEvent {
@@ -40,6 +43,8 @@ sealed class AnalyzerEvent {
     data class OnShoesCaptured(val uri: String) : AnalyzerEvent()
     data class OnClothesCaptured(val uri: String) : AnalyzerEvent()
     data class OnOccasionSelected(val occasion: String) : AnalyzerEvent()
+    data class OnLocationChanged(val location: String?) : AnalyzerEvent()
+    data object OnDetectLocationClicked : AnalyzerEvent()
     data object OnAnalyzeClicked : AnalyzerEvent()
     data class OnSaveClicked(val advice: FashionAdvice) : AnalyzerEvent()
     data object OnResetClicked : AnalyzerEvent()
@@ -51,15 +56,20 @@ class AnalyzerViewModel @Inject constructor(
     private val analyzerEngine: AnalyzerEngine,
     private val fashionRepository: FashionRepository,
     private val aiSettings: AiConfigurationSettings,
-    private val sessionRepository: FashionSessionRepository
+    private val sessionRepository: FashionSessionRepository,
+    private val locationRepository: LocationRepository
 ) : ViewModel() {
 
     private val _analyzerState = MutableStateFlow<AnalyzerUiState>(AnalyzerUiState.Idle)
     private val _selectedOccasion = MutableStateFlow("Work")
+    private val _manualLocation = MutableStateFlow<String?>(null)
+    private val _isLocating = MutableStateFlow(false)
 
     val uiState: StateFlow<AnalyzerScreenUiState> = combine(
         _analyzerState,
         _selectedOccasion,
+        _manualLocation,
+        _isLocating,
         sessionRepository.faceUri,
         sessionRepository.hairUri,
         sessionRepository.shoesUri,
@@ -67,10 +77,12 @@ class AnalyzerViewModel @Inject constructor(
     ) { params ->
         val analyzerState = params[0] as AnalyzerUiState
         val occasion = params[1] as String
-        val faceUri = params[2] as String?
-        val hairUri = params[3] as String?
-        val shoesUri = params[4] as String?
-        val clothesUri = params[5] as String?
+        val manualLoc = params[2] as String?
+        val isLocating = params[3] as Boolean
+        val faceUri = params[4] as String?
+        val hairUri = params[5] as String?
+        val shoesUri = params[6] as String?
+        val clothesUri = params[7] as String?
 
         AnalyzerScreenUiState(
             analyzerState = analyzerState,
@@ -78,7 +90,9 @@ class AnalyzerViewModel @Inject constructor(
             hairUri = hairUri,
             shoesUri = shoesUri,
             clothesUri = clothesUri,
-            selectedOccasion = occasion
+            selectedOccasion = occasion,
+            locationName = manualLoc,
+            isLocating = isLocating
         )
     }.stateIn(
         scope = viewModelScope,
@@ -103,6 +117,12 @@ class AnalyzerViewModel @Inject constructor(
             is AnalyzerEvent.OnOccasionSelected -> {
                 _selectedOccasion.value = event.occasion
             }
+            is AnalyzerEvent.OnLocationChanged -> {
+                _manualLocation.value = event.location
+            }
+            is AnalyzerEvent.OnDetectLocationClicked -> {
+                detectLocation()
+            }
             is AnalyzerEvent.OnAnalyzeClicked -> {
                 analyzePhotos()
             }
@@ -112,8 +132,21 @@ class AnalyzerViewModel @Inject constructor(
             is AnalyzerEvent.OnResetClicked -> {
                 _analyzerState.value = AnalyzerUiState.Idle
                 _selectedOccasion.value = "Work"
+                _manualLocation.value = null
                 sessionRepository.reset()
             }
+        }
+    }
+
+    private fun detectLocation() {
+        viewModelScope.launch {
+            _isLocating.value = true
+            locationRepository.updateLocation()
+            val latLng = locationRepository.currentLocation.first()
+            if (latLng != null) {
+                _manualLocation.value = "GPS: ${latLng.latitude}, ${latLng.longitude}"
+            }
+            _isLocating.value = false
         }
     }
 
@@ -124,6 +157,7 @@ class AnalyzerViewModel @Inject constructor(
             val sUri = uiState.value.shoesUri
             val cUri = uiState.value.clothesUri
             val occasion = uiState.value.selectedOccasion
+            val location = uiState.value.locationName
 
             if (fUri == null && hUri == null && sUri == null && cUri == null) {
                 _analyzerState.value = AnalyzerUiState.Error("Please capture at least one image.")
@@ -155,6 +189,7 @@ class AnalyzerViewModel @Inject constructor(
                     shoes = shoesBitmap,
                     clothes = clothesBitmap,
                     occasion = occasion,
+                    location = location,
                     apiKey = apiKey,
                     modelName = modelName
                 )


### PR DESCRIPTION
feat(kocolor): update app permissions and add privacy policy link
This commit updates the mobile application's manifest to include necessary permissions for notifications and location, while explicitly removing the advertising ID permission. It also introduces a privacy policy link within the settings screen and refines the project's version control ignore rules.

- **`AndroidManifest.xml`**:
    - Added `POST_NOTIFICATIONS` permission.
    - Added `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION` permissions.
    - Explicitly removed the `AD_ID` permission using `tools:node="remove"`.
- **`SettingsScreen.kt`**:
    - Added a "Privacy Policy" `TextButton` to the "About" section.
    - Implemented `LocalUriHandler` to open the privacy policy URL in a browser.
- **`strings.xml`**:
    - Defined new string resources for the privacy policy label and its corresponding URL.
- **`.gitignore`**:
    - Expanded the ignore list to include `.idea` configurations, `.gradle` files, `local.properties`, and build artifacts.