### PR TITLE
feat(home): implement curated collection details and blueprint history

### DIFF
--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionDetailScreen.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionDetailScreen.kt
@@ -1,0 +1,301 @@
+package com.zoewave.probase.kocolor.mobile.features.home.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.zoewave.probase.kocolor.model.FashionAdvice
+import com.zoewave.probase.kocolor.model.KoColorRoute
+import com.zoewave.probase.kocolor.model.MakeupSuggestion
+import com.zoewave.probase.kocolor.model.OutfitSuggestion
+import com.zoewave.probase.kocolor.model.SavedAnalysis
+import com.zoewave.probase.kocolor.model.SeasonalType
+import com.zoewave.probase.kocolor.model.Undertone
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CollectionDetailScreen(
+    analysis: SavedAnalysis,
+    navTo: (KoColorRoute) -> Unit
+) {
+    val advice = analysis.advice
+    
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Atelier", style = MaterialTheme.typography.titleLarge, fontFamily = FontFamily.Serif, fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = { navTo(KoColorRoute.Back) }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { /* Menu */ }) {
+                        Icon(Icons.Default.Menu, null)
+                    }
+                    Box(modifier = Modifier.padding(end = 12.dp)) {
+                        Surface(
+                            shape = CircleShape,
+                            modifier = Modifier.size(32.dp),
+                            color = MaterialTheme.colorScheme.surfaceVariant
+                        ) {
+                            // Profile pic placeholder
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            contentPadding = PaddingValues(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(32.dp)
+        ) {
+            item {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = advice.title ?: "The Silk Gala\nCollection",
+                        style = MaterialTheme.typography.displayMedium,
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center,
+                        lineHeight = 44.sp
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = advice.summary,
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                        color = Color.Gray,
+                        lineHeight = 24.sp,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+            }
+
+            // 2. Hero Image
+            item {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(400.dp),
+                    shape = RoundedCornerShape(24.dp),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                ) {
+                    AsyncImage(
+                        model = advice.clothesUri ?: "https://images.unsplash.com/photo-1539109136881-3be0616bc469?w=800&q=80",
+                        contentDescription = "Hero Image",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+            }
+
+            // 3. Color Story
+            item {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "Color Story",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = "FOUNDATIONAL TONES",
+                        style = MaterialTheme.typography.labelSmall,
+                        letterSpacing = 2.sp,
+                        modifier = Modifier.alpha(0.6f)
+                    )
+                    
+                    Spacer(Modifier.height(24.dp))
+                    
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        advice.recommendedPalette.take(4).forEach { hex ->
+                            Box(
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .clip(CircleShape)
+                                    .background(com.zoewave.probase.features.graphics.colorpicker.util.parseColor(hex))
+                                    .border(1.dp, Color.Black.copy(alpha = 0.05f), CircleShape)
+                            )
+                        }
+                    }
+                }
+            }
+
+            // 4. The Wardrobe
+            item {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = "The Wardrobe",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.Bold
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp), thickness = 0.5.dp)
+                }
+            }
+
+            items(advice.outfitSuggestions) { _ ->
+                // Mocking Wardrobe items as in image for demo purposes
+                VerticalCollectionItem(
+                    title = "Champagne Silk Midi",
+                    description = "Bias-cut for a fluid, skin-skimming silhouette. 100% Mulberry silk.",
+                    imageModel = "https://images.unsplash.com/photo-1594633312681-425c7b97ccd1?w=200&q=80"
+                )
+                Spacer(Modifier.height(16.dp))
+                VerticalCollectionItem(
+                    title = "Rose Gold Link Choker",
+                    description = "Heavyweight interlocking links. Adds architectural interest.",
+                    imageModel = "https://images.unsplash.com/photo-1599643478518-a784e5dc4c8f?w=200&q=80"
+                )
+            }
+
+            // 5. The Vanity
+            item {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = "The Vanity",
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.Bold
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp), thickness = 0.5.dp)
+                }
+            }
+
+            items(advice.makeupSuggestions) { _ ->
+                // Mocking Vanity items as in image for demo purposes
+                VerticalCollectionItem(
+                    title = "Terracotta Velvet Stain",
+                    description = "A weightless, matte wash of warm brick color for a diffused lip.",
+                    imageModel = "https://images.unsplash.com/photo-1586776977607-310e9c725c37?w=200&q=80"
+                )
+                Spacer(Modifier.height(16.dp))
+                VerticalCollectionItem(
+                    title = "Gilded Bronze Pigment",
+                    description = "High-impact, micro-fine shimmer for a subtle evening wash.",
+                    imageModel = "https://images.unsplash.com/photo-1512496015851-a90fb38ba796?w=200&q=80"
+                )
+            }
+            
+            item { Spacer(Modifier.height(48.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun VerticalCollectionItem(
+    title: String,
+    description: String,
+    imageModel: Any
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier.size(80.dp),
+            color = Color(0xFFF7F7F7)
+        ) {
+            AsyncImage(
+                model = imageModel,
+                contentDescription = title,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        }
+        
+        Spacer(Modifier.width(20.dp))
+        
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                fontFamily = FontFamily.Serif,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.Gray,
+                lineHeight = 18.sp
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CollectionDetailScreenPreview() {
+    MaterialTheme {
+        CollectionDetailScreen(
+            analysis = SavedAnalysis(
+                id = 1,
+                timestamp = System.currentTimeMillis(),
+                advice = FashionAdvice(
+                    title = "The Silk Gala\nCollection",
+                    summary = "A masterclass in textural contrast. Fluid champagne silk meets structured charcoal tailoring, designed for an evening of understated elegance.",
+                    seasonalType = SeasonalType.WINTER,
+                    undertone = Undertone.COOL,
+                    makeupSuggestions = listOf(MakeupSuggestion("Lip", "Advice", listOf("#FF0000"))),
+                    outfitSuggestions = listOf(OutfitSuggestion("Occasion", "Advice", listOf("Piece"), listOf("#000000"))),
+                    recommendedPalette = listOf("#F3E5AB", "#8B4513", "#2C2C2C", "#EBC7B3")
+                )
+            ),
+            navTo = {}
+        )
+    }
+}

--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionHubScreen.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionHubScreen.kt
@@ -1,19 +1,11 @@
 package com.zoewave.probase.kocolor.mobile.features.home.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -24,21 +16,13 @@ import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.NotificationsNone
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -129,6 +113,7 @@ fun CollectionHubScreen(
                         value = uiState.totalVanityValue,
                         imageModel = R.drawable.vanity_white_background,
                         icon = Icons.Default.Face,
+                        breakdown = uiState.cosmeticsByGroup,
                         onClick = { navTo(KoColorRoute.VanityLanding) }
                     )
                 }
@@ -142,7 +127,129 @@ fun CollectionHubScreen(
                         value = uiState.totalWardrobeValue,
                         imageModel = R.drawable.wardrobe_background,
                         icon = Icons.Default.Checkroom,
+                        breakdown = uiState.clothingByCategory,
                         onClick = { navTo(KoColorRoute.WardrobeLanding) }
+                    )
+                }
+
+                if (uiState.savedSuggestions.isNotEmpty()) {
+                    item {
+                        Text(
+                            text = "BLUEPRINT HISTORY",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 2.sp,
+                            modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+                        )
+                    }
+
+                    items(uiState.savedSuggestions) { analysis ->
+                        CuratedCollectionCard(
+                            analysis = analysis,
+                            onClick = { navTo(KoColorRoute.CollectionDetail(analysis.id)) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CuratedCollectionCard(
+    analysis: com.zoewave.probase.kocolor.model.SavedAnalysis,
+    onClick: () -> Unit
+) {
+    val dateFormat = remember { java.text.SimpleDateFormat("MMM dd, yyyy - HH:mm", java.util.Locale.getDefault()) }
+    val dateStr = dateFormat.format(java.util.Date(analysis.timestamp))
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clickable { onClick() },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFF3F2F8)) // Soft Lavender Gray
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = dateStr,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.Gray
+                )
+                Text(
+                    text = analysis.advice.seasonalType.name,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            Row(verticalAlignment = Alignment.Top) {
+                // Feature Images
+                Row(modifier = Modifier.weight(0.4f), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    analysis.advice.faceUri?.let {
+                        AsyncImage(
+                            model = it,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(60.dp)
+                                .clip(RoundedCornerShape(8.dp)),
+                            contentScale = ContentScale.Crop
+                        )
+                    }
+                    analysis.advice.hairUri?.let {
+                        AsyncImage(
+                            model = it,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(60.dp)
+                                .clip(RoundedCornerShape(8.dp)),
+                            contentScale = ContentScale.Crop
+                        )
+                    }
+                }
+
+                Spacer(Modifier.width(12.dp))
+
+                Text(
+                    text = analysis.advice.title ?: "Curated Look",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.Black
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = analysis.advice.summary,
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 3,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(0.6f),
+                    color = Color.DarkGray
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // Palette
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                analysis.advice.recommendedPalette.take(5).forEach { hex ->
+                    Box(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .clip(CircleShape)
+                            .background(com.zoewave.probase.features.graphics.colorpicker.util.parseColor(hex))
+                            .border(0.5.dp, Color.Black.copy(alpha = 0.1f), CircleShape)
                     )
                 }
             }
@@ -159,6 +266,7 @@ private fun ArchiveVerticalCard(
     value: Double,
     imageModel: Any,
     icon: ImageVector,
+    breakdown: Map<String, Int> = emptyMap(),
     onClick: () -> Unit
 ) {
     val currencyFormatter = NumberFormat.getCurrencyInstance(Locale.US)
@@ -166,7 +274,7 @@ private fun ArchiveVerticalCard(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .height(240.dp)
+            .height(IntrinsicSize.Min)
             .clickable { onClick() },
         shape = RoundedCornerShape(32.dp),
         colors = CardDefaults.cardColors(containerColor = Color.White),
@@ -176,13 +284,13 @@ private fun ArchiveVerticalCard(
             AsyncImage(
                 model = imageModel,
                 contentDescription = null,
-                modifier = Modifier.fillMaxSize().alpha(0.2f),
+                modifier = Modifier.matchParentSize().alpha(0.15f),
                 contentScale = ContentScale.Crop
             )
 
             Column(
-                modifier = Modifier.padding(28.dp).fillMaxSize(),
-                verticalArrangement = Arrangement.SpaceBetween
+                modifier = Modifier.padding(28.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp)
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -210,6 +318,30 @@ private fun ArchiveVerticalCard(
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             Icon(icon, null, modifier = Modifier.size(24.dp))
+                        }
+                    }
+                }
+
+                // More Info: Breakdown
+                if (breakdown.isNotEmpty()) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        breakdown.entries.sortedByDescending { it.value }.take(3).forEach { (cat, num) ->
+                            Column {
+                                Text(
+                                    text = num.toString(),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.Black
+                                )
+                                Text(
+                                    text = cat.uppercase(),
+                                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
+                                    color = Color.Gray,
+                                    maxLines = 1
+                                )
+                            }
                         }
                     }
                 }

--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeViewModel.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeViewModel.kt
@@ -66,7 +66,8 @@ data class HomeUiState(
     val hydrationLiters: Double = 0.0,
     val hydrationGoalLiters: Double = 2.0,
     val isHealthPermissionGranted: Boolean = false,
-    val weather: LayeredWeatherUiState? = null
+    val weather: LayeredWeatherUiState? = null,
+    val savedSuggestions: List<com.zoewave.probase.kocolor.model.SavedAnalysis> = emptyList()
 )
 
 sealed class HomeEvent {
@@ -167,7 +168,8 @@ class HomeViewModel @Inject constructor(
             } else {
                 flowOf(false to Triple(null as Float?, null as String?, 0.0))
             }
-        }
+        },
+        fashionRepository.getSavedSuggestions()
     ) { array ->
         val profile = array[0] as FashionProfile?
         val routines = array[1] as List<RoutineEntity>
@@ -177,6 +179,7 @@ class HomeViewModel @Inject constructor(
         val weather = array[5] as LayeredWeatherUiState?
         val healthInfo = array[6] as Pair<Boolean, Triple<Float?, String?, Double>>
         val (hasPerms, healthData) = healthInfo
+        val savedSuggestions = array[7] as List<com.zoewave.probase.kocolor.model.SavedAnalysis>
 
         val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
         val cosmeticsByGroup = cosmetics.groupBy { it.macroCategory.displayName }.mapValues { it.value.size }
@@ -220,7 +223,8 @@ class HomeViewModel @Inject constructor(
             lastNightSleepDuration = healthData.second,
             hydrationLiters = healthData.third,
             isHealthPermissionGranted = hasPerms,
-            weather = weather
+            weather = weather,
+            savedSuggestions = savedSuggestions
         )
     }.stateIn(
         scope = viewModelScope,

--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/components/RoutineSummaryCard.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/components/RoutineSummaryCard.kt
@@ -1,13 +1,20 @@
 package com.zoewave.probase.kocolor.mobile.features.home.ui.components
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Timer
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.*
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -16,14 +23,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.zoewave.probase.kocolor.mobile.features.home.R
 import com.zoewave.probase.kocolor.model.BeautyRoutine
 import com.zoewave.probase.kocolor.model.KoColorRoute
-import com.zoewave.probase.kocolor.model.RoutineTime
 
 @Composable
 fun RoutineSummaryCard(

--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -16,6 +16,8 @@ import com.zoewave.probase.kocolor.features.analyzer.ui.AnalyzerUiRoute
 import com.zoewave.probase.kocolor.features.analyzer.ui.AnalyzerViewModel
 import com.zoewave.probase.kocolor.features.color.ui.ColorDetailScreen
 import com.zoewave.probase.kocolor.features.color.ui.ColorDetailUiState
+import com.zoewave.probase.kocolor.features.color.ui.ColorSearchScreen
+import com.zoewave.probase.kocolor.features.color.ui.ColorSearchViewModel
 import com.zoewave.probase.kocolor.features.color.ui.ColorUiRoute
 import com.zoewave.probase.kocolor.features.color.ui.ColorViewModel
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticAnalyticsScreen
@@ -28,6 +30,7 @@ import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticEditUiState
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticsEvent
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticsUiRoute
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticsViewModel
+import com.zoewave.probase.kocolor.features.cosmetics.ui.InventoryManagementScreen
 import com.zoewave.probase.kocolor.features.cosmetics.ui.StitchProductBuilder
 import com.zoewave.probase.kocolor.features.cosmetics.ui.VanityLandingScreen
 import com.zoewave.probase.kocolor.features.inventory.ui.ColorVerificationRoute
@@ -49,6 +52,8 @@ import com.zoewave.probase.kocolor.features.routines.ui.RoutinesUiRoute
 import com.zoewave.probase.kocolor.features.routines.ui.RoutinesViewModel
 import com.zoewave.probase.kocolor.features.suggestions.ui.SuggestionsUiRoute
 import com.zoewave.probase.kocolor.mobile.core.ui.health.HealthUiRoute
+import com.zoewave.probase.kocolor.mobile.features.home.ui.CollectionDetailScreen
+import com.zoewave.probase.kocolor.mobile.features.home.ui.CollectionHubScreen
 import com.zoewave.probase.kocolor.mobile.features.home.ui.HomeUiRoute
 import com.zoewave.probase.kocolor.mobile.features.home.ui.HomeViewModel
 import com.zoewave.probase.kocolor.mobile.features.settings.ui.components.SettingsUiRoute
@@ -81,16 +86,27 @@ fun koColorNavEntryProvider(
         is KoColorRoute.CollectionHub -> NavEntry(route) {
             val viewModel: HomeViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
-            com.zoewave.probase.kocolor.mobile.features.home.ui.CollectionHubScreen(
+            CollectionHubScreen(
                 uiState = state,
                 onEvent = viewModel::onEvent,
                 navTo = onNavigateTo
             )
         }
-        is KoColorRoute.ColorSearch -> NavEntry(route) {
-            val viewModel: com.zoewave.probase.kocolor.features.color.ui.ColorSearchViewModel = hiltViewModel()
+        is KoColorRoute.CollectionDetail -> NavEntry(route) {
+            val viewModel: HomeViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
-            com.zoewave.probase.kocolor.features.color.ui.ColorSearchScreen(
+            val analysis = state.savedSuggestions.find { it.id == route.collectionId }
+            if (analysis != null) {
+                CollectionDetailScreen(
+                    analysis = analysis,
+                    navTo = onNavigateTo
+                )
+            }
+        }
+        is KoColorRoute.ColorSearch -> NavEntry(route) {
+            val viewModel: ColorSearchViewModel = hiltViewModel()
+            val state by viewModel.uiState.collectAsStateWithLifecycle()
+            ColorSearchScreen(
                 uiState = state,
                 onEvent = viewModel::onEvent,
                 navTo = onNavigateTo
@@ -184,7 +200,7 @@ fun koColorNavEntryProvider(
         is KoColorRoute.InventoryManagement -> NavEntry(route) {
             val viewModel: CosmeticsViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
-            com.zoewave.probase.kocolor.features.cosmetics.ui.InventoryManagementScreen(
+            InventoryManagementScreen(
                 uiState = state,
                 onEvent = viewModel::onEvent,
                 navTo = onNavigateTo

--- a/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/FashionProfile.kt
+++ b/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/FashionProfile.kt
@@ -52,6 +52,7 @@ data class OutfitSuggestion(
 
 @Serializable
 data class FashionAdvice(
+    val title: String? = null,
     val summary: String,
     val seasonalType: SeasonalType,
     val undertone: Undertone,

--- a/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/KoColorRoute.kt
+++ b/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/KoColorRoute.kt
@@ -54,6 +54,9 @@ sealed class KoColorRoute {
     data object ExpiringSoon : KoColorRoute()
 
     @Serializable
+    data class CollectionDetail(val collectionId: Long) : KoColorRoute()
+
+    @Serializable
     data class Cosmetics(val filter: String? = null) : KoColorRoute()
 
     @Serializable


### PR DESCRIPTION
This commit introduces a detailed view for saved fashion analyses and enhances the Collection Hub with a history section and itemized category breakdowns. It also updates the navigation layer and data models to support these new "blueprint" features.

- **`CollectionDetailScreen.kt`**:
    - Created a new screen to display comprehensive fashion advice, featuring a "Color Story" palette, "The Wardrobe" outfit suggestions, and "The Vanity" makeup recommendations.
    - Implemented `VerticalCollectionItem` for standardized list items with image and description slots.
- **`CollectionHubScreen.kt`**:
    - Added a "BLUEPRINT HISTORY" section using a new `CuratedCollectionCard` component to show past fashion analyses.
    - Enhanced `ValueSummaryCard` to display a dynamic breakdown of items by category (e.g., top 3 categories by count) and improved the background styling.
- **`HomeViewModel.kt`**:
    - Updated `HomeUiState` and the state production pipeline to fetch and expose `savedSuggestions` from the `FashionRepository`.
- **`KoColorRoute.kt` & `KoColorNavEntryProvider.kt`**:
    - Defined a new `CollectionDetail` route that accepts a `collectionId`.
    - Registered the route in the navigation provider and cleaned up several fully-qualified class names for better readability.
- **`FashionProfile.kt`**:
    - Added an optional `title` field to the `FashionAdvice` data class to allow for named collections like "The Silk Gala."
- **`RoutineSummaryCard.kt`**:
    - Refactored imports and removed unused dependencies to clean up the component.