### PR TITLE
feat: add camera and audio recording permissions for XR glass features

### DIFF
--- a/features/xr/glass/samples/src/main/AndroidManifest.xml
+++ b/features/xr/glass/samples/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
 </manifest>

--- a/features/xr/glass/src/main/AndroidManifest.xml
+++ b/features/xr/glass/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application>
         <activity


### PR DESCRIPTION
This commit updates the Android manifests for the XR glass library and its sample applications to include the necessary permissions for camera access and audio recording.

- **Manifest Updates**:
    - **Samples**: Added `CAMERA` and `RECORD_AUDIO` permissions to `features/xr/glass/samples/src/main/AndroidManifest.xml` to support computer vision and speech-related features in the demo apps.
    - **Library**: Added `RECORD_AUDIO` permission to `features/xr/glass/src/main/AndroidManifest.xml` to enable microphone access for library-level components.