### PR TITLE
feat(cosmetics): enhance category card visuals and include macro desc…

### DIFF
--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
@@ -31,7 +31,8 @@ data class CategoryMetadata(
     val representativeImageUrl: String? = null,
     val representativeColorHex: String? = null,
     val leadingBrand: String? = null,
-    val averageFillLevel: Double? = null
+    val averageFillLevel: Double? = null,
+    val description: String? = null
 )
 
 data class CosmeticsUiState(
@@ -139,7 +140,8 @@ class CosmeticsViewModel @Inject constructor(
         val models = entities.map { it.toModel() }
         val groupStats = entities.groupBy { it.macroCategory.displayName }.mapValues { it.value.size }
         
-        val categoryMetadata = models.groupBy { it.macroCategory.displayName }.mapValues { (_, items) ->
+        val categoryMetadata = models.groupBy { it.macroCategory.displayName }.mapValues { (name, items) ->
+            val macro = items.firstOrNull()?.macroCategory
             val representativeItem = items.filter { it.imageUrl != null }.maxByOrNull { it.usageCount } ?: items.maxByOrNull { it.usageCount }
             val brands = items.map { it.brand }.groupBy { it }.mapValues { it.value.size }
             val leadingBrand = brands.maxByOrNull { it.value }?.key
@@ -152,7 +154,8 @@ class CosmeticsViewModel @Inject constructor(
                 representativeImageUrl = representativeItem?.imageUrl,
                 representativeColorHex = representativeItem?.colorHex,
                 leadingBrand = leadingBrand,
-                averageFillLevel = averageFill
+                averageFillLevel = averageFill,
+                description = macro?.description
             )
         }
         val thirtyDaysInMillis = 30L * 24 * 60 * 60 * 1000

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
@@ -192,39 +192,53 @@ private fun AtelierCategoryCard(
     val totalValue = metadata?.totalValue ?: 0.0
     val leadingBrand = metadata?.leadingBrand
     val averageFill = metadata?.averageFillLevel ?: 1.0
+    val description = metadata?.description ?: when {
+        name.contains("Skincare", ignoreCase = true) -> "Everything applied before pigment."
+        name.contains("Complexion", ignoreCase = true) -> "Products that unify the skin tone."
+        name.contains("Dimension", ignoreCase = true) -> "Products that bring life, shadow, and light."
+        name.contains("Eyes", ignoreCase = true) -> "All definition for the upper face."
+        name.contains("Lips", ignoreCase = true) -> "All color and care for the mouth."
+        else -> "Professional curated category."
+    }
     
     val currencyFormatter = java.text.NumberFormat.getCurrencyInstance(java.util.Locale.US)
 
     Card(
         onClick = { navTo(KoColorRoute.CosmeticCategoryCover(name)) },
-        modifier = modifier.height(IntrinsicSize.Min),
-        shape = RoundedCornerShape(16.dp),
+        modifier = modifier.height(180.dp), // Increased height for background aesthetic
+        shape = RoundedCornerShape(24.dp),
         colors = CardDefaults.cardColors(containerColor = baseColor),
         border = BorderStroke(1.dp, Color.Black.copy(alpha = 0.05f))
     ) {
-        Row(
-            modifier = Modifier.padding(20.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            // 1. Professional Imagery
+        Box(modifier = Modifier.fillMaxSize()) {
+            // 1. Background Imagery (The "Aesthetic")
+            AsyncImage(
+                model = metadata?.representativeImageUrl ?: placeholderUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize().alpha(0.4f), // Subdued background
+                contentScale = ContentScale.Crop
+            )
+            
+            // 2. Readability Scrim
             Box(
                 modifier = Modifier
-                    .size(100.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(Color.White.copy(alpha = 0.5f))
+                    .fillMaxSize()
+                    .background(
+                        Brush.horizontalGradient(
+                            colors = listOf(baseColor, baseColor.copy(alpha = 0.6f), Color.Transparent),
+                            startX = 0f,
+                            endX = 1000f
+                        )
+                    )
+            )
+
+            // 3. Data Content
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.SpaceBetween
             ) {
-                AsyncImage(
-                    model = metadata?.representativeImageUrl ?: placeholderUrl,
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
-                )
-            }
-
-            Spacer(Modifier.width(24.dp))
-
-            // 2. Data Content
-            Column(modifier = Modifier.weight(1f)) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -234,7 +248,7 @@ private fun AtelierCategoryCard(
                         val displayName = if (name.contains("&")) name.substringBefore("&").trim() else name
                         Text(
                             text = displayName,
-                            style = MaterialTheme.typography.displaySmall.copy(fontSize = 28.sp),
+                            style = MaterialTheme.typography.displaySmall.copy(fontSize = 32.sp),
                             fontWeight = FontWeight.Bold,
                             fontFamily = FontFamily.Serif,
                             color = Color.Black
@@ -243,7 +257,7 @@ private fun AtelierCategoryCard(
                             text = "$count Items",
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.Medium,
-                            modifier = Modifier.alpha(0.6f)
+                            modifier = Modifier.alpha(0.8f)
                         )
                     }
 
@@ -256,22 +270,20 @@ private fun AtelierCategoryCard(
                     )
                 }
 
-                Spacer(Modifier.height(12.dp))
-
                 // Stock Status Bar
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                        Text(text = "Stock Status", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, modifier = Modifier.alpha(0.6f))
+                        Text(text = "Stock Status", style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, modifier = Modifier.alpha(0.8f))
                         Text(text = "${(averageFill * 100).toInt()}%", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black, color = Color(0xFF6B705C))
                     }
                     
-                    val statusColor = Color(0xFF6B705C) // Using the muted olive from the image for consistency
+                    val statusColor = Color(0xFF6B705C) 
 
                     LinearProgressIndicator(
                         progress = { averageFill.toFloat() },
-                        modifier = Modifier.fillMaxWidth().height(4.dp).clip(CircleShape),
+                        modifier = Modifier.fillMaxWidth().height(6.dp).clip(CircleShape),
                         color = statusColor,
-                        trackColor = statusColor.copy(alpha = 0.1f),
+                        trackColor = Color.White.copy(alpha = 0.3f),
                         strokeCap = androidx.compose.ui.graphics.StrokeCap.Round
                     )
                     
@@ -279,8 +291,8 @@ private fun AtelierCategoryCard(
                         Text(
                             text = "Leading Brand: $leadingBrand",
                             style = MaterialTheme.typography.bodySmall,
-                            fontWeight = FontWeight.Medium,
-                            modifier = Modifier.padding(top = 4.dp).alpha(0.6f)
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.alpha(0.8f)
                         )
                     }
                 }

--- a/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/CosmeticItem.kt
+++ b/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/CosmeticItem.kt
@@ -3,13 +3,13 @@ package com.zoewave.probase.kocolor.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class MacroCategory(val displayName: String) {
-    PREP("Skincare & Prep"),
-    COMPLEXION("Complexion"),
-    DIMENSION("Color & Dimension"),
-    EYES("Eyes & Brows"),
-    LIPS("Lips"),
-    TOOLS("Tools & Hygiene")
+enum class MacroCategory(val displayName: String, val description: String) {
+    PREP("Skincare & Prep", "Everything applied before pigment."),
+    COMPLEXION("Complexion", "Products that unify the skin tone."),
+    DIMENSION("Color & Dimension", "Products that bring life, shadow, and light."),
+    EYES("Eyes & Brows", "All definition for the upper face."),
+    LIPS("Lips", "All color and care for the mouth."),
+    TOOLS("Tools & Hygiene", "Brushes, sponges, and maintenance.")
 }
 
 @Serializable


### PR DESCRIPTION
…riptions

This commit upgrades the visual design of the cosmetic category cards on the landing screen to a more modern, high-fidelity aesthetic. It also enriches the data model by adding descriptive metadata to the top-level cosmetic categories.

- **`CosmeticItem.kt`**:
    - Updated the `MacroCategory` enum to include a `description` property for each category (e.g., "Everything applied before pigment" for Skincare & Prep).
- **`CosmeticsViewModel.kt`**:
    - Added a `description` field to the `CategoryMetadata` data class.
    - Updated the UI state mapping logic to extract and provide the category description from the domain model.
- **`VanityLandingScreen.kt`**:
    - Overhauled the category card layout by moving from a `Row`-based structure to a layered `Box` design.
    - Implemented a full-bleed background using the category's representative image with a 0.4 alpha and a horizontal gradient scrim for improved text readability.
    - Increased card height to `180.dp` and corner radius to `24.dp`.
    - Refined typography and spacing, increasing the category title size to `32.sp` and adjusting secondary text opacity to `0.8f`.
    - Styled the `LinearProgressIndicator` with a larger `6.dp` height and a semi-transparent white track for a more integrated look.