### PR TITLE
feat: implement remote capture bridge and diagnostics for Vision AI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:requiredDisplayCategory="xr_projected"
             android:theme="@style/Theme.ProBase">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/features/xr/glass/vision/doc/debug/preflight/implementation_plan.bridge_trigger.md
+++ b/features/xr/glass/vision/doc/debug/preflight/implementation_plan.bridge_trigger.md
@@ -1,0 +1,42 @@
+# Implementation Plan - Shared Vision Capture via Message Bridge
+
+The goal is to fix the "No available camera found" error by letting the **Glasses Activity** handle the camera hardware, while the **Phone Hub** acts as a remote control. This avoids binding issues in the phone activity and ensures we use the correct hardware.
+
+## User Review Required
+
+> [!IMPORTANT]
+> I am moving from a "Local Phone Binding" model to a "Remote Command" model.
+> 1. The Phone Hub will send a `CAPTURE_IMAGE` command via a shared repository.
+> 2. The Glasses Activity (which is already running) will receive the command and take the picture.
+> 3. The result will be shared back to the phone via a Singleton Repository.
+
+## Proposed Changes
+
+### Core Data (`core:data`)
+- No changes needed, `GlassBridgeRepository` already exists.
+
+### Vision Feature (`features/xr/glass/vision`)
+
+#### [MODIFY] [VisionViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt)
+- Inject `GlassBridgeRepository`.
+- **Command Listener**: In `init`, listen to `glassBridgeRepository.glassCommands`. If `CAPTURE_IMAGE` is received and an `imageCapture` is bound, execute `takePicture()`.
+- **Remote Trigger**: Implement `triggerGlassesCapture()` which emits the command.
+- **Deep Debugging**: Use `CameraManager` inside `setupCamera` to log the exact cameras available to the OS for the current context.
+
+#### [MODIFY] [UnifiedVisionScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt)
+- Update the **TRIGGER GLASSES CAMERA** button to use the new `triggerGlassesCapture()` method.
+
+#### [MODIFY] [app/src/main/AndroidManifest.xml](file:///Users/developer/AndroidStudioProjects/ProBase/app/src/main/AndroidManifest.xml)
+- Add `android:requiredDisplayCategory="xr_projected"` to `MainActivity`. This helps the OS expose projected hardware to the phone's main process.
+
+## Verification Plan
+
+### Automated Tests
+- Build the module: `./gradlew :features:xr:glass:vision:assembleDebug`
+
+### Manual Verification
+1.  **Launch Vision AI**: Verify both phone and glasses activities are running.
+2.  **Verify Binding**: Check Event Log for `SUCCESS: Camera successfully bound to Glasses` (this should now happen on the glasses side).
+3.  **Command Flow**: Tap the button on the phone. Verify the phone log shows `Command Sent: CAPTURE_IMAGE`.
+4.  **Capture Action**: Verify the glasses-side log shows it received the command and triggered the shutter.
+5.  **Result Sync**: Confirm the image appears on the phone preview immediately.

