### PR TITLE
feat: add professional scan entry points to cosmetics feature

### DIFF
--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
@@ -100,6 +100,11 @@ fun StitchProductBuilder(
                     }) {
                         Icon(Icons.Default.Close, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_close_desc))
                     }
+                },
+                actions = {
+                    IconButton(onClick = { navTo(KoColorRoute.BoxCapture()) }) {
+                        Icon(Icons.Default.AutoAwesome, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title), tint = Color(0xFF8B5E3C))
+                    }
                 }
             )
         },
@@ -201,6 +206,44 @@ fun StitchProductBuilder(
                 HorizontalDivider(modifier = Modifier.weight(1f), color = Color.LightGray.copy(alpha = 0.3f))
                 Text(stringResource(R.string.applications_kocolor_features_cosmetics_or_divider), modifier = Modifier.padding(horizontal = 16.dp), style = MaterialTheme.typography.labelSmall, color = Color.Gray)
                 HorizontalDivider(modifier = Modifier.weight(1f), color = Color.LightGray.copy(alpha = 0.3f))
+            }
+
+            Surface(
+                onClick = { navTo(KoColorRoute.BoxCapture()) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                color = Color(0xFF8B5E3C).copy(alpha = 0.05f),
+                border = BorderStroke(1.dp, Color(0xFF8B5E3C).copy(alpha = 0.2f))
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Surface(
+                        shape = CircleShape,
+                        color = Color(0xFF8B5E3C),
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(Icons.Default.AutoAwesome, null, tint = Color.White, modifier = Modifier.size(20.dp))
+                        }
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFF8B5E3C)
+                        )
+                        Text(
+                            text = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Gray
+                        )
+                    }
+                    Icon(Icons.Default.ChevronRight, null, tint = Color.LightGray)
+                }
             }
 
             Text(stringResource(R.string.applications_kocolor_features_cosmetics_manual_entry), style = MaterialTheme.typography.headlineSmall, fontFamily = FontFamily.Serif, fontWeight = FontWeight.Bold)

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
@@ -79,7 +79,7 @@ fun VanityLandingScreen(
                 },
                 actions = {
                     IconButton(onClick = { navTo(KoColorRoute.BoxCapture()) }) { 
-                        Icon(Icons.Default.AutoAwesome, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_add_item)) 
+                        Icon(Icons.Default.AutoAwesome, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title)) 
                     }
                     IconButton(onClick = { navTo(KoColorRoute.InventoryManagement) }) { Icon(Icons.Default.Inventory2, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_inventory_title)) }
                     IconButton(onClick = { navTo(KoColorRoute.ColorSearch) }) { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_filter)) }

--- a/applications/kocolor/features/cosmetics/src/main/res/values/strings.xml
+++ b/applications/kocolor/features/cosmetics/src/main/res/values/strings.xml
@@ -238,4 +238,7 @@
     <string name="applications_kocolor_features_cosmetics_avg_cost_use">AVG COST/USE</string>
     <string name="applications_kocolor_features_cosmetics_info_icon">i</string>
     <string name="applications_kocolor_features_cosmetics_expiring_desc">The following items in your collection are approaching their estimated expiry dates. Consider prioritizing their usage or planning for replacements.</string>
+
+    <string name="applications_kocolor_features_cosmetics_scan_box_title">Professional Scan</string>
+    <string name="applications_kocolor_features_cosmetics_scan_box_desc">7-angle AI analysis for boxes</string>
 </resources>


### PR DESCRIPTION
This commit introduces entry points for the "Professional Scan" AI analysis feature within the cosmetics product builder and vanity screens.

- **`StitchProductBuilder.kt`**:
    - Added a scan `IconButton` to the `TopAppBar` actions.
    - Implemented a prominent "Professional Scan" CTA card with a title and description, providing a visual alternative to manual entry.
- **`VanityLandingScreen.kt`**: Updated the scan icon's `contentDescription` to align with the new "Professional Scan" string for better accessibility and consistency.
- **`strings.xml`**: Defined new string resources for the "Professional Scan" feature title and description.