### PR TITLE
feat(navigation): consolidate top-level routes and update landing scr…

### DIFF
--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
@@ -90,8 +90,9 @@ fun VanityLandingScreen(
                 },
                 actions = {
                     IconButton(onClick = { showTaxonomyInfo = true }) { Icon(Icons.AutoMirrored.Filled.HelpOutline, contentDescription = "Information") }
+                    IconButton(onClick = { navTo(KoColorRoute.InventoryManagement) }) { Icon(Icons.Default.Inventory2, contentDescription = "Inventory") }
+                    IconButton(onClick = { navTo(KoColorRoute.ColorSearch) }) { Icon(Icons.Default.Search, contentDescription = "Search") }
                     IconButton(onClick = { navTo(KoColorRoute.CosmeticAnalytics) }) { Icon(Icons.Default.Insights, contentDescription = "Analytics") }
-                    IconButton(onClick = { /* Search */ }) { Icon(Icons.Default.Search, null) }
                 }
             )
         },

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Checkroom
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Insights
+import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.MonetizationOn
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
@@ -95,8 +96,9 @@ fun WardrobeLandingScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { navTo(KoColorRoute.WardrobeAnalytics) }) { Icon(Icons.Default.Insights, null) }
-                    IconButton(onClick = { /* Search */ }) { Icon(Icons.Default.Search, null) }
+                    IconButton(onClick = { navTo(KoColorRoute.Wardrobe) }) { Icon(Icons.Default.Inventory2, contentDescription = "Inventory") }
+                    IconButton(onClick = { navTo(KoColorRoute.ColorSearch) }) { Icon(Icons.Default.Search, contentDescription = "Search") }
+                    IconButton(onClick = { navTo(KoColorRoute.WardrobeAnalytics) }) { Icon(Icons.Default.Insights, contentDescription = "Analytics") }
                 }
             )
         }

--- a/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/KoColorRoute.kt
+++ b/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/KoColorRoute.kt
@@ -3,6 +3,7 @@ package com.zoewave.probase.kocolor.model
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.Inventory
@@ -121,11 +122,7 @@ sealed class KoColorRoute {
     val icon: ImageVector?
         get() = when (this) {
             Home -> Icons.Default.Home
-            ColorSearch -> Icons.Default.Search
-            InventoryManagement -> Icons.Default.Inventory
-            CosmeticAnalytics -> Icons.Default.Insights
-            Color -> Icons.Default.ColorLens
-            Routines -> Icons.Default.Face
+            CollectionHub -> Icons.Default.AutoAwesome
             Settings -> Icons.Default.Settings
             else -> null
         }
@@ -133,11 +130,7 @@ sealed class KoColorRoute {
     val label: String?
         get() = when (this) {
             Home -> "Home"
-            ColorSearch -> "Search"
-            InventoryManagement -> "Inventory"
-            CosmeticAnalytics -> "Analytics"
-            Color -> "Color"
-            Routines -> "Routines"
+            CollectionHub -> "Collection"
             Settings -> "Settings"
             else -> null
         }
@@ -145,8 +138,6 @@ sealed class KoColorRoute {
 
 val topLevelRoutes = listOf(
     KoColorRoute.Home,
-    KoColorRoute.ColorSearch,
-    KoColorRoute.InventoryManagement,
-    KoColorRoute.CosmeticAnalytics,
+    KoColorRoute.CollectionHub,
     KoColorRoute.Settings
 )


### PR DESCRIPTION
…een actions

This commit refactors the navigation model to use a consolidated `CollectionHub` route for top-level navigation instead of individual feature routes. It also updates the action bars in the Vanity and Wardrobe landing screens to provide direct access to inventory and search functionality.

- **`KoColorRoute.kt`**:
    - Introduced `CollectionHub` as a top-level route, mapped to the `AutoAwesome` icon and the "Collection" label.
    - Removed `ColorSearch`, `InventoryManagement`, and `CosmeticAnalytics` from the `topLevelRoutes` list to simplify the primary navigation structure.
    - Cleaned up the `icon` and `label` properties by removing deprecated route mappings.
- **`VanityLandingScreen.kt`**:
    - Updated the `TopAppBar` actions to include explicit navigation to `InventoryManagement` and `ColorSearch`.
    - Added missing `contentDescription` strings to action icons for improved accessibility.
- **`WardrobeLandingScreen.kt`**:
    - Expanded the top bar actions to include navigation to `Wardrobe` inventory and `ColorSearch`.
    - Reorganized the action icons and added descriptive labels for "Inventory", "Search", and "Analytics".