### PR TITLE
feat(routines): display product usage metrics in routine editor

### DIFF
--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutineEditorScreen.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutineEditorScreen.kt
@@ -279,8 +279,21 @@ private fun StepSummaryRow(uiState: RoutineStep, onEvent: (Unit) -> Unit, navTo:
 @Preview(showBackground = true)
 @Composable
 private fun StepHeroPagePreview() {
+    val sampleProduct = CosmeticItem(
+        id = 1L,
+        name = "Silk Primer",
+        brand = "KoColor",
+        category = CosmeticCategory.PRIMER,
+        amountRemaining = 25.0,
+        amountPerUse = 0.5,
+        volume = "30ml"
+    )
     MaterialTheme {
-        StepHeroPage(uiState = RoutineStep(id = "1", title = "Step", layeringOrder = 0) to emptyList(), onEvent = {}, navTo = {})
+        StepHeroPage(
+            uiState = RoutineStep(id = "1", title = "Prep", layeringOrder = 0, productIds = listOf(1L)) to listOf(sampleProduct),
+            onEvent = {},
+            navTo = {}
+        )
     }
 }
 
@@ -367,21 +380,43 @@ private fun StepHeroPage(
                 )
                 
                 if (linkedProduct != null) {
-                    Surface(
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
-                        shape = RoundedCornerShape(20.dp),
-                        border = BorderStroke(1.dp, Color.Black.copy(alpha = 0.05f))
-                    ) {
-                        Row(modifier = Modifier.padding(20.dp), verticalAlignment = Alignment.CenterVertically) {
-                            Box(modifier = Modifier.size(64.dp).clip(RoundedCornerShape(12.dp)).background(MaterialTheme.colorScheme.surfaceVariant)) {
-                                if (linkedProduct.imageUrl != null) AsyncImage(model = linkedProduct.imageUrl, null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Surface(
+                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                            shape = RoundedCornerShape(20.dp),
+                            border = BorderStroke(1.dp, Color.Black.copy(alpha = 0.05f))
+                        ) {
+                            Row(modifier = Modifier.padding(20.dp), verticalAlignment = Alignment.CenterVertically) {
+                                Box(modifier = Modifier.size(64.dp).clip(RoundedCornerShape(12.dp)).background(MaterialTheme.colorScheme.surfaceVariant)) {
+                                    if (linkedProduct.imageUrl != null) AsyncImage(model = linkedProduct.imageUrl, null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
+                                }
+                                Spacer(Modifier.width(16.dp))
+                                Column {
+                                    Text(text = linkedProduct.brand.uppercase(), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black, color = MaterialTheme.colorScheme.primary)
+                                    Text(text = linkedProduct.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, fontFamily = FontFamily.Serif)
+                                    Text(text = linkedProduct.category.displayName, style = MaterialTheme.typography.labelSmall, modifier = Modifier.alpha(0.5f))
+                                }
                             }
-                            Spacer(Modifier.width(16.dp))
-                            Column {
-                                Text(text = linkedProduct.brand.uppercase(), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black, color = MaterialTheme.colorScheme.primary)
-                                Text(text = linkedProduct.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, fontFamily = FontFamily.Serif)
-                                Text(text = linkedProduct.category.displayName, style = MaterialTheme.typography.labelSmall, modifier = Modifier.alpha(0.5f))
-                            }
+                        }
+
+                        // Usage Metrics
+                        val unit = linkedProduct.volume?.filter { it.isLetter() } ?: ""
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            MetricCard(
+                                label = "PER APPLICATION",
+                                value = linkedProduct.amountPerUse?.let { "$it $unit" } ?: "Not set",
+                                icon = Icons.Default.Opacity,
+                                modifier = Modifier.weight(1f)
+                            )
+                            MetricCard(
+                                label = "AMOUNT LEFT",
+                                value = linkedProduct.amountRemaining?.let { "${it.toInt()} $unit" } ?: "Unknown",
+                                icon = Icons.Default.Inventory2,
+                                modifier = Modifier.weight(1f)
+                            )
                         }
                     }
                 } else {
@@ -457,6 +492,28 @@ private fun StepHeroPage(
                 Text("EDIT RITUAL STAGE", fontWeight = FontWeight.Bold, letterSpacing = 1.sp)
             }
             Spacer(Modifier.height(48.dp))
+        }
+    }
+}
+
+@Composable
+private fun MetricCard(
+    label: String,
+    value: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        color = Color.White,
+        shape = RoundedCornerShape(16.dp),
+        border = BorderStroke(1.dp, Color.Black.copy(alpha = 0.05f)),
+        modifier = modifier
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Icon(icon, null, modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+            Spacer(Modifier.height(8.dp))
+            Text(text = value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Text(text = label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f))
         }
     }
 }


### PR DESCRIPTION
This commit enhances the routine editor's step preview by displaying detailed usage statistics for linked cosmetic products. It introduces a specialized metric card component to visualize application amounts and remaining volume, providing users with immediate inventory insights within their ritual configuration.

- **`RoutineEditorScreen.kt`**:
    - **New `MetricCard` component**: Created a reusable private composable to display product metrics with an icon, bold value, and label.
    - **Enhanced `StepHeroPage`**:
        - Refactored the layout to include a usage metrics section when a product is linked.
        - Added logic to parse units from product volume strings. - Integrated two `MetricCard` instances to show "PER APPLICATION" and "AMOUNT LEFT" data.
    - **Updated Previews**: Enhanced `StepHeroPagePreview` with a sample `CosmeticItem` to accurately reflect the new UI metrics in the design tool.


🌟 New Usage Intelligence:
1.
Product Metrics Row: Added a dedicated metrics section under the "Curated Selection" card.
2.
Per Application Tracking: You can now see the exact dosage for that ritual stage (e.g., "0.5 ml") directly on the card.
3.
Real-Time Inventory Status: Displays the "Amount Left" in your product bottle or jar, allowing you to track your supply as you progress through your daily acts of care.
4.
Smart Unit Detection: The UI automatically extracts and displays the correct units (ml, g, etc.) based on your product's volume data.
5.
Refined Visual Hierarchy: Maintained the premium editorial look with high-contrast metric cards that provide a quick glance at your style investments and product performance.