### PR TITLE
refactor(cosmetics): reset scan state and repository after adding item

### DIFF
--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
@@ -233,12 +233,10 @@ class CosmeticsViewModel @Inject constructor(
         when (event) {
             is CosmeticsEvent.AddItem -> {
                 addItem(event.item)
-                sessionRepository.setCosmeticDraft(CosmeticItem(
-                    name = "", 
-                    brand = "", 
-                    macroCategory = MacroCategory.COMPLEXION, 
-                    microCategory = MicroCategory.FOUNDATION
-                ))
+                sessionRepository.reset()
+                _isScanSuccessful.value = false
+                _lastScanFailed.value = false
+                _scanStatus.value = null
             }
             is CosmeticsEvent.UpdateItem -> updateItem(event.item)
             is CosmeticsEvent.DeleteItem -> deleteItem(event.id)


### PR DESCRIPTION
This commit updates the `AddItem` event logic within the `CosmeticsViewModel` to ensure the UI and repository states are properly cleared after a successful addition. It replaces manual draft clearing with a centralized reset call and resets scanning status flags.

- **`CosmeticsViewModel.kt`**:
    - Updated the `CosmeticsEvent.AddItem` handler to call `sessionRepository.reset()` instead of manually overwriting the draft with an empty `CosmeticItem`.
    - Added logic to reset `_isScanSuccessful`, `_lastScanFailed`, and `_scanStatus` to their default values, ensuring the scanning interface is ready for a new entry.