### PR TITLE
feat(home): implement robust location permissions and weather fallbac…

### DIFF
--- a/applications/kocolor/apps/mobile/features/home/build.gradle.kts
+++ b/applications/kocolor/apps/mobile/features/home/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.coil.compose)
     implementation(libs.google.play.services.maps)
+    implementation(libs.google.accompanist.permissions)
 
     implementation(libs.kotlinx.collections.immutable)
 }

--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeScreen.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.CloudQueue
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Settings
@@ -43,6 +44,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,6 +59,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import com.zoewave.probase.features.health.core.SkinInsight
 import com.zoewave.probase.features.weather.ui.components.layered.LayeredWeatherInfoIcon
 import com.zoewave.probase.features.weather.ui.components.layered.LayeredWeatherUiState
@@ -97,7 +101,7 @@ fun HomeUiRoute(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
 @Composable
 fun HomeScreen(
     uiState: HomeUiState,
@@ -105,6 +109,26 @@ fun HomeScreen(
     navTo: (KoColorRoute) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val locationPermissionsState = rememberMultiplePermissionsState(
+        listOf(
+            android.Manifest.permission.ACCESS_COARSE_LOCATION,
+            android.Manifest.permission.ACCESS_FINE_LOCATION,
+        )
+    )
+
+    LaunchedEffect(locationPermissionsState.allPermissionsGranted) {
+        if (locationPermissionsState.allPermissionsGranted) {
+            onEvent(HomeEvent.RefreshWeather)
+        }
+    }
+
+    // Explicitly request permissions on first launch if not already granted
+    LaunchedEffect(Unit) {
+        if (!locationPermissionsState.allPermissionsGranted) {
+            locationPermissionsState.launchMultiplePermissionRequest()
+        }
+    }
+
     val backgroundColor by animateColorAsState(
         targetValue = if (uiState.isDaytime) MaterialTheme.colorScheme.surface
         else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
@@ -280,6 +304,18 @@ fun HomeHeader(
                     modifier = Modifier
                         .size(80.dp)
                         .offset(x = 16.dp, y = (-16).dp)
+                )
+            } ?: Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .offset(x = 16.dp, y = (-16).dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.CloudQueue,
+                    contentDescription = "Weather unavailable",
+                    tint = Color.Gray.copy(alpha = 0.5f),
+                    modifier = Modifier.size(48.dp)
                 )
             }
         }

--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeViewModel.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeViewModel.kt
@@ -75,6 +75,7 @@ sealed class HomeEvent {
     data class ToggleStep(val routine: BeautyRoutine, val stepId: String) : HomeEvent()
     data object RefreshTip : HomeEvent()
     data class LogHydration(val volumeLiters: Double) : HomeEvent()
+    data object RefreshWeather : HomeEvent()
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -268,45 +269,65 @@ class HomeViewModel @Inject constructor(
     private fun fetchWeather() {
         viewModelScope.launch {
             try {
-                // 1. Get GPS coordinates
-                locationRepository.updateLocation()
-                val latLng = locationRepository.currentLocation.first { it != null }
+                // 1. Attempt to get GPS coordinates with a 5s timeout
+                val latLng = kotlinx.coroutines.withTimeoutOrNull(5000) {
+                    locationRepository.updateLocation()
+                    locationRepository.currentLocation.first { it != null }
+                }
                 
                 if (latLng != null) {
-                    // 2. Fetch weather by coords
+                    // 2. Fetch weather by real coords
                     val response = weatherRepo.openCurrentWeatherByCoords(latLng.latitude, latLng.longitude)
                     _locationName.value = response?.name
                     
                     // 3. Get environmental context (UV, humidity)
                     val envContext = weatherRepo.getEnvironmentalContext(latLng.latitude, latLng.longitude)
 
-                    if (response != null && envContext != null) {
-                        val conditions = mutableListOf<LayeredWeatherCondition>()
-                        val main = response.weather.firstOrNull()?.main ?: ""
-                        when {
-                            main.contains("Cloud", true) -> conditions.add(LayeredWeatherCondition.CLOUDY)
-                            main.contains("Rain", true) -> conditions.add(LayeredWeatherCondition.RAINY)
-                            main.contains("Thunder", true) -> conditions.add(LayeredWeatherCondition.THUNDER)
-                            else -> conditions.add(LayeredWeatherCondition.SUNNY)
-                        }
-                        if (response.wind.speed > 5.0) conditions.add(LayeredWeatherCondition.WINDY)
-                        
-                        _weather.value = LayeredWeatherUiState(
-                            temperature = response.main.temp,
-                            uvIndex = envContext.uvIndex,
-                            conditions = conditions
-                        )
-
-                        // Environmental Trigger Logic
-                        if (envContext.uvIndex > 3.0) {
-                            _beautyTip.value = "☀️ High UV detected. Prioritize SPF in your ritual today."
-                        } else if (envContext.humidity < 30.0) {
-                            _beautyTip.value = "💧 Low humidity. Use a humectant to retain moisture."
-                        }
+                    updateWeatherState(response, envContext)
+                } else {
+                    // 4. Fallback to Santa Barbara if GPS fails or times out
+                    android.util.Log.d("HomeViewModel", "GPS timeout/unavailable. Falling back to Santa Barbara.")
+                    val fallbackCity = "Santa Barbara, US"
+                    val response = weatherRepo.openCurrentWeatherByCity(fallbackCity)
+                    _locationName.value = response?.name ?: "Santa Barbara"
+                    
+                    val envContext = response?.coord?.let { 
+                        weatherRepo.getEnvironmentalContext(it.lat, it.lon)
                     }
+                    updateWeatherState(response, envContext)
                 }
             } catch (e: Exception) {
                 android.util.Log.e("HomeViewModel", "Error fetching weather", e)
+            }
+        }
+    }
+
+    private fun updateWeatherState(
+        response: com.zoewave.probase.core.model.weather.OpenWeatherResponse?,
+        envContext: com.zoewave.probase.core.model.weather.EnvironmentalContext?
+    ) {
+        if (response != null && envContext != null) {
+            val conditions = mutableListOf<LayeredWeatherCondition>()
+            val main = response.weather.firstOrNull()?.main ?: ""
+            when {
+                main.contains("Cloud", true) -> conditions.add(LayeredWeatherCondition.CLOUDY)
+                main.contains("Rain", true) -> conditions.add(LayeredWeatherCondition.RAINY)
+                main.contains("Thunder", true) -> conditions.add(LayeredWeatherCondition.THUNDER)
+                else -> conditions.add(LayeredWeatherCondition.SUNNY)
+            }
+            if (response.wind.speed > 5.0) conditions.add(LayeredWeatherCondition.WINDY)
+            
+            _weather.value = LayeredWeatherUiState(
+                temperature = response.main.temp,
+                uvIndex = envContext.uvIndex,
+                conditions = conditions
+            )
+
+            // Environmental Trigger Logic
+            if (envContext.uvIndex > 3.0) {
+                _beautyTip.value = "☀️ High UV detected. Prioritize SPF in your ritual today."
+            } else if (envContext.humidity < 30.0) {
+                _beautyTip.value = "💧 Low humidity. Use a humectant to retain moisture."
             }
         }
     }
@@ -340,6 +361,7 @@ class HomeViewModel @Inject constructor(
                     healthSessionManager.insertHydration(event.volumeLiters)
                 }
             }
+            HomeEvent.RefreshWeather -> fetchWeather()
         }
     }
 

--- a/features/weather/docs/WeatherLocation.md
+++ b/features/weather/docs/WeatherLocation.md
@@ -40,3 +40,58 @@ I will integrate the device's GPS to fetch local weather data and display the cu
    [!IMPORTANT] This feature requires the Location Permission (ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION). Since KoColor is intended to be privacy-first, I will ensure we only use the location for the immediate weather lookup and do not persist history.
    I've planned the integration of GPS-based weather fetching and city name display. This will replace the hardcoded "Santa Barbara" with your actual current location.
    Should I proceed with these changes?
+
+
+Implementation Plan - Robust Location Permissions & Weather Fallback
+I will implement a reliable location permission flow and a visual fallback for when weather data cannot be retrieved, ensuring the KoColor UI remains functional and informative.
+1. Research & Analysis
+   •
+   Hanging Issue: The current fetchWeather logic in HomeViewModel uses first { it != null } on GPS coordinates. If permissions are missing or GPS is off, this coroutine hangs forever, preventing weather data from ever loading.
+   •
+   Permission Flow: We need to use Accompanist Permissions for a modern, declarative way to request ACCESS_FINE_LOCATION and ACCESS_COARSE_LOCATION.
+   •
+   UI State: The "grayed out" icon will be a placeholder that appears while waiting for a timeout or if a terminal error occurs.
+
+
+2. Technical Steps
+   Module Configuration
+   •
+   [ ] Add libs.google.accompanist.permissions to :applications:kocolor:apps:mobile:features:home.
+   ViewModel Logic (HomeViewModel.kt)
+   •
+   [ ] Refactor fetchWeather():
+   ◦
+   Wrap the GPS coordinate retrieval in withTimeoutOrNull(5000).
+   ◦
+   If it returns null (timeout or permission issue), immediately fall back to fetching weather for a neutral location (e.g., "Santa Barbara, US").
+   ◦
+   Ensure _locationName is updated with "Santa Barbara (Fallback)" or similar if the real location is unavailable.
+   •
+   [ ] Add a RefreshWeather event to allow the UI to retry the fetch once permissions are granted.
+   UI Integration (HomeScreen.kt)
+   •
+   [ ] Implement rememberMultiplePermissionsState for location.
+   •
+   [ ] Trigger the permission request on screen launch (LaunchedEffect).
+   •
+   [ ] Update the weather display logic:
+   ◦
+   If uiState.weather is null, display a specialized Grayed Out Placeholder Icon (using Icons.Default.CloudQueue or similar with a gray tint).
+   ◦
+   If weather is loading/refreshing, show a subtle loading state.
+
+
+
+3. Verification
+   •
+   [ ] Denied Case: Verify that the "Santa Barbara" fallback and city name appear if permissions are denied.
+   •
+   [ ] Granted Case: Verify that real local weather and city name appear if permissions are granted.
+   •
+   [ ] GPS Off Case: Verify the timeout prevents the UI from hanging.
+   •
+   [ ] Build and run :applications:kocolor:apps:mobile.
+   I have designed a solution that solves the "hanging" weather issue and adds the requested "grayed out" fallback icon. It will intelligently wait 5 seconds for your GPS before falling back to a safe default so the screen never stays blank.
+
+
+


### PR DESCRIPTION
…k logic

This commit improves the reliability of the weather feature by integrating a declarative permission flow and a fallback mechanism for location retrieval. It prevents potential UI hangs by introducing a timeout for GPS coordinates and ensures the user is presented with a consistent experience even when location access is denied or unavailable.

- **`HomeScreen.kt`**:
    - Integrated `rememberMultiplePermissionsState` from Accompanist to handle `ACCESS_COARSE_LOCATION` and `ACCESS_FINE_LOCATION`.
    - Added `LaunchedEffect` blocks to request permissions on first launch and trigger a weather refresh immediately upon permission grant.
    - Implemented a fallback "Weather unavailable" UI component using a gray-tinted `CloudQueue` icon to display when weather data is null.
- **`HomeViewModel.kt`**:
    - Introduced a `RefreshWeather` event to trigger location-based updates from the UI.
    - Refactored `fetchWeather` to use `withTimeoutOrNull(5000)`, preventing the coroutine from hanging indefinitely if GPS data is slow or unavailable.
    - Implemented a fallback mechanism that fetches weather for "Santa Barbara, US" if the device location cannot be retrieved.
    - Extracted `updateWeatherState` into a private function to unify state updates and environmental tip logic for both real and fallback data.
- **`build.gradle.kts`**:
    - Added the Google Accompanist Permissions library dependency to support the modern permission request flow.
- **`WeatherLocation.md`**:
    - Updated documentation to include a detailed implementation plan for handling location timeouts and UI fallbacks.