### PR TITLE
feat: implement default glass bridge and ritual repositories

### DIFF
--- a/app/src/main/java/com/zoewave/probase/data/repository/DefaultGlassBridgeRepository.kt
+++ b/app/src/main/java/com/zoewave/probase/data/repository/DefaultGlassBridgeRepository.kt
@@ -1,0 +1,35 @@
+package com.zoewave.probase.data.repository
+
+import com.zoewave.probase.core.data.repository.GlassBridgeRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DefaultGlassBridgeRepository @Inject constructor() : GlassBridgeRepository {
+    private val _isGlassConnected = MutableStateFlow(false)
+    override val isGlassConnected: StateFlow<Boolean> = _isGlassConnected.asStateFlow()
+
+    private val _isGlassSessionActive = MutableStateFlow(false)
+    override val isGlassSessionActive: StateFlow<Boolean> = _isGlassSessionActive.asStateFlow()
+
+    private val _glassCommands = MutableSharedFlow<String>()
+    override val glassCommands: SharedFlow<String> = _glassCommands.asSharedFlow()
+
+    override fun updateGlassConnectionState(isConnected: Boolean) {
+        _isGlassConnected.value = isConnected
+    }
+
+    override fun updateGlassSessionState(isActive: Boolean) {
+        _isGlassSessionActive.value = isActive
+    }
+
+    override suspend fun sendGlassCommand(command: String) {
+        _glassCommands.emit(command)
+    }
+}

--- a/app/src/main/java/com/zoewave/probase/data/repository/DefaultRitualRepository.kt
+++ b/app/src/main/java/com/zoewave/probase/data/repository/DefaultRitualRepository.kt
@@ -1,0 +1,24 @@
+package com.zoewave.probase.data.repository
+
+import com.zoewave.probase.core.data.repository.RitualRepository
+import com.zoewave.probase.core.model.ritual.BeautyRoutine
+import com.zoewave.probase.core.model.ritual.CosmeticItem
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DefaultRitualRepository @Inject constructor() : RitualRepository {
+    override fun getRoutinesForDay(start: Long, end: Long): Flow<List<BeautyRoutine>> = flowOf(emptyList())
+
+    override suspend fun updateRoutine(routine: BeautyRoutine) {
+        // No-op implementation for main app shell
+    }
+
+    override fun getCosmeticById(id: Long): Flow<CosmeticItem?> = flowOf(null)
+
+    override suspend fun updateCosmetic(item: CosmeticItem) {
+        // No-op implementation for main app shell
+    }
+}

--- a/app/src/main/java/com/zoewave/probase/di/GlassModule.kt
+++ b/app/src/main/java/com/zoewave/probase/di/GlassModule.kt
@@ -1,0 +1,28 @@
+package com.zoewave.probase.di
+
+import com.zoewave.probase.core.data.repository.GlassBridgeRepository
+import com.zoewave.probase.core.data.repository.RitualRepository
+import com.zoewave.probase.data.repository.DefaultGlassBridgeRepository
+import com.zoewave.probase.data.repository.DefaultRitualRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class GlassModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindGlassBridgeRepository(
+        impl: DefaultGlassBridgeRepository
+    ): GlassBridgeRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindRitualRepository(
+        impl: DefaultRitualRepository
+    ): RitualRepository
+}


### PR DESCRIPTION
This commit introduces default implementations for the glass bridge and ritual repositories within the app's data layer and configures their dependency injection bindings.

- **`DefaultGlassBridgeRepository.kt`**: Implemented `GlassBridgeRepository` to manage glass connection states, session activity, and command communication using `StateFlow` and `SharedFlow`.
- **`DefaultRitualRepository.kt`**: Added a `RitualRepository` implementation providing empty and no-op defaults for routine and cosmetic data operations.
- **`GlassModule.kt`**: Created a new Dagger Hilt module to bind the core repository interfaces to their respective default implementations at the singleton scope.