### PR TITLE
feat(analyzer): implement navigation side effect in StyleSimulator

### DIFF
--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -176,6 +176,7 @@ fun koColorNavEntryProvider(
             val state by viewModel.uiState.collectAsStateWithLifecycle()
             StyleSimulatorScreen(
                 uiState = state,
+                effect = viewModel.effect,
                 onEvent = viewModel::onEvent,
                 navTo = onNavigateTo
             )

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/StyleSimulatorScreen.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/StyleSimulatorScreen.kt
@@ -35,9 +35,20 @@ import com.zoewave.probase.kocolor.model.*
 @Composable
 fun StyleSimulatorScreen(
     uiState: StyleSimulatorUiState,
+    effect: kotlinx.coroutines.flow.Flow<SimulatorEffect>? = null,
     onEvent: (SimulatorEvent) -> Unit,
     navTo: (KoColorRoute) -> Unit
 ) {
+    if (effect != null) {
+        LaunchedEffect(Unit) {
+            effect.collect { simulatorEffect ->
+                when (simulatorEffect) {
+                    SimulatorEffect.NavigateToHistory -> navTo(KoColorRoute.Color)
+                }
+            }
+        }
+    }
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -369,6 +380,7 @@ private fun StyleSimulatorScreenPreview() {
             recommendedPalette = listOf("#F4D03F", "#16A085", "#2C3E50"),
             recommendedClothing = listOf(ClothingItem(name = "Silk Evening Shirt", category = com.zoewave.probase.kocolor.model.ClothingCategory.TOPS, brand = "ZoeWave"))
         ),
+        effect = null,
         onEvent = {},
         navTo = {}
     )

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/StyleSimulatorViewModel.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/StyleSimulatorViewModel.kt
@@ -39,6 +39,10 @@ sealed class SimulatorEvent {
     data object Reset : SimulatorEvent()
 }
 
+sealed class SimulatorEffect {
+    data object NavigateToHistory : SimulatorEffect()
+}
+
 @HiltViewModel
 class StyleSimulatorViewModel @Inject constructor(
     private val routineDao: RoutineDao,
@@ -50,6 +54,9 @@ class StyleSimulatorViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(StyleSimulatorUiState())
     val uiState: StateFlow<StyleSimulatorUiState> = _uiState.asStateFlow()
+
+    private val _effect = kotlinx.coroutines.channels.Channel<SimulatorEffect>()
+    val effect = _effect.receiveAsFlow()
 
     init {
         checkRoutineStatus()
@@ -176,7 +183,7 @@ class StyleSimulatorViewModel @Inject constructor(
                 clothesUri = state.recommendedClothing.firstOrNull()?.imageUrl
             )
             fashionRepository.saveSuggestion(advice)
-            // Navigation would usually happen via a SideEffect, but here we can just update state if needed
+            _effect.send(SimulatorEffect.NavigateToHistory)
         }
     }
 }


### PR DESCRIPTION
This commit introduces a side-effect mechanism to the Style Simulator feature to handle navigation after saving suggestions. It uses a `Channel`-backed `Flow` to manage one-time UI events, specifically triggering a navigation to the color history route upon successful data persistence.

- **`StyleSimulatorViewModel.kt`**:
    - Defined a `SimulatorEffect` sealed class with a `NavigateToHistory` event.
    - Implemented an `effect` Flow using a `Channel` to communicate side effects to the UI.
    - Updated the advice saving logic to emit `NavigateToHistory` after the repository successfully saves the suggestion.
- **`StyleSimulatorScreen.kt`**:
    - Added an `effect` parameter to the `StyleSimulatorScreen` composable.
    - Integrated a `LaunchedEffect` to collect side effects from the ViewModel and trigger the provided `navTo` callback when `NavigateToHistory` is received.
- **`KoColorNavEntryProvider.kt`**:
    - Updated the navigation graph entry to pass the `viewModel.effect` flow into the `StyleSimulatorScreen`.