### PR TITLE
build(glass): update Glimmer dependencies to use core and font artifacts

### DIFF
--- a/applications/ashbike/apps/mobile/features/glass/build.gradle.kts
+++ b/applications/ashbike/apps/mobile/features/glass/build.gradle.kts
@@ -25,7 +25,8 @@ dependencies {
 
     // --- 2. Android XR / Glass (Glimmer) ---
     // Keeping these as they appear to be specific XR libraries in your catalog
-    implementation(libs.androidx.glimmer)
+    implementation(libs.androidx.glimmer.core)
+    implementation(libs.androidx.glimmer.google.fonts)
     implementation(libs.androidx.projected)
 
     // --- 3. AI & Gemini (Isolated Firebase SDK) ---


### PR DESCRIPTION
This commit refines the Android XR (Glimmer) dependency configuration within the glass feature module. It replaces the general Glimmer library with more specific core and Google Fonts artifacts to align with the latest library structure.

- **`build.gradle.kts`**:
    - Replaced the generic `libs.androidx.glimmer` dependency with `libs.androidx.glimmer.core` and `libs.androidx.glimmer.google.fonts`.