### PR TITLE
style(ui): refine typography and layout for routines and landing screens

### DIFF
--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionHubScreen.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionHubScreen.kt
@@ -78,7 +78,7 @@ fun CollectionHubScreen(
                     Icon(Icons.Default.Search, null, tint = Color.Gray)
                     Spacer(Modifier.width(12.dp))
                     Text(
-                        text = "Search your entire collection",
+                        text = "Search entire collection",
                         style = MaterialTheme.typography.bodyMedium,
                         color = Color.Gray,
                         modifier = Modifier.weight(1f)

--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeScreen.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeScreen.kt
@@ -5,15 +5,43 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.WaterDrop
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -28,14 +56,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.zoewave.probase.features.health.core.SkinInsight
-import com.zoewave.probase.kocolor.mobile.features.home.ui.components.*
-import com.zoewave.probase.kocolor.model.*
-
 import com.zoewave.probase.feature.weather.ui.components.layered.LayeredWeatherInfoIcon
 import com.zoewave.probase.feature.weather.ui.components.layered.LayeredWeatherUiState
+import com.zoewave.probase.features.health.core.SkinInsight
+import com.zoewave.probase.kocolor.mobile.features.home.ui.components.CollectionHubCard
+import com.zoewave.probase.kocolor.mobile.features.home.ui.components.LuxuryBrandLogo
+import com.zoewave.probase.kocolor.mobile.features.home.ui.components.RoutineSummaryCard
+import com.zoewave.probase.kocolor.model.FashionProfile
+import com.zoewave.probase.kocolor.model.KoColorRoute
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Preview(showBackground = true)
@@ -138,7 +166,7 @@ fun HomeScreen(
                 
                 if (routine != null) {
                     Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-                        SectionTitle(uiState = SectionTitleUiState(title, "Your bio-synced ritual"), onEvent = {}, navTo = {})
+                        SectionTitle(uiState = SectionTitleUiState(title, "Bio-synced ritual"), onEvent = {}, navTo = {})
                         RoutineSummaryCard(
                             uiState = routine to uiState.isDaytime,
                             onEvent = {},

--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/components/RoutineSummaryCard.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/components/RoutineSummaryCard.kt
@@ -54,19 +54,22 @@ fun RoutineSummaryCard(
                 modifier = Modifier.padding(28.dp).fillMaxSize(),
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
-                Column {
-                    Text(
-                        text = if (isDaytime) "Your Morning\nRitual" else "Your Evening\nRitual",
-                        style = MaterialTheme.typography.displaySmall,
-                        fontFamily = FontFamily.Serif,
-                        fontWeight = FontWeight.Bold,
-                        lineHeight = 36.sp,
-                        color = Color.Black
-                    )
-                    
-                    Spacer(Modifier.height(16.dp))
-                    
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = if (isDaytime) "Morning Ritual" else "Evening Ritual",
+                            style = MaterialTheme.typography.displaySmall.copy(fontSize = 32.sp),
+                            fontFamily = FontFamily.Serif,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.Black
+                        )
+                        
+                        Spacer(Modifier.height(12.dp))
+                        
                         Surface(
                             color = Color.Black.copy(alpha = 0.1f),
                             shape = RoundedCornerShape(12.dp)
@@ -80,28 +83,34 @@ fun RoutineSummaryCard(
                                 color = Color.Black
                             )
                         }
-                        
-                        Spacer(Modifier.width(16.dp))
-                        
-                        Box(contentAlignment = Alignment.Center, modifier = Modifier.size(48.dp)) {
-                            CircularProgressIndicator(
-                                progress = { 1f },
-                                modifier = Modifier.fillMaxSize(),
-                                color = Color.Black.copy(alpha = 0.05f),
-                                strokeWidth = 4.dp
-                            )
-                            CircularProgressIndicator(
-                                progress = { progress },
-                                modifier = Modifier.fillMaxSize(),
-                                color = Color.Black,
-                                strokeWidth = 4.dp,
-                                strokeCap = androidx.compose.ui.graphics.StrokeCap.Round
-                            )
+                    }
+                    
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.size(80.dp)) {
+                        CircularProgressIndicator(
+                            progress = { 1f },
+                            modifier = Modifier.fillMaxSize(),
+                            color = Color.Black.copy(alpha = 0.05f),
+                            strokeWidth = 6.dp
+                        )
+                        CircularProgressIndicator(
+                            progress = { progress },
+                            modifier = Modifier.fillMaxSize(),
+                            color = Color.Black,
+                            strokeWidth = 6.dp,
+                            strokeCap = androidx.compose.ui.graphics.StrokeCap.Round
+                        )
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Text(
                                 text = "$completedCount/$totalCount",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Black,
                                 color = Color.Black
+                            )
+                            Text(
+                                text = "DONE",
+                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
+                                fontWeight = FontWeight.Bold,
+                                color = Color.Black.copy(alpha = 0.5f)
                             )
                         }
                     }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
@@ -121,7 +121,7 @@ fun VanityLandingScreen(
                         fontWeight = FontWeight.Bold
                     )
                     Text(
-                        text = "Here is a glance at your collection today.",
+                        text = "Here is a glance at the collection today.",
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                     )

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
@@ -3,17 +3,42 @@ package com.zoewave.probase.kocolor.features.inventory.ui
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
+import androidx.compose.material.icons.filled.Checkroom
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Insights
+import androidx.compose.material.icons.filled.MonetizationOn
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,9 +54,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.kocolor.model.ClothingItem
 import com.zoewave.probase.kocolor.model.KoColorRoute
-import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import java.text.NumberFormat
 import java.util.Locale
 
@@ -85,13 +110,13 @@ fun WardrobeLandingScreen(
             item {
                 Column {
                     Text(
-                        text = "Your Curated Closet.",
+                        text = "Curated Closet.",
                         style = MaterialTheme.typography.headlineLarge,
                         fontFamily = FontFamily.Serif,
                         fontWeight = FontWeight.Bold
                     )
                     Text(
-                        text = "A professional look at your style investments.",
+                        text = "A professional look at style investments.",
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                     )

--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutineDetailScreen.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutineDetailScreen.kt
@@ -2,10 +2,22 @@ package com.zoewave.probase.kocolor.features.routines.ui
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -13,13 +25,32 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.NightsStay
+import androidx.compose.material.icons.filled.Reorder
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeFloatingActionButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
@@ -28,7 +59,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.zoewave.probase.kocolor.features.routines.ui.components.GlassConnectionHeaderAction
-import com.zoewave.probase.kocolor.model.*
+import com.zoewave.probase.kocolor.model.BeautyRoutine
+import com.zoewave.probase.kocolor.model.CosmeticItem
+import com.zoewave.probase.kocolor.model.KoColorRoute
+import com.zoewave.probase.kocolor.model.RoutineStep
+import com.zoewave.probase.kocolor.model.RoutineTime
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
@@ -150,7 +185,7 @@ fun RoutineDetailScreen(
                                 )
                             }
                             Text(
-                                text = if (isMorning) "Your Morning Ritual" else "Your Evening Ritual",
+                                text = if (isMorning) "Morning Ritual" else "Evening Ritual",
                                 style = MaterialTheme.typography.headlineMedium,
                                 fontFamily = FontFamily.Serif,
                                 fontWeight = FontWeight.Bold
@@ -188,7 +223,7 @@ fun RoutineDetailScreen(
                     
                     Spacer(Modifier.height(16.dp))
                     Text(
-                        text = "Every step is an act of care. Complete your sequence to prepare for a balanced day ahead.",
+                        text = "Every step is an act of care. Complete sequence to prepare for a balanced day ahead.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                         lineHeight = 22.sp

--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutinesScreen.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutinesScreen.kt
@@ -2,6 +2,7 @@ package com.zoewave.probase.kocolor.features.routines.ui
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,14 +14,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.LightMode
-import androidx.compose.material.icons.filled.NightsStay
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -99,7 +96,7 @@ fun RoutinesScreen(
                         fontWeight = FontWeight.Bold
                     )
                     Text(
-                        text = "Your daily acts of mindful care.",
+                        text = "Daily acts of mindful care.",
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                     )
@@ -184,19 +181,22 @@ fun HeroRitualCard(
                     modifier = Modifier.padding(28.dp).fillMaxSize(),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Column {
-                        Text(
-                            text = if (isMorning) "Your Morning\nRitual" else "Your Evening\nRitual",
-                            style = MaterialTheme.typography.displaySmall,
-                            fontFamily = FontFamily.Serif,
-                            fontWeight = FontWeight.Bold,
-                            lineHeight = 36.sp,
-                            color = Color.Black
-                        )
-                        
-                        Spacer(Modifier.height(16.dp))
-                        
-                        Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = if (isMorning) "Morning Ritual" else "Evening Ritual",
+                                style = MaterialTheme.typography.displaySmall.copy(fontSize = 32.sp),
+                                fontFamily = FontFamily.Serif,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.Black
+                            )
+                            
+                            Spacer(Modifier.height(12.dp))
+                            
                             Surface(
                                 color = Color.Black.copy(alpha = 0.1f),
                                 shape = RoundedCornerShape(12.dp)
@@ -210,28 +210,40 @@ fun HeroRitualCard(
                                     color = Color.Black
                                 )
                             }
-                            
-                            Spacer(Modifier.width(16.dp))
-                            
-                            Box(contentAlignment = Alignment.Center, modifier = Modifier.size(48.dp)) {
-                                CircularProgressIndicator(
-                                    progress = { 1f },
-                                    modifier = Modifier.fillMaxSize(),
-                                    color = Color.Black.copy(alpha = 0.05f),
-                                    strokeWidth = 4.dp
-                                )
-                                CircularProgressIndicator(
-                                    progress = { progress },
-                                    modifier = Modifier.fillMaxSize(),
-                                    color = accentColor,
-                                    strokeWidth = 4.dp,
-                                    strokeCap = androidx.compose.ui.graphics.StrokeCap.Round
-                                )
+                        }
+                        
+                        Box(
+                            contentAlignment = Alignment.Center, 
+                            modifier = Modifier
+                                .size(80.dp)
+                                .padding(top = 4.dp)
+                                .clickable(onClick = { onEvent(RoutinesEvent.ResetRoutine(routine.id)) })
+                        ) {
+                            CircularProgressIndicator(
+                                progress = { 1f },
+                                modifier = Modifier.fillMaxSize(),
+                                color = Color.Black.copy(alpha = 0.05f),
+                                strokeWidth = 6.dp
+                            )
+                            CircularProgressIndicator(
+                                progress = { progress },
+                                modifier = Modifier.fillMaxSize(),
+                                color = accentColor,
+                                strokeWidth = 6.dp,
+                                strokeCap = androidx.compose.ui.graphics.StrokeCap.Round
+                            )
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 Text(
                                     text = "$completedCount/$totalCount",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Bold,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.Black,
                                     color = Color.Black
+                                )
+                                Text(
+                                    text = "DONE",
+                                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
+                                    fontWeight = FontWeight.Bold,
+                                    color = Color.Black.copy(alpha = 0.5f)
                                 )
                             }
                         }


### PR DESCRIPTION
This commit standardizes the UI copy across several screens by removing personal pronouns for a more concise, professional tone. It also redesigns the routine summary and card components to feature a more prominent progress indicator and a refined horizontal layout.

- **`RoutineSummaryCard.kt` & `RoutinesScreen.kt`**:
    - Redesigned the ritual card layout to use a horizontal `Row` arrangement, allowing the progress indicator to sit alongside the title.
    - Enhanced the `CircularProgressIndicator` by increasing its size (80dp), stroke width (6dp), and adding a "DONE" status label.
    - Updated typography for ritual titles to `32.sp` and adjusted spacing for better visual hierarchy.
    - Added a reset routine event trigger to the progress indicator in the routines management screen.
- **`HomeScreen.kt` & `CollectionHubScreen.kt`**:
    - Simplified section headers and search hints (e.g., "Search entire collection" instead of "Search your entire collection").
    - Cleaned up wildcard imports to follow explicit import standards.
- **`WardrobeLandingScreen.kt` & `VanityLandingScreen.kt`**:
    - Refined landing screen headers and descriptions to remove "Your" prefixing, aligning with the new editorial style.
    - Organized imports and removed unused Material icon references.
- **`RoutineDetailScreen.kt`**:
    - Updated ritual titles and instructional text for brevity.
    - Refined the layout of the ritual header to include better spacing and specific typography styling.