### PR TITLE
feat(routines): update glass connection icons and refactor routine se…

### DIFF
--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutinesViewModel.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutinesViewModel.kt
@@ -166,8 +166,13 @@ class RoutinesViewModel @Inject constructor(
 
     private fun toggleStep(routineId: Long, stepId: String) {
         viewModelScope.launch {
-            val routine = (uiState.value.morningRoutine ?: uiState.value.eveningRoutine)?.takeIf { it.id == routineId }
-                ?: return@launch
+            val morning = uiState.value.morningRoutine
+            val evening = uiState.value.eveningRoutine
+            val routine = when {
+                morning?.id == routineId -> morning
+                evening?.id == routineId -> evening
+                else -> null
+            } ?: return@launch
             
             val updatedSteps = routine.steps.map { step ->
                 if (step.id == stepId) {

--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/components/GlassConnectionHeaderAction.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/components/GlassConnectionHeaderAction.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cast
 import androidx.compose.material.icons.filled.CastConnected
-import androidx.compose.material.icons.filled.PermDeviceInformation
-import androidx.compose.material.icons.filled.UsbOff
+import androidx.compose.material.icons.filled.PhonelinkOff
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -38,8 +38,8 @@ fun GlassConnectionHeaderAction(
 
     val icon = when (buttonState) {
         GlassButtonState.PROJECTING -> Icons.Default.CastConnected
-        GlassButtonState.READY_TO_START -> Icons.Default.PermDeviceInformation
-        GlassButtonState.NO_GLASSES -> Icons.Default.UsbOff
+        GlassButtonState.READY_TO_START -> Icons.Default.Cast
+        GlassButtonState.NO_GLASSES -> Icons.Default.PhonelinkOff
     }
 
     Surface(


### PR DESCRIPTION
…lection logic

This commit updates the visual representation of glass connection states and improves the reliability of routine step updates within the ViewModel.

- **`GlassConnectionHeaderAction.kt`**:
    - Updated the iconography for glass connection states to use more intuitive symbols.
    - Changed the `READY_TO_START` icon to `Icons.Default.Cast` and the `NO_GLASSES` icon to `Icons.Default.PhonelinkOff`.
- **`RoutinesViewModel.kt`**:
    - Refactored the `toggleStep` function to explicitly check both morning and evening routines for a matching `routineId`.
    - This ensures the correct routine is identified and updated even when multiple routines are present in the current UI state, resolving a logic bug where the second routine might be ignored.