### PR TITLE
feat(photodo): implement financial context provider for budget tracking

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CidrRootsConfiguration">
     <excludeRoots>
       <file path="$PROJECT_DIR$/applications/gotmind/Docs" />
       <file path="$PROJECT_DIR$/applications/gotmind/features/memblox/docs" />
       <file path="$PROJECT_DIR$/applications/kocolor/Docs" />
+      <file path="$PROJECT_DIR$/applications/kocolor/Site" />
       <file path="$PROJECT_DIR$/applications/rxlogic/docs" />
       <file path="$PROJECT_DIR$/features/health/docs" />
       <file path="$PROJECT_DIR$/features/payment/Docs" />

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/di/FinancialBridgeModule.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/di/FinancialBridgeModule.kt
@@ -1,0 +1,20 @@
+package com.zoewave.probase.photodo.mobile.di
+
+import com.zoewave.probase.core.model.FinancialContextProvider
+import com.zoewave.probase.photodo.mobile.financial.PhotoDoFinancialContextProvider
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class FinancialBridgeModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindFinancialContextProvider(
+        impl: PhotoDoFinancialContextProvider
+    ): FinancialContextProvider
+}

--- a/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/financial/PhotoDoFinancialContextProvider.kt
+++ b/applications/photodo/apps/mobile/src/main/java/com/zoewave/probase/photodo/mobile/financial/PhotoDoFinancialContextProvider.kt
@@ -1,0 +1,31 @@
+package com.zoewave.probase.photodo.mobile.financial
+
+import com.zoewave.probase.core.model.FinancialContextProvider
+import com.zoewave.probase.applications.photodo.db.repo.PhotoDoRepo
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import javax.inject.Inject
+
+class PhotoDoFinancialContextProvider @Inject constructor(
+    private val repo: PhotoDoRepo
+) : FinancialContextProvider {
+
+    override suspend fun getFinancialContext(): String? {
+        val categories = repo.getCategoriesWithProjectsAndTasks().first()
+        if (categories.isEmpty()) return null
+        
+        return buildJsonObject {
+            put("currency", "USD")
+            putJsonObject("projects") {
+                categories.forEach { categoryWithData ->
+                    categoryWithData.projects.forEach { projectWithTasks ->
+                        val project = projectWithTasks.project
+                        put(project.name.lowercase(), project.projectBudget - project.currentSpend)
+                    }
+                }
+            }
+        }.toString()
+    }
+}


### PR DESCRIPTION
This commit introduces a financial context provider for the Photodo application, enabling the retrieval of project-specific budget information. It integrates the local repository with the core financial modeling layer to expose remaining budget data in a structured JSON format.

- **`.idea/misc.xml`**:
    - Added the `applications/kocolor/Site` directory to the project's excluded roots.
- **`FinancialBridgeModule.kt`**:
    - Created a new Hilt module to bind the `PhotoDoFinancialContextProvider` implementation to the `FinancialContextProvider` interface.
- **`PhotoDoFinancialContextProvider.kt`**:
    - Implemented `getFinancialContext` to fetch and aggregate category and project data from `PhotoDoRepo`.
    - Logic calculates the remaining budget for each project (`projectBudget` - `currentSpend`) and returns the data as a serialized JSON object with USD currency formatting.