### PR TITLE
feat(glass): implement remote exit command and dynamic routine titles

### DIFF
--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/FashionRepository.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/FashionRepository.kt
@@ -13,7 +13,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -32,12 +34,19 @@ class FashionRepository @Inject constructor(
     private val _isGlassSessionActive = MutableStateFlow(false)
     val isGlassSessionActive = _isGlassSessionActive.asStateFlow()
 
+    private val _glassCommands = MutableSharedFlow<String>()
+    val glassCommands = _glassCommands.asSharedFlow()
+
     fun updateGlassConnectionState(isConnected: Boolean) {
         _isGlassConnected.value = isConnected
     }
 
     fun updateGlassSessionState(isActive: Boolean) {
         _isGlassSessionActive.value = isActive
+    }
+
+    suspend fun sendGlassCommand(command: String) {
+        _glassCommands.emit(command)
     }
 
     fun getProfile(): Flow<FashionProfile?> {

--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutinesViewModel.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutinesViewModel.kt
@@ -158,7 +158,11 @@ class RoutinesViewModel @Inject constructor(
             is RoutinesEvent.ResetRoutine -> resetRoutine(event.routineId)
             is RoutinesEvent.ProjectToGlass -> {
                 viewModelScope.launch {
-                    _sideEffect.emit(RoutinesSideEffect.LaunchGlassProjection(event.time))
+                    if (uiState.value.glassButtonState == GlassButtonState.PROJECTING) {
+                        fashionRepository.sendGlassCommand("EXIT")
+                    } else {
+                        _sideEffect.emit(RoutinesSideEffect.LaunchGlassProjection(event.time))
+                    }
                 }
             }
         }

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GlassesMainActivity.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GlassesMainActivity.kt
@@ -66,6 +66,14 @@ class GlassesMainActivity : ComponentActivity() {
         // Initialize features. Phone app is responsible for pre-requesting permissions.
         initializeGlassesFeatures()
 
+        lifecycleScope.launch {
+            fashionRepository.glassCommands.collect { command ->
+                if (command == "EXIT") {
+                    finish()
+                }
+            }
+        }
+
         setContent {
             GlimmerTheme {
                 GlassApp(

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassRitualLayout.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassRitualLayout.kt
@@ -46,7 +46,11 @@ fun GlassRitualLayout(
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Text(
-                            text = if (areVisualsOn) "Morning Ritual" else "Display Off",
+                            text = if (areVisualsOn) {
+                                uiState.morningRoutine?.title?.replaceFirstChar { it.uppercase() } ?: "Morning Ritual"
+                            } else {
+                                "Display Off"
+                            },
                             style = GlimmerTheme.typography.titleMedium,
                             color = GlimmerTheme.colors.primary
                         )


### PR DESCRIPTION
This commit introduces a command mechanism to allow the mobile application to control the XR glasses session, specifically enabling remote termination of the glass activity. It also enhances the glass UI to display dynamic routine titles from the data layer.

- **`FashionRepository.kt`**:
    - Introduced a `MutableSharedFlow` and a corresponding public `SharedFlow` to broadcast commands to the glass module.
    - Added `sendGlassCommand` to allow other components to emit commands into the flow.
- **`RoutinesViewModel.kt`**:
    - Updated `ProjectToGlass` event handling to toggle the session state. If the glasses are already projecting, it now sends an "EXIT" command instead of launching a new projection.
- **`GlassesMainActivity.kt`**:
    - Implemented a lifecycle-aware collector for `glassCommands` that calls `finish()` when an "EXIT" command is received, allowing the mobile app to remotely close the XR activity.
- **`GlassRitualLayout.kt`**:
    - Refactored the header text to dynamically display the title from the current routine state with capitalization, falling back to a default string if no title is present.