### PR TITLE
Glass debug

### DIFF
--- a/features/xr/glass/docs/DebugGlass.md
+++ b/features/xr/glass/docs/DebugGlass.md
@@ -1,0 +1,34 @@
+You hit the exact limitation of the `package:mine` filter in Android Studio, and your screenshots perfectly illustrate the problem.
+
+The reason the Display Glasses logcat is completely empty when you use `package:mine` is because **your app is not installed on the glasses.**
+
+Because of the projected architecture, your app's process (e.g., `com.zoewave.probase`) only exists on the Pixel 10 Pro. The `package:mine` filter tells Android Studio to look for logs matching the Process ID (PID) of the app you just deployed. Since the app was deployed to the phone, Android Studio finds a PID for it on the phone, but finds absolutely nothing on the glasses.
+
+To the Display Glasses, your app does not exist. The glasses only know that the Android OS system service on the phone is asking for a hardware connection.
+
+### How to Filter the Display Glasses Logcat
+
+To see what the glasses are doing, you must stop searching for your app and start searching for the **system services** handling the hardware.
+
+**Step 1: Clear the Package Filter**
+In the Display Glasses Logcat tab, delete `package:mine` from the search bar. If you leave it blank, you will see a massive firehose of system logs.
+
+**Step 2: Filter by Hardware and XR Tags**
+Instead of filtering by package, filter by the specific `tag` of the internal C++ drivers and XR services. Type these into the search bar:
+
+* **To debug the Camera/Vision failure:**
+  `tag:CameraManager OR tag:CameraService OR tag:CameraDevice`
+  *(This will show you exactly what happens on the headset when your Phone's `ViewModel` asks for the `EXTERNAL` lens).*
+* **To debug the XR Projection Bridge:**
+  `tag:XrCompositor OR tag:ProjectedDisplay OR tag:SurfaceFlinger`
+  *(This shows the video stream and spatial anchor handshakes).*
+* **To debug Audio/Mic drops:**
+  `tag:AudioFlinger OR tag:AudioPolicy`
+
+### The Debugging Workflow
+
+1. Keep your split-screen setup.
+2. On the **Left (Pixel 10 Pro)**: Keep `package:mine`. Watch your `VisionVM` logs print out your probing steps (`Probing Glasses (Attempt 1 of 3)...`).
+3. On the **Right (Display Glasses)**: Use `tag:CameraService`.
+
+When your phone hits the camera probe line in your code, look at the right screen. You will see the headset's internal OS react to the probe and output the raw hardware error explaining exactly why it is returning `0 cameras` to your phone.

--- a/features/xr/glass/vision/doc/debug/projected_camera_architecture.md
+++ b/features/xr/glass/vision/doc/debug/projected_camera_architecture.md
@@ -50,7 +50,6 @@ suspend fun initializeGlassesCamera(activity: ComponentActivity) {
     val cameraProvider = ProcessCameraProvider.awaitInstance(projectedContext)
     
     // 3. Select the outward-pointing Glasses camera
-    // Within a projected context, DEFAULT_BACK_CAMERA is automatically mapped to the glasses.
     val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
 
     // 4. Pre-binding Hardware Verification
@@ -68,8 +67,8 @@ suspend fun initializeGlassesCamera(activity: ComponentActivity) {
                 .build()
         )
 
-    // CORRECT: Use Extender to apply Camera2-level options (e.g. FPS range)
-    val fpsRange = Range(10, 10) // Optimized for Computer Vision thermals
+    // CORRECT: Use Extender to apply Camera2-level options
+    val fpsRange = Range(10, 10) 
     Camera2Interop.Extender(imageCaptureBuilder)
         .setCaptureRequestOption(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, fpsRange)
 
@@ -92,39 +91,49 @@ suspend fun initializeGlassesCamera(activity: ComponentActivity) {
 
 ---
 
-## 4. Verification Logs (End-to-End Trace)
+## 4. Cross-Device Debugging Strategy
 
-Use these log patterns to verify your setup is working correctly.
+Because AI Glasses execute logic on the phone but manage hardware on the headset, logs are split across two distinct streams.
 
-### Context & Hardware Check
-| Stage | Log Message | Meaning |
-| :--- | :--- | :--- |
-| **Start** | `VisionDebug: PHASE 1 SUCCESS: Created ProjectedContext.` | The OS has recognized the glasses link. |
-| **Discovery** | `CameraManagerGlobal: Connecting to camera service` | The system is reaching out to the virtual hardware bridge. |
-| **Validation** | `CameraValidator: Virtual device with ID: 1 has X cameras.` | **MUST be > 0.** If 0, the OS hasn't finished linking the hardware. |
-| **Verification**| `VisionDebug: PHASE 4 SUCCESS: Hardware verified.` | CameraX confirms `DEFAULT_BACK_CAMERA` exists in this context. |
+### A. The Phone Logcat (Application Space)
+- **Target**: The connected Phone or Emulator.
+- **Filter**: `package:mine` or `tag:VisionVM`.
+- **Content**: Jetpack Compose state, Gemini API calls, and the `ProjectedContext` lifecycle.
 
-### Binding & Runtime
-| Stage | Log Message | Meaning |
-| :--- | :--- | :--- |
-| **Binding** | `VisionDebug: PHASE 6 SUCCESS: Shutter linked to Glasses.` | The camera is now active and controlled by the glasses lifecycle. |
-| **Capture** | `VisionVM: Capture Success! Processing bitmap...` | The image has been successfully pulled from the glasses hardware memory. |
+### B. The Display Glasses Logcat (Hardware Space)
+- **Target**: `Display Glasses (emulator-5556)`.
+- **Filter**: `tag:XR_Compositor`, `tag:CameraDevice`, `tag:SurfaceFlinger`.
+- **Content**: Low-level hardware faults, frame drops, and projection bridge handshake errors.
+
+### C. Recommended Workflow
+1. **Split Logcat**: Right-click the Logcat tab in Android Studio and select **Split Right**.
+2. **Left Panel**: Target **Phone**. Monitor `VisionVM` for "Phase" success signals.
+3. **Right Panel**: Target **Glasses**. Monitor for hardware initialization errors or permission denials.
 
 ---
 
-## 5. Common Failure Signatures
+## 5. Verification Logs (End-to-End Trace)
 
-### "Cams: 0" (Hardware Link Missing)
-- **Log**: `IllegalArgumentException: No available camera can be found. Cams:0`
-- **Cause**: The `ProjectedContext` was used before the virtual hardware was ready.
-- **Fix**: Add a 1.5s delay or retry loop after `createProjectedDeviceContext`.
+### Phone Logcat (Logic Trace)
+| Stage | Log Message | Meaning |
+| :--- | :--- | :--- |
+| **Start** | `VisionDebug: PHASE 1 SUCCESS: Created ProjectedContext.` | The OS has recognized the glasses link. |
+| **Verification**| `VisionDebug: PHASE 4 SUCCESS: Hardware verified.` | CameraX confirms `DEFAULT_BACK_CAMERA` exists. |
+| **Binding** | `VisionDebug: PHASE 6 SUCCESS: Shutter linked to Glasses.` | The camera is now active. |
 
-### "Filters: 1" (Selector Conflict)
-- **Log**: `Bind failed: No available camera can be found. Filters:1`
-- **Cause**: The `CameraSelector` has contradictory filters (e.g. asking for `EXTERNAL` when the OS reports the lens as `BACK`).
-- **Fix**: Use `DEFAULT_BACK_CAMERA` inside the `ProjectedContext`; do not add manual lens-facing requirements.
+### Glasses Logcat (Hardware Trace)
+| Stage | Log Message | Meaning |
+| :--- | :--- | :--- |
+| **Bridge** | `CameraManagerGlobal: Connecting to camera service` | Glasses OS is linking to the Phone's request. |
+| **Validation** | `CameraValidator: Virtual device with ID: 1 has X cameras.` | **MUST be > 0.** If 0, hardware mount failed. |
+| **Handshake** | `XR_Compositor: New projected buffer allocated` | Visual data is streaming from glasses to phone memory. |
 
-### "Channel Broken" (ANR/Crash)
-- **Log**: `InputDispatcher: Channel is unrecoverably broken`
-- **Cause**: Running the initialization loop on the Main thread.
-- **Fix**: Offload `setupCamera` to `Dispatchers.IO`.
+---
+
+## 6. Common Failure Signatures
+
+| Observation | Root Cause | Fix |
+| :--- | :--- | :--- |
+| **`Cams: 0`** | Virtual hardware not yet registered. | Add retry loop with 1.5s delay in `setupCamera`. |
+| **`Filters: 1`** | Lens facing conflict (BACK vs EXTERNAL). | Remove explicit facing requirements when using raw IDs. |
+| **`Error 3`** | Hardware link timeout on the headset. | Restart the glasses emulator or check physical cable. |

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
@@ -176,7 +176,11 @@ class VisionViewModel @Inject constructor(
                 }
 
                 val providers = listOf(
-                    "Glasses" to try { ProjectedContext.createProjectedDeviceContext(baseContext) } catch (e: Exception) { null },
+                    "Glasses" to try { 
+                        val ctx = ProjectedContext.createProjectedDeviceContext(baseContext)
+                        addLog("PHASE 1 SUCCESS: Created ProjectedContext for Glasses.")
+                        ctx
+                    } catch (e: Exception) { null },
                     "Host (Phone)" to try { ProjectedContext.createHostDeviceContext(baseContext) } catch (e: Exception) { null },
                     "Application" to getApplication<Application>()
                 )
@@ -194,7 +198,10 @@ class VisionViewModel @Inject constructor(
                             addLog("OS reports ${ids.size} cameras in $name: [${ids.joinToString()}]")
                             
                             // 1. Fetch provider for THIS specific context
+                            addLog("Fetching CameraProvider for $name...")
                             val cameraProvider = ProcessCameraProvider.awaitInstance(ctx)
+                            val providerCams = cameraProvider.availableCameraInfos.size
+                            addLog("Provider reports $providerCams cameras in $name.")
 
                             for (id in ids) {
                                 val chars = cm.getCameraCharacteristics(id)
@@ -208,6 +215,7 @@ class VisionViewModel @Inject constructor(
                                 addLog("-> Found ID $id ($facingName). Testing binding...")
 
                                 // 2. Create selector that matches the OS facing property to avoid CameraX filtering conflict
+                                addLog("PHASE 4: Hardware Verification for ID $id ($facingName)...")
                                 val selector = CameraSelector.Builder()
                                     .requireLensFacing(
                                         when (lensFacing) {
@@ -225,7 +233,7 @@ class VisionViewModel @Inject constructor(
 
                                 if (bindCameraOnMainThread(activity, cameraProvider, selector)) {
                                     _cameraSource.value = "$name ($facingName - ID $id)"
-                                    addLog("SUCCESS: Camera $id bound to $name.")
+                                    addLog("PHASE 6 SUCCESS: Shutter linked to $name (ID $id).")
                                     bound = true
                                     break
                                 }

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.util.Log
@@ -38,10 +37,10 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.nio.ByteBuffer
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 data class VisionUiState(
     val imageDescription: String = "",
@@ -56,7 +55,9 @@ data class VisionUiState(
     val error: String? = null
 )
 
-@OptIn(ExperimentalProjectedApi::class, ExperimentalCamera2Interop::class, ExperimentalLensFacing::class)
+@ExperimentalLensFacing
+@ExperimentalCamera2Interop
+@OptIn(ExperimentalProjectedApi::class)
 @HiltViewModel
 class VisionViewModel @Inject constructor(
     application: Application,
@@ -65,7 +66,7 @@ class VisionViewModel @Inject constructor(
     private val bridgeRepository: GlassBridgeRepository
 ) : AndroidViewModel(application) {
 
-    private val TAG = "VisionVM"
+    private val tag = "VisionVM"
     private val cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
     private var imageCapture: ImageCapture? = null
 
@@ -97,7 +98,7 @@ class VisionViewModel @Inject constructor(
             isPermissionGranted = args[5] as Boolean,
             isGlassesPermissionGranted = args[6] as Boolean,
             capturedImage = args[7] as Bitmap?,
-            logs = args[8] as List<String>,
+            logs = @Suppress("UNCHECKED_CAST") (args[8] as List<String>),
             error = args[9] as String?
         )
     }.stateIn(
@@ -154,13 +155,14 @@ class VisionViewModel @Inject constructor(
                 _isGlassesPermissionGranted.value = granted
                 addLog("Glasses camera permission status: ${if (granted) "GRANTED" else "DENIED"}")
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to check glasses permission", e)
+                Log.e(tag, "Failed to check glasses permission", e)
                 _isGlassesPermissionGranted.value = false
             }
         }
     }
 
-    @OptIn(ExperimentalCamera2Interop::class, ExperimentalLensFacing::class)
+    @ExperimentalLensFacing
+    @ExperimentalCamera2Interop
     fun setupCamera(activity: Activity) {
         viewModelScope.launch {
             // FIX: Run probing in IO thread to prevent ANR/Crash
@@ -182,7 +184,7 @@ class VisionViewModel @Inject constructor(
                         ctx
                     } catch (e: Exception) { null },
                     "Host (Phone)" to try { ProjectedContext.createHostDeviceContext(baseContext) } catch (e: Exception) { null },
-                    "Application" to getApplication<Application>()
+                    "Application" to getApplication()
                 )
 
                 var bound = false
@@ -241,10 +243,10 @@ class VisionViewModel @Inject constructor(
 
                             if (bound) break
                             addLog("No cameras could be bound in $name. Waiting...")
-                            delay(1000)
+                            delay(1000.milliseconds)
                         } catch (e: Exception) {
                             addLog("Probe error in $name: ${e.message}")
-                            delay(1000)
+                            delay(1000.milliseconds)
                         }
                     }
                 }
@@ -276,7 +278,7 @@ class VisionViewModel @Inject constructor(
             true
         } catch (e: Exception) {
             // Log.d is fine here as it's not blocking
-            Log.e(TAG, "Bind failed for selector: ${e.message}")
+            Log.e(tag, "Bind failed for selector: ${e.message}")
             false
         }
     }
@@ -302,7 +304,7 @@ class VisionViewModel @Inject constructor(
 
             override fun onError(exception: ImageCaptureException) {
                 addLog("Capture Error: ${exception.message}")
-                Log.e(TAG, "Capture failed", exception)
+                Log.e(tag, "Capture failed", exception)
                 repository.updateCapturing(false)
                 _error.value = "Capture failed: ${exception.message}"
             }
@@ -354,15 +356,8 @@ class VisionViewModel @Inject constructor(
     private fun addLog(message: String) {
         val timestamp = java.text.SimpleDateFormat("HH:ss:mm", java.util.Locale.getDefault()).format(java.util.Date())
         val formattedMsg = "[$timestamp] $message"
-        Log.d(TAG, formattedMsg)
-        _logs.value = _logs.value + formattedMsg
-    }
-
-    private fun ImageProxy.toBitmap(): Bitmap {
-        val buffer: ByteBuffer = planes[0].buffer
-        val bytes = ByteArray(buffer.remaining())
-        buffer.get(bytes)
-        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+        Log.d(tag, formattedMsg)
+        _logs.value += formattedMsg
     }
 
     override fun onCleared() {


### PR DESCRIPTION
What was fixed:
•
Opt-in Requirement: Applied the @ExperimentalLensFacing and @ExperimentalCamera2Interop annotations directly to the class and setupCamera function. These experimental APIs require explicit markers rather than just standard @OptIn blocks in this environment.
•
CameraX 1.3+ Integration: Removed the redundant toBitmap extension and switched to the built-in ImageProxy.toBitmap() member function provided by CameraX.
•
Threading Safety: Moved the entire hardware probing sequence to Dispatchers.IO to prevent the UI thread from blocking, which was causing the OS to kill the app process.
•
Dynamic Filtering: Updated the CameraSelector to dynamically match the lens facing reported by the OS (e.g., FRONT, BACK, or EXTERNAL), resolving the filter conflict that was blocking emulator webcams.
•
Code Cleanup: Fixed naming conventions (renamed TAG to tag), removed unused imports (BitmapFactory, ByteBuffer), and added a @Suppress("UNCHECKED_CAST") to the logs mapping.
The code now compiles successfully and should allow the Vision AI feature to bind to both real AI glasses hardware and emulator virtual cameras.