### PR TITLE
Glass build

### DIFF
--- a/app/src/main/java/com/zoewave/probase/data/repository/DefaultGlassBridgeRepository.kt
+++ b/app/src/main/java/com/zoewave/probase/data/repository/DefaultGlassBridgeRepository.kt
@@ -1,5 +1,6 @@
 package com.zoewave.probase.data.repository
 
+import android.util.Log
 import com.zoewave.probase.core.data.repository.GlassBridgeRepository
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,6 +31,7 @@ class DefaultGlassBridgeRepository @Inject constructor() : GlassBridgeRepository
     }
 
     override suspend fun sendGlassCommand(command: String) {
+        Log.d("GlassBridge", "Emitting command: $command")
         _glassCommands.emit(command)
     }
 }

--- a/features/xr/glass/docs/HardWare.md
+++ b/features/xr/glass/docs/HardWare.md
@@ -1,0 +1,350 @@
+There are two primary ways to get a projected context, depending on where your
+code is executing:
+
+## Get a projected context if your code is running in an projected activity
+
+If your app's code is running from within your [projected activity](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/support-different-types#activity-lifecycle), its own
+activity context is already a [projected context](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/support-different-types#projected-context). In this scenario, calls
+made within that activity can already access the glasses' hardware.
+
+## Get a projected context for code running in a phone app component
+
+If a part of your app outside of your projected activity (such as a phone
+activity or a service) needs to access the glasses' hardware, it must explicitly
+obtain a projected context. To do this, use the
+[`createProjectedDeviceContext`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createProjectedDeviceContext(android.content.Context)) method:
+
+
+```kotlin
+@OptIn(ExperimentalProjectedApi::class)
+private fun getGlassesContext(context: Context): Context? {
+    return try {
+        // From a phone Activity or Service, get a context for the AI glasses.
+        ProjectedContext.createProjectedDeviceContext(context)
+    } catch (e: IllegalStateException) {
+        Log.e(TAG, "Failed to create projected device context", e)
+        null
+    }
+}
+```
+
+<br />
+
+### Check for validity
+
+Wrap the [`createProjectedDeviceContext`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createProjectedDeviceContext(android.content.Context)) call within the
+[`ProjectedContext.isProjectedDeviceConnected`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#isProjectedDeviceConnected(android.content.Context,kotlin.coroutines.CoroutineContext)). While this method returns
+`true`, the projected context remains valid to the connected device, and your
+phone app activity or service (such as a `CameraManager`) can access the AI
+glasses hardware.
+
+### Clean up on disconnect
+
+The projected context is tied to the lifecycle of the connected device, so it is
+destroyed when the device disconnects. When the device disconnects,
+[`ProjectedContext.isProjectedDeviceConnected`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#isProjectedDeviceConnected(android.content.Context,kotlin.coroutines.CoroutineContext)) returns `false`. Your app
+should listen for this change and clean up any system services (such as a
+`CameraManager`) or resources that your app created using that projected
+context.
+
+### Re-initialize on reconnect
+
+When the glasses reconnect, your app can obtain another projected
+context instance using [`createProjectedDeviceContext`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createProjectedDeviceContext(android.content.Context)), and then
+re-initialize any system services or resources using the new projected context.
+
+## Record audio with the glasses' microphone
+
+You can record audio from the glasses using two distinct methods:
+
+- Use a [projected context](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/support-different-types#projected-context).
+- Use Bluetooth Hands-Free Profile (HFP).
+
+### Choose a recording methods
+
+The method you choose depends on whether you need high-fidelity, XR-specific
+audio processing, or standard Bluetooth audio input.
+
+| Recording method | Microphone access | Common use case |
+|---|---|---|
+| Projected Context | Multiple microphones | Recording using a projected context lets your app access multiple microphones from the glasses and its specialized hardware features, such as: - XR-specific spatialization. - Advanced denoising. - Voice separation that distinguishes between wearer's and bystander's voices. - Maintain recording access in multidevice environments even when the glasses are not the active Bluetooth device. |
+| Bluetooth HFP | Single microphone | Relies on the Bluetooth Hands-Free Profile (HFP) for immediate, out-of-the-box compatibility. In this mode, the glasses connect to the phone using standard Headset and Advanced Audio Distribution Profile (A2DP) [profiles](https://developer.android.com/develop/connectivity/bluetooth/profiles), functioning like a typical Bluetooth peripheral. If your app is already designed for standard Bluetooth recording, you can use this method to record audio from the glasses without integrating any XR-specific capabilities. |
+
+### Record audio using a projected context
+
+To record audio using a projected context, first request the required runtime
+permissions, and then record the audio using the [`AudioRecord`](https://developer.android.com/reference/kotlin/android/media/AudioRecord) API, as
+described in the following sections.
+
+#### Request runtime permissions
+
+To access multiple microphones on the glasses, you must request audio
+permissions specifically for the projected device. The standard, phone-scoped
+`RECORD_AUDIO` permission that a user has granted for your app on their mobile
+device is insufficient.
+
+Follow these steps to request the permissions:
+
+1. [Declare the `RECORD_AUDIO` permission](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#declare-permissions) in your app's manifest file.
+2. Request the projected-device-scoped permissions in one of the following
+   ways, depending on where your code is executing:
+
+    - **Code executing from a projected activity** : Use the [`ActivityResultLauncher`](https://developer.android.com/reference/kotlin/androidx/activity/result/ActivityResultLauncher) with the [`ProjectedPermissionsResultContract`](https://developer.android.com/reference/kotlin/androidx/xr/projected/permissions/ProjectedPermissionsResultContract#ProjectedPermissionsResultContract()). For more information on using this method, see the [register the permissions launcher](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#register) section and subsequent sections in the guide for requesting hardware permissions.
+    - **Code executing from a host phone activity** : Use [`Activity#requestPermissions(permissions, requestCode, deviceId)`](https://developer.android.com/reference/kotlin/android/app/Activity#requestpermissions_1) and provide the device ID obtained from your `projectedDeviceContext`, as described in the [understand the permission request user flow](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#permissions-user-flow) section of the guide for requesting hardware permissions.
+
+#### Initialize AudioRecord with a projected context
+
+To ensure that audio is recorded from the glasses rather than the host phone,
+you must associate the `AudioRecord` object with the projected device context.
+
+The following code uses the [`AudioRecord.Builder`](https://developer.android.com/reference/kotlin/android/media/AudioRecord.Builder) and passes the
+`projectedDeviceContext` to the [`setContext`](https://developer.android.com/reference/kotlin/android/media/AudioRecord.Builder#setcontext) method:
+
+
+```kotlin
+// Initialize AudioRecord with projected device context
+val audioRecord = AudioRecord.Builder()
+    .setAudioSource(MediaRecorder.AudioSource.CAMCORDER)
+    .setAudioFormat(audioFormat)
+    .setBufferSizeInBytes(bufferSize)
+    // pass in the projected device context
+    .setContext(projectedDeviceContext)
+    .build()
+
+audioRecord.startRecording()
+```
+
+<br />
+
+##### Key points about the code
+
+- You can set the audio source to [`CAMCORDER`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder.AudioSource#camcorder),
+  [`VOICE_RECOGNITION`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder.AudioSource#voice_recognition), [`VOICE_COMMUNICATION`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder.AudioSource#voice_communication), or
+  [`UNPROCESSED`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder.AudioSource#unprocessed) to tailor the audio processing to your specific use
+  case.
+
+  For example, use `VOICE_COMMUNICATION` if your use case needs automatic
+  noise reduction. `VOICE_RECOGNITION` is processed with acoustic echo
+  cancellation (AEC). And if you need raw, unaltered audio, select
+  `UNPROCESSED` or `CAMCORDER`.
+- To ensure compatibility with the glasses, the `audioFormat` object must
+  define a sample rate of 16kHz and a channel configuration of either mono or
+  stereo (using [`CHANNEL_IN_MONO`](https://developer.android.com/reference/kotlin/android/media/AudioFormat#channel_in_mono) or [`CHANNEL_IN_STEREO`](https://developer.android.com/reference/kotlin/android/media/AudioFormat#channel_in_stereo)).
+
+- Use [`AudioRecord.getMinBufferSize()`](https://developer.android.com/reference/kotlin/android/media/AudioRecord#getminbuffersize) to determine the minimum buffer
+  size to create the `AudioRecord` object. However, to prevent audio drops
+  from the glasses, you should read from this buffer in short, frequent chunks
+  (ideally 20ms slices) rather than waiting for the entire buffer to fill.
+
+> [!WARNING]
+> **Preview:** Support for using the [`MediaRecorder`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder) API with a projected context will be available in an upcoming Android Beta release.
+
+##### Clean up after use
+
+When your app no longer needs the microphone, or when the activity is stopped,
+call [`stop`](https://developer.android.com/reference/kotlin/android/media/AudioRecord#stop) and [`release`](https://developer.android.com/reference/kotlin/android/media/AudioRecord#release) on the `AudioRecord` object.
+
+##### Check for runtime permissions before recording
+
+Before calling [`startRecording`](https://developer.android.com/reference/kotlin/android/media/AudioRecord#startrecording), [verify that the user has granted the
+microphone permission for the glasses](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#check-function) using the projected context.
+
+### Record audio using Bluetooth HFP
+
+To record audio using Bluetooth HFP, first request the required runtime
+permissions, and then record the audio using the [`AudioManager`](https://developer.android.com/reference/kotlin/android/media/AudioManager) API, as
+described in the following sections.
+
+#### Request permissions
+
+As with any standard Bluetooth audio device, the [`RECORD_AUDIO`](https://developer.android.com/reference/kotlin/android/Manifest.permission#record_audio),
+[`BLUETOOTH_CONNECT`](https://developer.android.com/reference/kotlin/android/Manifest.permission#bluetooth_connect), and other related permissions are controlled by the
+phone and not the connected device (such as audio glasses or display glasses).
+
+Follow these steps to request the permissions:
+
+1. [Declare following permissions](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#declare-permissions) in your app's manifest file:
+
+    - [`RECORD_AUDIO`](https://developer.android.com/reference/kotlin/android/Manifest.permission#record_audio)
+    - [`BLUETOOTH_CONNECT`](https://developer.android.com/reference/kotlin/android/Manifest.permission#bluetooth_connect)
+    - [`MODIFY_AUDIO_SETTINGS`](https://developer.android.com/reference/kotlin/android/Manifest.permission#modify_audio_settings)
+2. Request both the `RECORD_AUDIO` and `BLUETOOTH_CONNECT` permissions at
+   runtime using the [standard Android permission flow](https://developer.android.com/training/permissions/requesting).
+
+#### Use AudioManager to route audio
+
+After the user has granted your app the necessary runtime permissions, use the
+[`AudioManager`](https://developer.android.com/reference/kotlin/android/media/AudioManager) API to set the communication device to
+[`TYPE_BLUETOOTH_SCO`](https://developer.android.com/reference/kotlin/android/media/AudioDeviceInfo#type_bluetooth_sco) to route the audio through Bluetooth HFP. This
+directs the system to retrieve audio from the Bluetooth peripheral.
+
+
+```kotlin
+val audioManager = context.getSystemService(AudioManager::class.java) ?: return
+val devices = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
+val hfpDevice = devices.find { it.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO }
+
+hfpDevice?.let { device ->
+    val audioRecord = AudioRecord.Builder()
+        .setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION)
+        .setAudioFormat(audioFormat)
+        .setBufferSizeInBytes(bufferSize)
+        .build()
+
+    // Route recording to the Bluetooth device
+    audioRecord.setPreferredDevice(device)
+    audioManager.setCommunicationDevice(device)
+
+    audioRecord.startRecording()
+```
+
+<br />
+
+> [!NOTE]
+> **Note:** To learn more about Bluetooth connectivity, refer to our [documentation](https://developer.android.com/develop/connectivity/bluetooth).
+
+## Capture an image with the glasses' camera
+
+To capture an image with the glasses' camera, set up and bind the CameraX's
+[`ImageCapture`](https://developer.android.com/reference/kotlin/androidx/camera/core/ImageCapture) [use case](https://developer.android.com/media/camera/camerax#ease-of-use) to the glasses' camera using the correct
+context for your app:
+
+
+```kotlin
+private fun startCameraOnGlasses(activity: ComponentActivity) {
+    // 1. Get the CameraProvider using the projected context.
+    // When using the projected context, DEFAULT_BACK_CAMERA maps to the AI glasses' camera.
+    val projectedContext = try {
+        ProjectedContext.createProjectedDeviceContext(activity)
+    } catch (e: IllegalStateException) {
+        Log.e(TAG, "AI Glasses context could not be created", e)
+        return
+    }
+
+    val cameraProviderFuture = ProcessCameraProvider.getInstance(projectedContext)
+
+    cameraProviderFuture.addListener({
+        val cameraProvider: ProcessCameraProvider = cameraProviderFuture.get()
+        val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
+        // 2. Check for the presence of a camera.
+        if (!cameraProvider.hasCamera(cameraSelector)) {
+            Log.w(TAG, "The selected camera is not available.")
+            return@addListener
+        }
+
+        // 3. Query supported streaming resolutions using Camera2 Interop.
+        val cameraInfo = cameraProvider.getCameraInfo(cameraSelector)
+        val camera2CameraInfo = Camera2CameraInfo.from(cameraInfo)
+        val cameraCharacteristics = camera2CameraInfo.getCameraCharacteristic(
+            CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP
+        )
+
+        // 4. Define the resolution strategy.
+        val targetResolution = Size(1920, 1080)
+        val resolutionStrategy = ResolutionStrategy(
+            targetResolution,
+            ResolutionStrategy.FALLBACK_RULE_CLOSEST_LOWER
+        )
+        val resolutionSelector = ResolutionSelector.Builder()
+            .setResolutionStrategy(resolutionStrategy)
+            .build()
+
+        // 5. If you have other continuous use cases bound, such as Preview or ImageAnalysis,
+        // you can use  Camera2 Interop's CaptureRequestOptions to set the FPS
+        val fpsRange = Range(30, 60)
+        val captureRequestOptions = CaptureRequestOptions.Builder()
+            .setCaptureRequestOption(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, fpsRange)
+            .build()
+
+        // 6. Initialize the ImageCapture use case with options.
+        val imageCapture = ImageCapture.Builder()
+            // Optional: Configure resolution, format, etc.
+            .setResolutionSelector(resolutionSelector)
+            .build()
+
+        try {
+            // Unbind use cases before rebinding.
+            cameraProvider.unbindAll()
+
+            // Bind use cases to camera using the Activity as the LifecycleOwner.
+            cameraProvider.bindToLifecycle(
+                activity,
+                cameraSelector,
+                imageCapture
+            )
+        } catch (exc: Exception) {
+            Log.e(TAG, "Use case binding failed", exc)
+        }
+    }, ContextCompat.getMainExecutor(activity))
+}
+```
+
+<br />
+
+### Key points about the code
+
+- Obtains an instance of the [`ProcessCameraProvider`](https://developer.android.com/reference/kotlin/androidx/camera/lifecycle/ProcessCameraProvider) using the [**projected device context**](https://developer.android.com/develop/xr/jetpack-xr-sdk/access-hardware-projected-context#phone-activity-service).
+- Within the projected context's scope, the glasses' primary, outward-pointing camera maps to the `DEFAULT_BACK_CAMERA` when selecting a camera.
+- A pre-binding check uses [`cameraProvider.hasCamera(cameraSelector)`](https://developer.android.com/reference/kotlin/androidx/camera/lifecycle/ProcessCameraProvider#hasCamera(androidx.camera.core.CameraSelector)) to verify that the selected camera is available on the device before proceeding.
+- Uses **Camera2 Interop** with [`Camera2CameraInfo`](https://developer.android.com/reference/kotlin/androidx/camera/camera2/interop/Camera2CameraInfo) to read the underlying [`CameraCharacteristics#SCALER_STREAM_CONFIGURATION_MAP`](https://developer.android.com/reference/kotlin/android/hardware/camera2/CameraCharacteristics#scaler_stream_configuration_map), which can be useful for advanced checks on supported resolutions.
+- A custom [`ResolutionSelector`](https://developer.android.com/reference/kotlin/androidx/camera/core/resolutionselector/ResolutionSelector) is built to precisely control the output image resolution for [`ImageCapture`](https://developer.android.com/reference/kotlin/androidx/camera/core/ImageCapture).
+- Creates an `ImageCapture` use case that is configured with a custom `ResolutionSelector`.
+- Binds the `ImageCapture` use case to the activity's lifecycle. This automatically manages the opening and closing of the camera based on the activity's state (for example, stopping the camera when the activity is paused).
+
+After the glasses' camera is set up, you can capture an image with the
+CameraX's `ImageCapture` class. Refer to the CameraX's documentation to learn
+about using [`takePicture`](https://developer.android.com/media/camera/camerax/take-photo#take_a_picture) to [capture an image](https://developer.android.com/media/camera/camerax/take-photo#take_a_picture).
+
+### Capture a video with the glasses' camera
+
+To capture a video instead of an image with the glasses' camera, replace the
+`ImageCapture` components with the corresponding [`VideoCapture`](https://developer.android.com/reference/kotlin/androidx/camera/video/VideoCapture) components
+and modify the capture execution logic.
+
+The main changes involve using a different use case, creating a different output
+file, and initiating the capture using the appropriate video recording method.
+For more information about the `VideoCapture` API and how to use it, see the
+[CameraX's video capture documentation](https://developer.android.com/media/camera/camerax/video-capture#using-videocapture-api).
+
+> [!IMPORTANT]
+> **Important:** Battery power and thermal dissipation on glasses devices is often limited. When developing for glasses, pay close attention to the requested **output format** and **resolution**, as these can severely impact system power and temperature.
+
+The following table shows the recommended resolution and frame rate depending on
+your app's use case:
+
+| Use case | Resolution | Frame rate |
+|---|---|---|
+| Video Communication | 1280 x 720 | 15 FPS |
+| Computer Vision | 640 x 480 | 10 FPS |
+| AI Video Streaming | 640 x 480 | 1 FPS |
+
+## Access a phone's hardware from a projected activity
+
+An [projected activity](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/support-different-types#activity-lifecycle) can also access the phone's hardware (such as the
+camera or microphone) by using [`createHostDeviceContext(context)`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createHostDeviceContext(android.content.Context)) to get
+the host device's (phone) context:
+
+
+```kotlin
+@OptIn(ExperimentalProjectedApi::class)
+private fun getPhoneContext(activity: ComponentActivity): Context? {
+    return try {
+        // From an AI glasses Activity, get a context for the phone.
+        ProjectedContext.createHostDeviceContext(activity)
+    } catch (e: IllegalStateException) {
+        Log.e(TAG, "Failed to create host device context", e)
+        null
+    }
+}
+```
+
+<br />
+
+When accessing hardware or resources that are specific to the host device
+(phone) in a hybrid app (an app containing both mobile and glasses
+experiences), you must explicitly select the correct context to make sure your
+app can access the correct hardware:
+
+- Use the [`Activity`](https://developer.android.com/reference/kotlin/android/app/Activity) context from the phone `Activity` or the [`ProjectedContext.createHostDeviceContext`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createHostDeviceContext(android.content.Context)) to get the phone's context.
+- Don't use [`getApplicationContext`](https://developer.android.com/reference/kotlin/android/content/Context#getapplicationcontext) because the application context can incorrectly return the glasses' context if a projected activity was the most-recently-launched component.

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GlassesMainActivity.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GlassesMainActivity.kt
@@ -3,6 +3,7 @@ package com.zoewave.probase.features.xr.glass
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.camera.core.ExperimentalLensFacing
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -16,11 +17,11 @@ import androidx.xr.projected.ProjectedDeviceController
 import androidx.xr.projected.ProjectedDeviceController.Capability.Companion.CAPABILITY_VISUAL_UI
 import androidx.xr.projected.ProjectedDisplayController
 import androidx.xr.projected.experimental.ExperimentalProjectedApi
+import com.zoewave.probase.core.data.repository.GlassBridgeRepository
+import com.zoewave.probase.core.data.repository.LiveAiRepository
 import com.zoewave.probase.features.xr.glass.data.GlassSessionRepository
 import com.zoewave.probase.features.xr.glass.ui.GlassApp
 import com.zoewave.probase.features.xr.glass.ui.GlimmerSample
-import com.zoewave.probase.core.data.repository.GlassBridgeRepository
-import com.zoewave.probase.core.data.repository.LiveAiRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -40,6 +41,7 @@ class GlassesMainActivity : ComponentActivity() {
 
     private var initialSample: GlimmerSample? = null
 
+    @androidx.annotation.OptIn(ExperimentalLensFacing::class)
     @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -50,8 +52,11 @@ class GlassesMainActivity : ComponentActivity() {
 
         audioInterface = GlassAudioInterface(
             this,
-            "Resuming your ritual.",
+            "", // Empty default to prevent unintentional greeting
         )
+        if (initialSample == GlimmerSample.Ritual) {
+            audioInterface.speak("Resuming your ritual.")
+        }
         lifecycle.addObserver(audioInterface)
         lifecycle.addObserver(liveAiRepository)
 
@@ -104,12 +109,18 @@ class GlassesMainActivity : ComponentActivity() {
     }
 
     private fun initializeGlassesFeatures() {
-        lifecycleScope.launch {
+        // Peer Review Adjustment: Move controllers to main thread to avoid lifecycle race conditions.
+        // Clarification: create() is a suspend function in alpha08, so we use launch(Main.immediate).
+        lifecycleScope.launch(kotlinx.coroutines.Dispatchers.Main.immediate) {
             try {
                 val projectedDeviceController = ProjectedDeviceController.create(this@GlassesMainActivity)
                 val connected = projectedDeviceController.capabilities.isNotEmpty()
                 isVisualUiSupported = projectedDeviceController.capabilities.contains(CAPABILITY_VISUAL_UI)
-                glassSessionRepository.updateConnection(connected)
+                
+                // Keep repository update async as it might be state-driven
+                launch {
+                    glassSessionRepository.updateConnection(connected)
+                }
 
                 val controller = ProjectedDisplayController.create(this@GlassesMainActivity)
                 displayController = controller
@@ -120,7 +131,9 @@ class GlassesMainActivity : ComponentActivity() {
                 lifecycle.addObserver(observer)
             } catch (e: Exception) {
                 android.util.Log.e("GlassesMain", "Init failed", e)
-                glassSessionRepository.updateConnection(false)
+                launch {
+                    glassSessionRepository.updateConnection(false)
+                }
             }
         }
     }

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassXRDemosPhoneScreen.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassXRDemosPhoneScreen.kt
@@ -44,8 +44,6 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.xr.projected.ProjectedContext
 import androidx.xr.projected.experimental.ExperimentalProjectedApi
-import androidx.xr.projected.permissions.ProjectedPermissionsRequestParams
-import androidx.xr.projected.permissions.ProjectedPermissionsResultContract
 import com.zoewave.probase.features.glass.translation.ui.UnifiedTranslationScreen
 import com.zoewave.probase.features.glass.vision.ui.UnifiedVisionScreen
 import com.zoewave.probase.features.glass.vision.ui.VisionUiEvent
@@ -72,14 +70,6 @@ fun GlassXRDemosPhoneRoute(
 
     val phonePermissionState = com.google.accompanist.permissions.rememberPermissionState(android.Manifest.permission.CAMERA)
 
-    val projectedPermissionLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
-        ProjectedPermissionsResultContract()
-    ) { results ->
-        android.util.Log.d("GlassXRDemos", "Projected permissions result: $results")
-        // Re-poll status
-        visionViewModel.onEvent(VisionUiEvent.CheckPermissions(context))
-    }
-
     LaunchedEffect(Unit) {
         viewModel.checkConnection(context)
         visionViewModel.onEvent(VisionUiEvent.CheckPermissions(context))
@@ -101,26 +91,6 @@ fun GlassXRDemosPhoneRoute(
         requestPhonePermission = {
             android.util.Log.d("GlassXRDemos", "requestPhonePermission clicked")
             phonePermissionState.launchPermissionRequest()
-        },
-        onRequestGlassesPermission = {
-            android.util.Log.d("GlassXRDemos", "onRequestGlassesPermission triggered.")
-            try {
-                // Primary method: Use standard contract for better robustness in low-discovery states
-                val params = ProjectedPermissionsRequestParams(
-                    permissions = listOf(android.Manifest.permission.CAMERA),
-                    rationale = "Camera access is needed on your AI glasses for this demo."
-                )
-                projectedPermissionLauncher.launch(listOf(params))
-                
-                // Secondary check for targeted request capability
-                val activity = context as? android.app.Activity
-                val glassesContext = try { ProjectedContext.createProjectedDeviceContext(context) } catch (e: Exception) { null }
-                if (glassesContext != null && activity != null && android.os.Build.VERSION.SDK_INT >= 35) {
-                    android.util.Log.d("GlassXRDemos", "Device ID available: ${glassesContext.deviceId}. Contract launched.")
-                }
-            } catch (e: Exception) {
-                android.util.Log.e("GlassXRDemos", "Failed to trigger permissions", e)
-            }
         }
     )
 }
@@ -138,7 +108,6 @@ fun GlassXRDemosPhoneScreen(
     onNextSample: (GlimmerSample) -> Unit,
     onPreviousSample: (GlimmerSample) -> Unit,
     onVisionEvent: (VisionUiEvent) -> Unit,
-    onRequestGlassesPermission: () -> Unit,
     requestPhonePermission: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -226,7 +195,6 @@ fun GlassXRDemosPhoneScreen(
                     uiState = visionUiState,
                     onEvent = onVisionEvent,
                     onNavigateToSettings = { /* No-op for now */ },
-                    onRequestGlassesPermission = onRequestGlassesPermission,
                     onBack = onStopDemo,
                     requestPhonePermission = requestPhonePermission
                 )
@@ -325,7 +293,6 @@ private fun GlassXRDemosPhoneScreenPreview() {
             onNextSample = {},
             onPreviousSample = {},
             onVisionEvent = {},
-            onRequestGlassesPermission = {},
             requestPhonePermission = {}
         )
     }

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/data/VisionRepository.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/data/VisionRepository.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,25 +23,25 @@ class VisionRepository @Inject constructor() {
     val isCapturing: StateFlow<Boolean> = _isCapturing.asStateFlow()
 
     fun updateCapturedImage(bitmap: Bitmap?) {
-        _capturedImage.value = bitmap
+        _capturedImage.update { bitmap }
     }
 
     fun updateImageDescription(description: String) {
-        _imageDescription.value = description
+        _imageDescription.update { description }
     }
 
     fun updateAnalyzing(analyzing: Boolean) {
-        _isAnalyzing.value = analyzing
+        _isAnalyzing.update { analyzing }
     }
 
     fun updateCapturing(capturing: Boolean) {
-        _isCapturing.value = capturing
+        _isCapturing.update { capturing }
     }
 
     fun clear() {
-        _capturedImage.value = null
-        _imageDescription.value = ""
-        _isAnalyzing.value = false
-        _isCapturing.value = false
+        _capturedImage.update { null }
+        _imageDescription.update { "" }
+        _isAnalyzing.update { false }
+        _isCapturing.update { false }
     }
 }

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/LiveVisionActivity.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/LiveVisionActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.ExperimentalLensFacing
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,20 +24,18 @@ import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.xr.projected.ProjectedDeviceController
 import androidx.xr.projected.experimental.ExperimentalProjectedApi
-import androidx.xr.projected.permissions.ProjectedPermissionsRequestParams
-import androidx.xr.projected.permissions.ProjectedPermissionsResultContract
 import dagger.hilt.android.AndroidEntryPoint
 
 @OptIn(ExperimentalProjectedApi::class)
 @AndroidEntryPoint
 class LiveVisionActivity : ComponentActivity() {
 
-    private val projectedPermissionLauncher =
-        registerForActivityResult(ProjectedPermissionsResultContract()) { results ->
-            if (results[Manifest.permission.CAMERA] == true) {
-                Log.d("LiveVisionActivity", "Projected camera permission granted")
+    private val permissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                Log.d("LiveVisionActivity", "Camera permission granted")
             } else {
-                Log.e("LiveVisionActivity", "Projected camera permission denied")
+                Log.e("LiveVisionActivity", "Camera permission denied")
             }
         }
 
@@ -83,16 +82,10 @@ class LiveVisionActivity : ComponentActivity() {
 
     private fun checkAndRequestPermissions() {
         val permission = Manifest.permission.CAMERA
-        // Use attribution context for XR hardware access tracking
-        val attributionContext = createAttributionContext("xr_projected")
-        val permissionStatus = ContextCompat.checkSelfPermission(attributionContext, permission)
+        val permissionStatus = ContextCompat.checkSelfPermission(this, permission)
 
         if (permissionStatus != PackageManager.PERMISSION_GRANTED) {
-            val params = ProjectedPermissionsRequestParams(
-                permissions = listOf(permission),
-                rationale = "Camera access is needed on your AI glasses to describe what you see."
-            )
-            projectedPermissionLauncher.launch(listOf(params))
+            permissionLauncher.launch(permission)
         }
     }
 }

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/LiveVisionActivity.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/LiveVisionActivity.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.xr.projected.ProjectedContext
 import androidx.xr.projected.ProjectedDeviceController
 import androidx.xr.projected.experimental.ExperimentalProjectedApi
 import androidx.xr.projected.permissions.ProjectedPermissionsRequestParams
@@ -69,31 +68,7 @@ class LiveVisionActivity : ComponentActivity() {
                         onNavigateToSettings = {
                             // Navigate to settings logic
                         },
-                        onBack = { finish() },
-                        onRequestGlassesPermission = {
-                            android.util.Log.d("LiveVisionActivity", "onRequestGlassesPermission triggered. Using device-targeted request.")
-                            try {
-                                val glassesContext = ProjectedContext.createProjectedDeviceContext(this@LiveVisionActivity)
-                                val deviceId = glassesContext.deviceId
-                                
-                                if (android.os.Build.VERSION.SDK_INT >= 35) {
-                                    requestPermissions(
-                                        arrayOf(Manifest.permission.CAMERA),
-                                        1002,
-                                        deviceId
-                                    )
-                                    android.util.Log.d("LiveVisionActivity", "Triggered activity.requestPermissions with deviceId: $deviceId")
-                                } else {
-                                    val params = ProjectedPermissionsRequestParams(
-                                        permissions = listOf(Manifest.permission.CAMERA),
-                                        rationale = "Camera access is needed on your AI glasses to describe what you see."
-                                    )
-                                    projectedPermissionLauncher.launch(listOf(params))
-                                }
-                            } catch (e: Exception) {
-                                android.util.Log.e("LiveVisionActivity", "Failed to trigger device-targeted permissions", e)
-                            }
-                        }
+                        onBack = { finish() }
                     )
                     
                     // The Glimmer UI for glasses is usually handled by a separate 

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
@@ -84,7 +84,6 @@ import kotlinx.coroutines.Dispatchers
 fun UnifiedVisionRoute(
     viewModel: VisionViewModel = hiltViewModel(),
     onNavigateToSettings: () -> Unit = {},
-    onRequestGlassesPermission: () -> Unit = {},
     onBack: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -103,12 +102,9 @@ fun UnifiedVisionRoute(
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 viewModel.onEvent(VisionUiEvent.CheckPermissions(context))
-                // Always try to initialize if glasses granted, to re-discover hardware
-                if (activity != null) {
-                    val glassesGranted = viewModel.cameraManager.checkGlassesPermission(activity)
-                    if (glassesGranted) {
-                        viewModel.cameraManager.initialize(activity)
-                    }
+                // Always try to initialize if camera permission is granted
+                if (activity != null && cameraPermissionState.status.isGranted) {
+                    viewModel.cameraManager.initialize(activity)
                 }
             }
         }
@@ -118,16 +114,10 @@ fun UnifiedVisionRoute(
         }
     }
 
-    // Initial sync
-    LaunchedEffect(cameraPermissionState.status.isGranted) {
-        viewModel.onEvent(VisionUiEvent.CheckPermissions(context))
-    }
-
     UnifiedVisionScreen(
         uiState = uiState,
         onEvent = viewModel::onEvent,
         onNavigateToSettings = onNavigateToSettings,
-        onRequestGlassesPermission = onRequestGlassesPermission,
         onBack = onBack,
         requestPhonePermission = { cameraPermissionState.launchPermissionRequest() }
     )
@@ -144,7 +134,6 @@ fun UnifiedVisionScreen(
     uiState: VisionUiState,
     onEvent: (VisionUiEvent) -> Unit,
     onNavigateToSettings: () -> Unit,
-    onRequestGlassesPermission: () -> Unit,
     onBack: () -> Unit,
     requestPhonePermission: () -> Unit,
     modifier: Modifier = Modifier
@@ -190,8 +179,7 @@ fun UnifiedVisionScreen(
         VisionRequirementGate(
             uiState = uiState,
             onNavigateToSettings = onNavigateToSettings,
-            onRequestPhonePermission = requestPhonePermission,
-            onRequestGlassesPermission = onRequestGlassesPermission
+            onRequestPhonePermission = requestPhonePermission
         ) {
             Column(
                 modifier = Modifier
@@ -224,13 +212,6 @@ fun UnifiedVisionScreen(
                             activeIcon = Icons.Default.Camera,
                             inactiveIcon = Icons.Default.CameraAlt,
                             statusOverride = if (uiState.isPermissionGranted) "ALLOWED" else "DENIED"
-                        )
-                        DiagnosticRow(
-                            label = "Glasses Camera Access",
-                            isActive = uiState.isGlassesPermissionGranted,
-                            activeIcon = Icons.Default.Camera,
-                            inactiveIcon = Icons.Default.CameraAlt,
-                            statusOverride = if (uiState.isGlassesPermissionGranted) "ALLOWED" else "DENIED"
                         )
                         DiagnosticRow(
                             label = "Camera Source",

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
@@ -91,7 +91,7 @@ fun UnifiedVisionRoute(
     val uiState by viewModel.uiState.collectAsState()
     val cameraPermissionState = rememberPermissionState(Manifest.permission.CAMERA)
     val context = LocalContext.current
-    val activity = context as? android.app.Activity
+    val activity = context as? androidx.activity.ComponentActivity
     val lifecycleOwner = LocalLifecycleOwner.current
 
     // Initial sync

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
@@ -1,6 +1,7 @@
 package com.zoewave.probase.features.glass.vision.ui
 
 import android.Manifest
+import android.util.Log
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.ExperimentalLensFacing
 import androidx.compose.foundation.Image
@@ -63,6 +64,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -100,10 +102,12 @@ fun UnifiedVisionRoute(
     // Refresh permission and camera status on Resume
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
+            Log.d("VisionUI", "UnifiedVisionRoute Lifecycle: $event")
             if (event == Lifecycle.Event.ON_RESUME) {
                 viewModel.onEvent(VisionUiEvent.CheckPermissions(context))
                 // Always try to initialize if camera permission is granted
                 if (activity != null && cameraPermissionState.status.isGranted) {
+                    Log.d("VisionUI", "Initializing camera from ON_RESUME")
                     viewModel.cameraManager.initialize(activity)
                 }
             }
@@ -207,7 +211,7 @@ fun UnifiedVisionScreen(
                             statusOverride = if (isConnected) "CONNECTED" else "DISCONNECTED"
                         )
                         DiagnosticRow(
-                            label = "Phone Camera Access",
+                            label = "Camera Access",
                             isActive = uiState.isPermissionGranted,
                             activeIcon = Icons.Default.Camera,
                             inactiveIcon = Icons.Default.CameraAlt,
@@ -215,7 +219,7 @@ fun UnifiedVisionScreen(
                         )
                         DiagnosticRow(
                             label = "Camera Source",
-                            isActive = uiState.cameraSource.contains("Glasses"),
+                            isActive = uiState.cameraSource.contains("Hardware"),
                             activeIcon = Icons.Default.CheckCircle,
                             inactiveIcon = Icons.Default.Error,
                             statusOverride = uiState.cameraSource,
@@ -337,6 +341,7 @@ fun UnifiedVisionScreen(
                 // --- CONTROLS SECTION ---
                 Button(
                     onClick = {
+                        Log.d("VisionUI", "CAPTURE_BUTTON_CLICKED (Phone UI)")
                         if (!uiState.isPermissionGranted) {
                             requestPhonePermission()
                         } else {
@@ -349,7 +354,7 @@ fun UnifiedVisionScreen(
                 ) {
                     Icon(Icons.Default.CameraAlt, contentDescription = null)
                     Spacer(Modifier.width(12.dp))
-                    Text("TRIGGER GLASSES CAMERA")
+                    Text("CAPTURE IMAGE")
                 }
                 
                 if (uiState.error != null) {
@@ -398,6 +403,27 @@ fun DiagnosticRow(
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.Bold,
             color = if (isActive) Color(0xFF4CAF50) else (if (isCritical) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant)
+        )
+    }
+}
+
+@ExperimentalLensFacing
+@ExperimentalCamera2Interop
+@Preview(showBackground = true)
+@Composable
+private fun UnifiedVisionScreenPreview() {
+    MaterialTheme {
+        UnifiedVisionScreen(
+            uiState = VisionUiState(
+                cameraSource = "Hardware Camera (Projected)",
+                isPermissionGranted = true,
+                isApiKeySet = true,
+                imageDescription = "A scenic view of a mountain path."
+            ),
+            onEvent = {},
+            onNavigateToSettings = {},
+            onBack = {},
+            requestPhonePermission = {}
         )
     }
 }

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionScreen.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionScreen.kt
@@ -1,6 +1,5 @@
 package com.zoewave.probase.features.glass.vision.ui
 
-import android.Manifest
 import android.app.Activity
 import android.util.Log
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
@@ -33,40 +32,26 @@ import androidx.xr.glimmer.Icon
 import androidx.xr.glimmer.IconButton
 import androidx.xr.glimmer.Text
 import androidx.xr.glimmer.TitleChip
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.isGranted
-import com.google.accompanist.permissions.rememberPermissionState
 
 /**
  * The entry point for the Vision screen.
+ *
+ * ARCHITECTURAL NOTE: This route runs on the Glasses.
+ * It must NOT request permissions or initialize the CameraManager.
+ * The host phone app handles the Context Bridge setup.
  */
 @ExperimentalLensFacing
 @ExperimentalCamera2Interop
-@OptIn(ExperimentalPermissionsApi::class, androidx.xr.projected.experimental.ExperimentalProjectedApi::class)
+@OptIn(androidx.xr.projected.experimental.ExperimentalProjectedApi::class)
 @Composable
 fun VisionRoute(
     viewModel: VisionViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val cameraPermissionState = rememberPermissionState(Manifest.permission.CAMERA)
-    val context = LocalContext.current
-    val activity = context as? androidx.activity.ComponentActivity
-
-    // Sync permission status with ViewModel
-    LaunchedEffect(cameraPermissionState.status.isGranted) {
-        val granted = cameraPermissionState.status.isGranted
-        Log.d("VisionUI", "GlassesRoute: Permission Status Updated = $granted")
-        viewModel.onEvent(VisionUiEvent.UpdatePermissionStatus(granted))
-        if (granted && activity != null) {
-            Log.d("VisionUI", "GlassesRoute: Initializing camera manager")
-            viewModel.cameraManager.initialize(activity)
-        }
-    }
 
     VisionScreen(
         uiState = uiState,
-        onEvent = viewModel::onEvent,
-        requestPhonePermission = { cameraPermissionState.launchPermissionRequest() }
+        onEvent = viewModel::onEvent
     )
 }
 
@@ -80,7 +65,6 @@ fun VisionRoute(
 fun VisionScreen(
     uiState: VisionUiState,
     onEvent: (VisionUiEvent) -> Unit,
-    requestPhonePermission: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -101,7 +85,7 @@ fun VisionScreen(
         Box(
             modifier = modifier
                 .fillMaxSize()
-                .background(Color.Black), // Transparent on glasses
+                .background(Color.Black), // Pure Black ensures total optical transparency
             contentAlignment = Alignment.BottomCenter
         ) {
             // DEBUG OVERLAY
@@ -152,15 +136,12 @@ fun VisionScreen(
                     )
                 }
 
-                // Capture Button (Alternative trigger)
+                // Capture Button
                 IconButton(
                     onClick = {
                         Log.d("VisionUI", "GLASSES_ICON_CLICKED (Glimmer UI)")
-                        if (uiState.isPermissionGranted) {
-                            onEvent(VisionUiEvent.TriggerCapture)
-                        } else {
-                            requestPhonePermission()
-                        }
+                        // We assume the phone already handled permissions. Just fire the capture!
+                        onEvent(VisionUiEvent.TriggerCapture)
                     }
                 ) {
                     Icon(

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionScreen.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionScreen.kt
@@ -32,8 +32,6 @@ import androidx.xr.glimmer.Icon
 import androidx.xr.glimmer.IconButton
 import androidx.xr.glimmer.Text
 import androidx.xr.glimmer.TitleChip
-import androidx.xr.projected.ProjectedDisplayController
-import androidx.xr.projected.ProjectedDisplayController.PresentationMode
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
@@ -57,8 +55,6 @@ fun VisionRoute(
     LaunchedEffect(cameraPermissionState.status.isGranted) {
         viewModel.onEvent(VisionUiEvent.UpdatePermissionStatus(cameraPermissionState.status.isGranted))
         if (cameraPermissionState.status.isGranted && activity != null) {
-            val glassesGranted = viewModel.cameraManager.checkGlassesPermission(activity)
-            viewModel.onEvent(VisionUiEvent.UpdateGlassesPermissionStatus(glassesGranted))
             viewModel.cameraManager.initialize(activity)
         }
     }

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionScreen.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionScreen.kt
@@ -50,7 +50,7 @@ fun VisionRoute(
     val uiState by viewModel.uiState.collectAsState()
     val cameraPermissionState = rememberPermissionState(Manifest.permission.CAMERA)
     val context = LocalContext.current
-    val activity = context as? Activity
+    val activity = context as? androidx.activity.ComponentActivity
 
     // Sync permission status with ViewModel
     LaunchedEffect(cameraPermissionState.status.isGranted) {

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionScreen.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionScreen.kt
@@ -2,6 +2,7 @@ package com.zoewave.probase.features.glass.vision.ui
 
 import android.Manifest
 import android.app.Activity
+import android.util.Log
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.ExperimentalLensFacing
 import androidx.compose.foundation.background
@@ -53,8 +54,11 @@ fun VisionRoute(
 
     // Sync permission status with ViewModel
     LaunchedEffect(cameraPermissionState.status.isGranted) {
-        viewModel.onEvent(VisionUiEvent.UpdatePermissionStatus(cameraPermissionState.status.isGranted))
-        if (cameraPermissionState.status.isGranted && activity != null) {
+        val granted = cameraPermissionState.status.isGranted
+        Log.d("VisionUI", "GlassesRoute: Permission Status Updated = $granted")
+        viewModel.onEvent(VisionUiEvent.UpdatePermissionStatus(granted))
+        if (granted && activity != null) {
+            Log.d("VisionUI", "GlassesRoute: Initializing camera manager")
             viewModel.cameraManager.initialize(activity)
         }
     }
@@ -151,6 +155,7 @@ fun VisionScreen(
                 // Capture Button (Alternative trigger)
                 IconButton(
                     onClick = {
+                        Log.d("VisionUI", "GLASSES_ICON_CLICKED (Glimmer UI)")
                         if (uiState.isPermissionGranted) {
                             onEvent(VisionUiEvent.TriggerCapture)
                         } else {

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
@@ -1,6 +1,7 @@
 package com.zoewave.probase.features.glass.vision.ui
 
 import android.graphics.Bitmap
+import android.util.Log
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.ExperimentalLensFacing
 import androidx.lifecycle.ViewModel
@@ -50,6 +51,7 @@ class VisionViewModel @Inject constructor(
     val cameraManager: SimpleGlassesCameraManager
 ) : ViewModel() {
 
+    private val instanceId = java.util.UUID.randomUUID().toString().take(4)
     private val _isApiKeySet = MutableStateFlow(false)
     private val _isPermissionGranted = MutableStateFlow(false)
     private val _error = MutableStateFlow<String?>(null)
@@ -91,25 +93,34 @@ class VisionViewModel @Inject constructor(
     }
 
     private fun checkInitialPermissions(context: android.content.Context) {
+        val contextName = context::class.java.simpleName
         val phoneGranted = androidx.core.content.ContextCompat.checkSelfPermission(
             context, android.Manifest.permission.CAMERA
         ) == android.content.pm.PackageManager.PERMISSION_GRANTED
         _isPermissionGranted.value = phoneGranted
-        cameraManager.addLog("Camera Permission Status: ${if (phoneGranted) "GRANTED" else "DENIED"}")
+        val msg = "Camera Permission Status: ${if (phoneGranted) "GRANTED" else "DENIED"} (Checked from $contextName)"
+        Log.d("VisionVM", "[$instanceId] $msg")
+        cameraManager.addLog("[$instanceId] $msg")
     }
 
     fun onEvent(event: VisionUiEvent) {
+        Log.d("VisionVM", "[$instanceId] onEvent: ${event::class.java.simpleName}")
         when (event) {
             is VisionUiEvent.CheckPermissions -> checkInitialPermissions(event.context)
             is VisionUiEvent.TriggerCapture -> triggerGlassesCapture()
-            is VisionUiEvent.UpdatePermissionStatus -> _isPermissionGranted.value = event.granted
+            is VisionUiEvent.UpdatePermissionStatus -> {
+                Log.d("VisionVM", "[$instanceId] Permission updated: ${event.granted}")
+                _isPermissionGranted.value = event.granted
+            }
         }
     }
 
     private fun observeBridgeCommands() {
         viewModelScope.launch {
             bridgeRepository.glassCommands.collect { cmd ->
+                Log.d("VisionVM", "[$instanceId] Command received from bridge: $cmd")
                 if (cmd == "CAPTURE_IMAGE") {
+                    Log.d("VisionVM", "[$instanceId] Dispatching takePicture to cameraManager")
                     cameraManager.takePicture()
                 }
             }
@@ -136,7 +147,8 @@ class VisionViewModel @Inject constructor(
 
     private fun triggerGlassesCapture() {
         viewModelScope.launch {
-            cameraManager.addLog("Sending Remote Command: CAPTURE_IMAGE...")
+            Log.d("VisionVM", "[$instanceId] Triggering capture. Sending command: CAPTURE_IMAGE")
+            cameraManager.addLog("[$instanceId] Sending Remote Command: CAPTURE_IMAGE...")
             bridgeRepository.sendGlassCommand("CAPTURE_IMAGE")
         }
     }

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
@@ -27,7 +27,6 @@ data class VisionUiState(
     val isApiKeySet: Boolean = false,
     val cameraSource: String = "Phone",
     val isPermissionGranted: Boolean = false,
-    val isGlassesPermissionGranted: Boolean = false,
     val capturedImage: Bitmap? = null,
     val discoveredCameras: List<Pair<String, String>> = emptyList(),
     val logs: List<String> = emptyList(),
@@ -38,8 +37,6 @@ sealed interface VisionUiEvent {
     data class CheckPermissions(val context: android.content.Context) : VisionUiEvent
     data object TriggerCapture : VisionUiEvent
     data class UpdatePermissionStatus(val granted: Boolean) : VisionUiEvent
-    data class UpdateGlassesPermissionStatus(val granted: Boolean) : VisionUiEvent
-    data object RequestGlassesPermission : VisionUiEvent
 }
 
 @ExperimentalLensFacing
@@ -55,7 +52,6 @@ class VisionViewModel @Inject constructor(
 
     private val _isApiKeySet = MutableStateFlow(false)
     private val _isPermissionGranted = MutableStateFlow(false)
-    private val _isGlassesPermissionGranted = MutableStateFlow(false)
     private val _error = MutableStateFlow<String?>(null)
 
     val uiState: StateFlow<VisionUiState> = combine(
@@ -65,7 +61,6 @@ class VisionViewModel @Inject constructor(
         _isApiKeySet,
         cameraManager.cameraSource,
         _isPermissionGranted,
-        _isGlassesPermissionGranted,
         repository.capturedImage,
         cameraManager.discoveredCameras,
         cameraManager.logs,
@@ -78,11 +73,10 @@ class VisionViewModel @Inject constructor(
             isApiKeySet = args[3] as Boolean,
             cameraSource = args[4] as String,
             isPermissionGranted = args[5] as Boolean,
-            isGlassesPermissionGranted = args[6] as Boolean,
-            capturedImage = args[7] as Bitmap?,
-            discoveredCameras = @Suppress("UNCHECKED_CAST") (args[8] as List<Pair<String, String>>),
-            logs = @Suppress("UNCHECKED_CAST") (args[9] as List<String>),
-            error = args[10] as String?
+            capturedImage = args[6] as Bitmap?,
+            discoveredCameras = @Suppress("UNCHECKED_CAST") (args[7] as List<Pair<String, String>>),
+            logs = @Suppress("UNCHECKED_CAST") (args[8] as List<String>),
+            error = args[9] as String?
         )
     }.stateIn(
         scope = viewModelScope,
@@ -101,19 +95,7 @@ class VisionViewModel @Inject constructor(
             context, android.Manifest.permission.CAMERA
         ) == android.content.pm.PackageManager.PERMISSION_GRANTED
         _isPermissionGranted.value = phoneGranted
-        cameraManager.addLog("Phone Camera: ${if (phoneGranted) "GRANTED" else "DENIED"}")
-        
-        try {
-            val glassesContext = androidx.xr.projected.ProjectedContext.createProjectedDeviceContext(context)
-            val glassesGranted = androidx.core.content.ContextCompat.checkSelfPermission(
-                glassesContext, android.Manifest.permission.CAMERA
-            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
-            _isGlassesPermissionGranted.value = glassesGranted
-            cameraManager.addLog("Glasses Camera: ${if (glassesGranted) "GRANTED" else "DENIED"}")
-        } catch (e: Exception) {
-            cameraManager.addLog("Glasses Permission Check Error: ${e.message}")
-            _isGlassesPermissionGranted.value = false
-        }
+        cameraManager.addLog("Camera Permission Status: ${if (phoneGranted) "GRANTED" else "DENIED"}")
     }
 
     fun onEvent(event: VisionUiEvent) {
@@ -121,12 +103,6 @@ class VisionViewModel @Inject constructor(
             is VisionUiEvent.CheckPermissions -> checkInitialPermissions(event.context)
             is VisionUiEvent.TriggerCapture -> triggerGlassesCapture()
             is VisionUiEvent.UpdatePermissionStatus -> _isPermissionGranted.value = event.granted
-            is VisionUiEvent.UpdateGlassesPermissionStatus -> _isGlassesPermissionGranted.value = event.granted
-            is VisionUiEvent.RequestGlassesPermission -> {
-                // This will be handled by the Route/Screen via a separate callback if needed, 
-                // but we can log the intent here.
-                cameraManager.addLog("Intent: Request Glasses Permission")
-            }
         }
     }
 

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/VisionViewModel.kt
@@ -10,7 +10,7 @@ import com.google.ai.client.generativeai.type.content
 import com.zoewave.probase.core.data.repository.AiConfigurationSettings
 import com.zoewave.probase.core.data.repository.GlassBridgeRepository
 import com.zoewave.probase.features.glass.vision.data.VisionRepository
-import com.zoewave.probase.features.glass.vision.ui.manager.GlassesCameraManager
+import com.zoewave.probase.features.glass.vision.ui.manager.SimpleGlassesCameraManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -50,7 +50,7 @@ class VisionViewModel @Inject constructor(
     private val settings: AiConfigurationSettings,
     private val repository: VisionRepository,
     private val bridgeRepository: GlassBridgeRepository,
-    val cameraManager: GlassesCameraManager
+    val cameraManager: SimpleGlassesCameraManager
 ) : ViewModel() {
 
     private val _isApiKeySet = MutableStateFlow(false)

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/components/VisionRequirementGate.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/components/VisionRequirementGate.kt
@@ -77,14 +77,14 @@ fun VisionRequirementGate(
             Spacer(Modifier.height(32.dp))
 
             RequirementCard(
-                title = "Phone Camera Access",
-                description = "Required to allow projected access.",
+                title = "Camera Access",
+                description = "Required to enable vision capabilities.",
                 isMet = isPhonePermissionOk,
                 icon = Icons.Default.CameraAlt,
-                buttonLabel = "GRANT PHONE ACCESS",
+                buttonLabel = "GRANT CAMERA ACCESS",
                 onButtonClick = {
                     if (!isPhonePermissionOk) {
-                        android.util.Log.d("VisionGate", "GRANT PHONE ACCESS clicked")
+                        android.util.Log.d("VisionGate", "GRANT CAMERA ACCESS clicked")
                         onRequestPhonePermission()
                     }
                 }

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/components/VisionRequirementGate.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/components/VisionRequirementGate.kt
@@ -40,14 +40,12 @@ fun VisionRequirementGate(
     uiState: VisionUiState,
     onNavigateToSettings: () -> Unit,
     onRequestPhonePermission: () -> Unit,
-    onRequestGlassesPermission: () -> Unit,
     content: @Composable () -> Unit
 ) {
     val isPhonePermissionOk = uiState.isPermissionGranted
-    val isGlassesPermissionOk = uiState.isGlassesPermissionGranted
     val isApiKeyOk = uiState.isApiKeySet
 
-    if (isPhonePermissionOk && isGlassesPermissionOk && isApiKeyOk) {
+    if (isPhonePermissionOk && isApiKeyOk) {
         content()
     } else {
         Column(
@@ -88,22 +86,6 @@ fun VisionRequirementGate(
                     if (!isPhonePermissionOk) {
                         android.util.Log.d("VisionGate", "GRANT PHONE ACCESS clicked")
                         onRequestPhonePermission()
-                    }
-                }
-            )
-
-            Spacer(Modifier.height(16.dp))
-
-            RequirementCard(
-                title = "Glasses Camera Access",
-                description = "Allow the app to use the glasses hardware.",
-                isMet = isGlassesPermissionOk,
-                icon = Icons.Default.CameraAlt,
-                buttonLabel = "GRANT GLASSES ACCESS",
-                onButtonClick = {
-                    if (!isGlassesPermissionOk) {
-                        android.util.Log.d("VisionGate", "GRANT GLASSES ACCESS clicked")
-                        onRequestGlassesPermission()
                     }
                 }
             )

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
@@ -59,24 +59,35 @@ class SimpleGlassesCameraManager @Inject constructor(
 
     fun initialize(activity: Activity) {
         scope.launch {
-            addLog("Initializing Glasses Camera (Simple Manager)...")
+            addLog("[INIT] Starting Initialization Sequence...")
+            Log.d(tag, "initialize() called with activity: ${activity::class.java.simpleName}")
             
             val projectedContext = try {
-                ProjectedContext.createProjectedDeviceContext(activity)
+                addLog("[INIT] Creating ProjectedContext...")
+                ProjectedContext.createProjectedDeviceContext(activity).also {
+                    Log.d(tag, "ProjectedContext created successfully")
+                }
             } catch (e: Exception) {
-                addLog("ERROR: Could not create ProjectedContext: ${e.message}")
+                val msg = "ERROR: Could not create context bridge: ${e.message}"
+                addLog(msg)
+                Log.e(tag, msg, e)
                 return@launch
             }
 
             try {
+                addLog("[INIT] Requesting ProcessCameraProvider...")
                 val cameraProvider = ProcessCameraProvider.awaitInstance(projectedContext)
+                addLog("[INIT] Provider acquired. Selecting DEFAULT_BACK_CAMERA...")
                 val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
 
                 if (!cameraProvider.hasCamera(cameraSelector)) {
-                    addLog("ERROR: Glasses camera (DEFAULT_BACK_CAMERA) not found.")
+                    val msg = "ERROR: Hardware camera not found on projected device."
+                    addLog(msg)
+                    Log.w(tag, msg)
                     return@launch
                 }
-
+                
+                addLog("[INIT] Camera found. Building ResolutionSelector (640x480)...")
                 // AI Glasses optimized resolution (640x480) to manage thermal/battery
                 val targetResolution = Size(640, 480)
                 val resolutionStrategy = ResolutionStrategy(
@@ -87,6 +98,7 @@ class SimpleGlassesCameraManager @Inject constructor(
                     .setResolutionStrategy(resolutionStrategy)
                     .build()
 
+                addLog("[INIT] Building ImageCapture use case...")
                 imageCapture = ImageCapture.Builder()
                     .setResolutionSelector(resolutionSelector)
                     .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
@@ -94,45 +106,74 @@ class SimpleGlassesCameraManager @Inject constructor(
 
                 withContext(Dispatchers.Main) {
                     try {
+                        addLog("[INIT] Requesting Main Thread binding...")
+                        Log.d(tag, "Main thread binding start. imageCapture is currently: ${if (imageCapture == null) "NULL" else "NOT NULL"}")
+                        
+                        addLog("[INIT] Unbinding previous use cases...")
                         cameraProvider.unbindAll()
+                        
+                        addLog("[INIT] Binding to lifecycle: ${activity::class.java.simpleName}...")
                         cameraProvider.bindToLifecycle(
                             activity as LifecycleOwner,
                             cameraSelector,
                             imageCapture
                         )
-                        _cameraSource.value = "AI Glasses (Projected)"
-                        addLog("SUCCESS: Camera bound to AI Glasses context at 640x480.")
+                        _cameraSource.value = "Hardware Camera (Projected)"
+                        addLog("SUCCESS: Camera bound and ready at 640x480.")
+                        Log.d(tag, "Camera initialization complete and bound to lifecycle. ImageCapture instance: $imageCapture")
                     } catch (e: Exception) {
-                        addLog("ERROR: Lifecycle binding failed: ${e.message}")
+                        val msg = "ERROR: Lifecycle binding failed: ${e.message}"
+                        addLog(msg)
+                        Log.e(tag, msg, e)
                     }
                 }
             } catch (e: Exception) {
-                addLog("ERROR: Camera initialization failed: ${e.message}")
+                val msg = "ERROR: Camera initialization failed: ${e.message}"
+                addLog(msg)
+                Log.e(tag, msg, e)
             }
         }
     }
 
     fun takePicture() {
+        Log.d(tag, "takePicture() called")
         val capture = imageCapture ?: run {
-            addLog("ERROR: ImageCapture not initialized")
+            val msg = "ERROR: Cannot capture - ImageCapture not initialized"
+            addLog(msg)
+            Log.e(tag, msg)
             return
         }
         
-        addLog("Taking picture from glasses...")
+        addLog("Capturing image from hardware...")
         repository.updateCapturing(true)
 
+        Log.d(tag, "Triggering takePicture on ImageCapture instance...")
         capture.takePicture(cameraExecutor, object : ImageCapture.OnImageCapturedCallback() {
             override fun onCaptureSuccess(image: ImageProxy) {
-                addLog("Capture Success!")
+                val width = image.width
+                val height = image.height
+                val format = image.format
+                Log.d(tag, "onCaptureSuccess: size=${width}x${height}, format=$format")
+                addLog("Capture Success! Processing ${width}x${height} frame...")
+                
                 val bitmap = image.toBitmap()
+                if (bitmap != null) {
+                    Log.d(tag, "Bitmap generated successfully: ${bitmap.width}x${bitmap.height}")
+                    repository.updateCapturedImage(bitmap)
+                    addLog("Image updated in repository.")
+                } else {
+                    Log.e(tag, "Failed to generate bitmap from ImageProxy")
+                    addLog("ERROR: Bitmap generation failed.")
+                }
+                
                 image.close()
-                repository.updateCapturedImage(bitmap)
                 repository.updateCapturing(false)
             }
 
             override fun onError(exception: ImageCaptureException) {
-                addLog("Capture Error: ${exception.message}")
-                Log.e(tag, "Capture failed", exception)
+                val msg = "Capture Error: ${exception.message} (Type: ${exception.imageCaptureError})"
+                addLog(msg)
+                Log.e(tag, msg, exception)
                 repository.updateCapturing(false)
             }
         })

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
@@ -2,7 +2,6 @@ package com.zoewave.probase.features.glass.vision.ui.manager
 
 import android.app.Activity
 import android.app.Application
-import android.content.pm.PackageManager
 import android.util.Log
 import android.util.Size
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
@@ -15,7 +14,6 @@ import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.lifecycle.awaitInstance
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.xr.projected.ProjectedContext
 import com.zoewave.probase.features.glass.vision.data.VisionRepository
@@ -58,19 +56,6 @@ class SimpleGlassesCameraManager @Inject constructor(
 
     private val _discoveredCameras = MutableStateFlow<List<Pair<String, String>>>(emptyList())
     val discoveredCameras: StateFlow<List<Pair<String, String>>> = _discoveredCameras.asStateFlow()
-
-    fun checkGlassesPermission(activity: Activity): Boolean {
-        return try {
-            val projectedContext = ProjectedContext.createProjectedDeviceContext(activity)
-            val status = ContextCompat.checkSelfPermission(projectedContext, android.Manifest.permission.CAMERA)
-            val granted = status == PackageManager.PERMISSION_GRANTED
-            addLog("Glasses permission check: ${if (granted) "GRANTED" else "DENIED"}")
-            granted
-        } catch (e: Exception) {
-            Log.e(tag, "Failed to check glasses permission", e)
-            false
-        }
-    }
 
     fun initialize(activity: Activity) {
         scope.launch {

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
@@ -1,9 +1,8 @@
 package com.zoewave.probase.features.glass.vision.ui.manager
 
-import android.app.Activity
-import android.app.Application
 import android.util.Log
 import android.util.Size
+import androidx.activity.ComponentActivity
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ExperimentalLensFacing
@@ -14,7 +13,6 @@ import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.lifecycle.awaitInstance
-import androidx.lifecycle.LifecycleOwner
 import androidx.xr.projected.ProjectedContext
 import com.zoewave.probase.features.glass.vision.data.VisionRepository
 import kotlinx.coroutines.CoroutineScope
@@ -25,7 +23,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import javax.inject.Inject
@@ -40,7 +37,6 @@ import javax.inject.Singleton
 @androidx.xr.projected.experimental.ExperimentalProjectedApi
 @Singleton
 class SimpleGlassesCameraManager @Inject constructor(
-    private val application: Application,
     private val repository: VisionRepository
 ) {
     private val tag = "SimpleGlassesCameraManager"
@@ -57,7 +53,7 @@ class SimpleGlassesCameraManager @Inject constructor(
     private val _discoveredCameras = MutableStateFlow<List<Pair<String, String>>>(emptyList())
     val discoveredCameras: StateFlow<List<Pair<String, String>>> = _discoveredCameras.asStateFlow()
 
-    fun initialize(activity: Activity) {
+    fun initialize(activity: ComponentActivity) {
         scope.launch {
             addLog("[INIT] Starting Initialization Sequence...")
             Log.d(tag, "initialize() called with activity: ${activity::class.java.simpleName}")
@@ -104,28 +100,26 @@ class SimpleGlassesCameraManager @Inject constructor(
                     .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
                     .build()
 
-                withContext(Dispatchers.Main) {
-                    try {
-                        addLog("[INIT] Requesting Main Thread binding...")
-                        Log.d(tag, "Main thread binding start. imageCapture is currently: ${if (imageCapture == null) "NULL" else "NOT NULL"}")
-                        
-                        addLog("[INIT] Unbinding previous use cases...")
-                        cameraProvider.unbindAll()
-                        
-                        addLog("[INIT] Binding to lifecycle: ${activity::class.java.simpleName}...")
-                        cameraProvider.bindToLifecycle(
-                            activity as LifecycleOwner,
-                            cameraSelector,
-                            imageCapture
-                        )
-                        _cameraSource.value = "Hardware Camera (Projected)"
-                        addLog("SUCCESS: Camera bound and ready at 640x480.")
-                        Log.d(tag, "Camera initialization complete and bound to lifecycle. ImageCapture instance: $imageCapture")
-                    } catch (e: Exception) {
-                        val msg = "ERROR: Lifecycle binding failed: ${e.message}"
-                        addLog(msg)
-                        Log.e(tag, msg, e)
-                    }
+                try {
+                    addLog("[INIT] Unbinding previous use cases...")
+                    cameraProvider.unbindAll()
+
+                    addLog("[INIT] Binding to lifecycle: ${activity::class.java.simpleName}...")
+                    cameraProvider.bindToLifecycle(
+                        activity,
+                        cameraSelector,
+                        imageCapture
+                    )
+                    _cameraSource.value = "Hardware Camera (Projected)"
+                    addLog("SUCCESS: Camera bound and ready at 640x480.")
+                    Log.d(
+                        tag,
+                        "Camera initialization complete and bound to lifecycle. ImageCapture instance: $imageCapture"
+                    )
+                } catch (e: Exception) {
+                    val msg = "ERROR: Lifecycle binding failed: ${e.message}"
+                    addLog(msg)
+                    Log.e(tag, msg, e)
                 }
             } catch (e: Exception) {
                 val msg = "ERROR: Camera initialization failed: ${e.message}"

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
@@ -1,0 +1,162 @@
+package com.zoewave.probase.features.glass.vision.ui.manager
+
+import android.app.Activity
+import android.app.Application
+import android.content.pm.PackageManager
+import android.util.Log
+import android.util.Size
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalLensFacing
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.lifecycle.awaitInstance
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import androidx.xr.projected.ProjectedContext
+import com.zoewave.probase.features.glass.vision.data.VisionRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * A simplified camera manager that strictly follows the Android XR SDK documentation
+ * for capturing images on projected devices (AI Glasses).
+ */
+@ExperimentalLensFacing
+@ExperimentalCamera2Interop
+@androidx.xr.projected.experimental.ExperimentalProjectedApi
+@Singleton
+class SimpleGlassesCameraManager @Inject constructor(
+    private val application: Application,
+    private val repository: VisionRepository
+) {
+    private val tag = "SimpleGlassesCameraManager"
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+    private var imageCapture: ImageCapture? = null
+
+    private val _cameraSource = MutableStateFlow("Phone (Initializing...)")
+    val cameraSource: StateFlow<String> = _cameraSource.asStateFlow()
+
+    private val _logs = MutableStateFlow<List<String>>(emptyList())
+    val logs: StateFlow<List<String>> = _logs.asStateFlow()
+
+    private val _discoveredCameras = MutableStateFlow<List<Pair<String, String>>>(emptyList())
+    val discoveredCameras: StateFlow<List<Pair<String, String>>> = _discoveredCameras.asStateFlow()
+
+    fun checkGlassesPermission(activity: Activity): Boolean {
+        return try {
+            val projectedContext = ProjectedContext.createProjectedDeviceContext(activity)
+            val status = ContextCompat.checkSelfPermission(projectedContext, android.Manifest.permission.CAMERA)
+            val granted = status == PackageManager.PERMISSION_GRANTED
+            addLog("Glasses permission check: ${if (granted) "GRANTED" else "DENIED"}")
+            granted
+        } catch (e: Exception) {
+            Log.e(tag, "Failed to check glasses permission", e)
+            false
+        }
+    }
+
+    fun initialize(activity: Activity) {
+        scope.launch {
+            addLog("Initializing Glasses Camera (Simple Manager)...")
+            
+            val projectedContext = try {
+                ProjectedContext.createProjectedDeviceContext(activity)
+            } catch (e: Exception) {
+                addLog("ERROR: Could not create ProjectedContext: ${e.message}")
+                return@launch
+            }
+
+            try {
+                val cameraProvider = ProcessCameraProvider.awaitInstance(projectedContext)
+                val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
+                if (!cameraProvider.hasCamera(cameraSelector)) {
+                    addLog("ERROR: Glasses camera (DEFAULT_BACK_CAMERA) not found.")
+                    return@launch
+                }
+
+                // AI Glasses optimized resolution (640x480) to manage thermal/battery
+                val targetResolution = Size(640, 480)
+                val resolutionStrategy = ResolutionStrategy(
+                    targetResolution,
+                    ResolutionStrategy.FALLBACK_RULE_CLOSEST_LOWER
+                )
+                val resolutionSelector = ResolutionSelector.Builder()
+                    .setResolutionStrategy(resolutionStrategy)
+                    .build()
+
+                imageCapture = ImageCapture.Builder()
+                    .setResolutionSelector(resolutionSelector)
+                    .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
+                    .build()
+
+                withContext(Dispatchers.Main) {
+                    try {
+                        cameraProvider.unbindAll()
+                        cameraProvider.bindToLifecycle(
+                            activity as LifecycleOwner,
+                            cameraSelector,
+                            imageCapture
+                        )
+                        _cameraSource.value = "AI Glasses (Projected)"
+                        addLog("SUCCESS: Camera bound to AI Glasses context at 640x480.")
+                    } catch (e: Exception) {
+                        addLog("ERROR: Lifecycle binding failed: ${e.message}")
+                    }
+                }
+            } catch (e: Exception) {
+                addLog("ERROR: Camera initialization failed: ${e.message}")
+            }
+        }
+    }
+
+    fun takePicture() {
+        val capture = imageCapture ?: run {
+            addLog("ERROR: ImageCapture not initialized")
+            return
+        }
+        
+        addLog("Taking picture from glasses...")
+        repository.updateCapturing(true)
+
+        capture.takePicture(cameraExecutor, object : ImageCapture.OnImageCapturedCallback() {
+            override fun onCaptureSuccess(image: ImageProxy) {
+                addLog("Capture Success!")
+                val bitmap = image.toBitmap()
+                image.close()
+                repository.updateCapturedImage(bitmap)
+                repository.updateCapturing(false)
+            }
+
+            override fun onError(exception: ImageCaptureException) {
+                addLog("Capture Error: ${exception.message}")
+                Log.e(tag, "Capture failed", exception)
+                repository.updateCapturing(false)
+            }
+        })
+    }
+
+    fun addLog(message: String) {
+        val timestamp = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.getDefault()).format(java.util.Date())
+        val formattedMsg = "[$timestamp] $message"
+        Log.d(tag, formattedMsg)
+        _logs.update { it + formattedMsg }
+    }
+}


### PR DESCRIPTION
Walkthrough: Stateless Glasses UI Refactoring
I have refactored the glasses-side Vision UI to correctly align with the Jetpack XR Split-Computing architecture. The glasses-side UI is now "dumb" regarding hardware setup, delegating all permission and initialization responsibilities to the host phone app.
Changes Made
VisionScreen.kt
•
Eliminated Permission Redundancy: Removed Accompanist's rememberPermissionState and associated logic. Because the glasses do not have their own package permission manager, checking permissions on the glasses side was incorrectly returning false and blocking interactions.
•
Fixed Initialization race: Removed the cameraManager.initialize() call from VisionRoute. Since this route runs inside GlassesMainActivity (already a projected context), attempting to re-initialize the context bridge would have caused an IllegalStateException.
•
Stateless Interaction: Simplified the capture IconButton. It now assumes the host phone has already handled permissions and established the bridge, and directly fires the capture event.
•
Total Transparency: Ensured the root background uses Color.Black to guarantee absolute optical transparency on the glasses' additive display.
Verification Results
Build Success
•
Ran ./gradlew :features:xr:glass:vision:assembleDebug and confirmed a successful build.
Architectural Correctness
•
Clear Responsibility:
◦
Host (Phone): Responsible for android.permission.CAMERA requests and cameraManager.initialize(activity).
◦
Glasses: Responsible purely for rendering AI results and triggering capture signals back to the ViewModel.
•
Improved Performance: Removing redundant lifecycle monitoring and state tracking reduces the overhead of the Glimmer UI.
Important
This refactor resolves the issue where the camera capture was "doing nothing" because it was stalled on an impossible permission check within the glasses context.