### PR TITLE
refactor(routines): update routine card layout and progress visualiza…

### DIFF
--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/components/RoutineSummaryCard.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/components/RoutineSummaryCard.kt
@@ -59,33 +59,37 @@ fun RoutineSummaryCard(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Column(modifier = Modifier.weight(1f)) {
+                    // 1. TOP: Title
+                    Text(
+                        text = if (isDaytime) "Morning Ritual" else "Evening Ritual",
+                        style = MaterialTheme.typography.displaySmall.copy(fontSize = 32.sp),
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.Black
+                    )
+                }
+                
+                // 2. MIDDLE: Progress label and circle
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Surface(
+                        color = Color.Black.copy(alpha = 0.1f),
+                        shape = RoundedCornerShape(12.dp)
+                    ) {
                         Text(
-                            text = if (isDaytime) "Morning Ritual" else "Evening Ritual",
-                            style = MaterialTheme.typography.displaySmall.copy(fontSize = 32.sp),
-                            fontFamily = FontFamily.Serif,
-                            fontWeight = FontWeight.Bold,
+                            text = if (isDaytime) "CURRENT RITUAL" else "EVENING RITUAL",
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Black,
+                            letterSpacing = 1.sp,
                             color = Color.Black
                         )
-                        
-                        Spacer(Modifier.height(12.dp))
-                        
-                        Surface(
-                            color = Color.Black.copy(alpha = 0.1f),
-                            shape = RoundedCornerShape(12.dp)
-                        ) {
-                            Text(
-                                text = if (isDaytime) "CURRENT RITUAL" else "EVENING RITUAL",
-                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Black,
-                                letterSpacing = 1.sp,
-                                color = Color.Black
-                            )
-                        }
                     }
                     
-                    Box(contentAlignment = Alignment.Center, modifier = Modifier.size(80.dp)) {
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.size(84.dp)) {
                         CircularProgressIndicator(
                             progress = { 1f },
                             modifier = Modifier.fillMaxSize(),
@@ -116,6 +120,7 @@ fun RoutineSummaryCard(
                     }
                 }
 
+                // 3. BOTTOM: Duration and rest
                 Column {
                     Text(
                         text = "15 mins duration",

--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutinesScreen.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutinesScreen.kt
@@ -181,42 +181,39 @@ fun HeroRitualCard(
                     modifier = Modifier.padding(28.dp).fillMaxSize(),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
+                    // 1. TOP: Title
+                    Text(
+                        text = if (isMorning) "Morning Ritual" else "Evening Ritual",
+                        style = MaterialTheme.typography.displaySmall.copy(fontSize = 32.sp),
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.Black
+                    )
+                    
+                    // 2. MIDDLE: Progress label and circle
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Column(modifier = Modifier.weight(1f)) {
+                        Surface(
+                            color = Color.Black.copy(alpha = 0.1f),
+                            shape = RoundedCornerShape(12.dp)
+                        ) {
                             Text(
-                                text = if (isMorning) "Morning Ritual" else "Evening Ritual",
-                                style = MaterialTheme.typography.displaySmall.copy(fontSize = 32.sp),
-                                fontFamily = FontFamily.Serif,
-                                fontWeight = FontWeight.Bold,
+                                text = if (isMorning) "CURRENT RITUAL" else "EVENING RITUAL",
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Black,
+                                letterSpacing = 1.sp,
                                 color = Color.Black
                             )
-                            
-                            Spacer(Modifier.height(12.dp))
-                            
-                            Surface(
-                                color = Color.Black.copy(alpha = 0.1f),
-                                shape = RoundedCornerShape(12.dp)
-                            ) {
-                                Text(
-                                    text = if (isMorning) "CURRENT RITUAL" else "EVENING RITUAL",
-                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Black,
-                                    letterSpacing = 1.sp,
-                                    color = Color.Black
-                                )
-                            }
                         }
                         
                         Box(
                             contentAlignment = Alignment.Center, 
                             modifier = Modifier
-                                .size(80.dp)
-                                .padding(top = 4.dp)
+                                .size(84.dp)
                                 .clickable(onClick = { onEvent(RoutinesEvent.ResetRoutine(routine.id)) })
                         ) {
                             CircularProgressIndicator(
@@ -249,6 +246,7 @@ fun HeroRitualCard(
                         }
                     }
 
+                    // 3. BOTTOM: Duration and rest
                     Column {
                         Text(
                             text = "15 mins duration",


### PR DESCRIPTION
…tion

This commit refactors the layout hierarchy of routine cards in both the home summary and the main routines screen. The changes improve vertical spacing and visual balance by separating the title from the progress controls and standardizing the sizing of the circular progress indicator.

- **`RoutineSummaryCard.kt`**:
    - Refactored the layout into three distinct sections: Top (Title), Middle (Label and Progress), and Bottom (Duration/Rest).
    - Moved the "Ritual" title to the top-level `Column` to allow for better vertical distribution.
    - Grouped the "CURRENT RITUAL" label and the `CircularProgressIndicator` within a horizontal `Row`.
    - Increased the progress indicator container size from `80.dp` to `84.dp`.
- **`RoutinesScreen.kt`**:
    - Applied the same three-section structural refactor (Top, Middle, Bottom) to maintain UI consistency with the home card.
    - Updated the progress indicator container size to `84.dp` and removed the top padding to align with the new centered horizontal arrangement.
    - Cleaned up redundant `Modifier.weight` and `Spacer` calls by leveraging `Arrangement.SpaceBetween`.