--- a/features/xr/glass/vision/doc/debug/preflight/walkthrough.bridge_fix.md
+++ b/features/xr/glass/vision/doc/debug/preflight/walkthrough.bridge_fix.md
@@ -1,0 +1,34 @@
+# Walkthrough - Vision Bridge Capture Fix
+
+I have implemented a **Message Bridge** strategy to resolve the "No camera found" error. Instead of the phone hub trying to access the glasses camera hardware directly (which was being blocked by the OS), the phone now acts as a remote control for the **Glasses Activity**.
+
+## Changes Made
+
+### 1. Remote Command Bridge
+- Updated [VisionViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt).
+- **Sender**: Added `triggerGlassesCapture()` which sends a `CAPTURE_IMAGE` command via `GlassBridgeRepository`.
+- **Receiver**: Added a listener in the `init` block. When the `CAPTURE_IMAGE` command is received, the ViewModel instance running on the **glasses** (which has direct hardware access) executes the picture capture.
+- This ensures the camera is always driven by the activity with the correct display category and hardware links.
+
+### 2. Deep Diagnostics
+- Added direct **OS CameraManager** logging in the setup flow.
+- The Event Log will now show exactly what cameras the Android system reports to the process for every context (e.g., `OS CameraManager reports 1 cameras for Glasses: [0]`).
+- This bypasses CameraX's abstraction to show the raw hardware state.
+
+### 3. Manifest Enhancement
+- Updated [AndroidManifest.xml](file:///Users/developer/AndroidStudioProjects/ProBase/app/src/main/AndroidManifest.xml).
+- Added `android:requiredDisplayCategory="xr_projected"` to `MainActivity`.
+- This informs the OS that the main phone activity is "projected-aware," which helps it see virtual hardware when using a `ProjectedContext`.
+
+## Verification Results
+
+### Build Status
+> [!TIP]
+> The project builds successfully with the new bridge logic.
+
+### Test Instructions
+1. Open the **Vision AI** demo.
+2. Tap **TRIGGER GLASSES CAMERA** on your phone.
+3. **Observation**: The phone Log shows `Sending Remote Command: CAPTURE_IMAGE...`.
+4. **Observation**: The Glasses-side Log (viewable in the unified log) shows `Received Remote Command: CAPTURE_IMAGE` and then `Capture Success!`.
+5. Verify the image taken by the glasses appears on your phone screen.

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
@@ -252,7 +252,7 @@ fun UnifiedVisionScreen(
                     if (!uiState.isPermissionGranted) {
                         cameraPermissionState.launchPermissionRequest()
                     } else {
-                        viewModel.takePicture()
+                        viewModel.triggerGlassesCapture()
                     }
                 },
                 modifier = Modifier.fillMaxWidth().height(56.dp),

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
@@ -21,6 +21,7 @@ import androidx.xr.projected.experimental.ExperimentalProjectedApi
 import com.google.ai.client.generativeai.GenerativeModel
 import com.google.ai.client.generativeai.type.content
 import com.zoewave.probase.core.data.repository.AiConfigurationSettings
+import com.zoewave.probase.core.data.repository.GlassBridgeRepository
 import com.zoewave.probase.features.glass.vision.data.VisionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -52,7 +53,8 @@ data class VisionUiState(
 class VisionViewModel @Inject constructor(
     application: Application,
     private val settings: AiConfigurationSettings,
-    private val repository: VisionRepository
+    private val repository: VisionRepository,
+    private val bridgeRepository: GlassBridgeRepository
 ) : AndroidViewModel(application) {
 
     private val TAG = "VisionVM"
@@ -98,6 +100,22 @@ class VisionViewModel @Inject constructor(
 
     init {
         checkStatus()
+        observeBridgeCommands()
+    }
+
+    private fun observeBridgeCommands() {
+        viewModelScope.launch {
+            bridgeRepository.glassCommands.collect { cmd ->
+                if (cmd == "CAPTURE_IMAGE") {
+                    addLog("Received Remote Command: CAPTURE_IMAGE")
+                    if (imageCapture != null) {
+                        takePicture()
+                    } else {
+                        addLog("Cannot execute capture: Camera not bound in this context.")
+                    }
+                }
+            }
+        }
     }
 
     private fun checkStatus() {
@@ -110,6 +128,13 @@ class VisionViewModel @Inject constructor(
 
     fun updatePermissionStatus(granted: Boolean) {
         _isPermissionGranted.value = granted
+    }
+
+    fun triggerGlassesCapture() {
+        viewModelScope.launch {
+            addLog("Sending Remote Command: CAPTURE_IMAGE...")
+            bridgeRepository.sendGlassCommand("CAPTURE_IMAGE")
+        }
     }
 
     fun checkGlassesPermission(activity: Activity) {
@@ -145,6 +170,11 @@ class VisionViewModel @Inject constructor(
                 for (attempt in 1..3) {
                     addLog("Probing $name context (Attempt $attempt of 3)...")
                     try {
+                        // DEEP DEBUG: Check OS CameraManager directly
+                        val cm = ctx.getSystemService(android.content.Context.CAMERA_SERVICE) as android.hardware.camera2.CameraManager
+                        val osCams = cm.cameraIdList
+                        addLog("OS CameraManager reports ${osCams.size} cameras for $name: [${osCams.joinToString()}]")
+                        
                         val cameraProvider = ProcessCameraProvider.awaitInstance(ctx)
                         val availableCams = cameraProvider.availableCameraInfos.size
                         addLog("$name reports $availableCams total cameras.")


### PR DESCRIPTION
This commit transitions the Vision AI feature to a "Remote Command" model to resolve camera binding errors. By using a message bridge, the phone hub now acts as a remote control that triggers image capture on the glasses-side activity, which has direct access to the hardware.

- **`VisionViewModel.kt`**:
    - **Remote Command Logic**: Injected `GlassBridgeRepository` to facilitate communication between the phone and glasses. Added `triggerGlassesCapture` to send commands and a listener in `init` to execute `takePicture` when a `CAPTURE_IMAGE` command is received.
    - **Enhanced Diagnostics**: Integrated raw `CameraManager` queries within the camera setup flow to log the exact number of cameras reported by the OS, bypassing CameraX abstractions for deeper debugging.
- **`UnifiedVisionScreen.kt`**:
    - Updated the primary action button to invoke `triggerGlassesCapture`, ensuring the capture sequence follows the new bridge architecture.
- **`AndroidManifest.xml`**:
    - Added `android:requiredDisplayCategory="xr_projected"` to `MainActivity` to help the OS expose projected hardware resources to the main application process.
- **Documentation**:
    - Created an implementation plan and walkthrough for the "Vision Bridge" strategy, detailing the shift from local phone binding to remote execution.