### PR TITLE
Ko color scan

### DIFF
--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -105,6 +105,11 @@ fun koColorNavEntryProvider(
         is KoColorRoute.BoxCapture -> NavEntry(route) {
             val viewModel: BoxCaptureViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+            androidx.compose.runtime.LaunchedEffect(route.mode) {
+                viewModel.setMode(route.mode)
+            }
+
             BoxCaptureUiRoute(
                 uiState = state,
                 onEvent = { event ->

--- a/applications/kocolor/features/boxcapture/build.gradle.kts
+++ b/applications/kocolor/features/boxcapture/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
     // ML Kit
     implementation(libs.mlkit.text.recognition)
+    implementation(libs.gms.play.services.code.scanner)
     implementation(libs.kotlinx.coroutines.play.services)
 
     // CameraX

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
@@ -36,6 +36,9 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import coil.compose.AsyncImage
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
@@ -53,6 +56,7 @@ import java.util.Locale
 
 sealed class BoxCaptureEvent {
     data class Capture(val uri: String) : BoxCaptureEvent()
+    data class BarcodeScanned(val code: String) : BoxCaptureEvent()
     data object Retry : BoxCaptureEvent()
     data object Dismiss : BoxCaptureEvent()
     data class Success(val item: CosmeticItem) : BoxCaptureEvent()
@@ -211,6 +215,25 @@ private fun CameraView(
     val lifecycleOwner = LocalLifecycleOwner.current
     val coroutineScope = rememberCoroutineScope()
 
+    val scanner = remember(context) {
+        val options = GmsBarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_ALL_FORMATS)
+            .build()
+        GmsBarcodeScanning.getClient(context, options)
+    }
+
+    LaunchedEffect(uiState.step) {
+        if (uiState.step == CaptureStep.BARCODE) {
+            scanner.startScan()
+                .addOnSuccessListener { barcode ->
+                    barcode.rawValue?.let { onEvent(BoxCaptureEvent.BarcodeScanned(it)) }
+                }
+                .addOnFailureListener {
+                    // Fail silently or let user retry
+                }
+        }
+    }
+
     val previewUseCase = remember { Preview.Builder().build() }
     val imageCaptureUseCase = remember { ImageCapture.Builder().build() }
     var surfaceRequest by remember { mutableStateOf<SurfaceRequest?>(null) }
@@ -296,31 +319,54 @@ private fun CameraView(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            Button(
-                onClick = {
-                    coroutineScope.launch(Dispatchers.IO) {
-                        val file = createFile(context)
-                        val options = ImageCapture.OutputFileOptions.Builder(file).build()
-                        imageCaptureUseCase.takePicture(
-                            options,
-                            ContextCompat.getMainExecutor(context),
-                            object : ImageCapture.OnImageSavedCallback {
-                                override fun onImageSaved(output: ImageCapture.OutputFileResults) {
-                                    onEvent(BoxCaptureEvent.Capture(Uri.fromFile(file).toString()))
-                                }
-                                override fun onError(exception: ImageCaptureException) {
-                                    Log.e("BoxCapture", "Capture failed", exception)
-                                }
+            if (uiState.step == CaptureStep.BARCODE) {
+                Button(
+                    onClick = {
+                        scanner.startScan()
+                            .addOnSuccessListener { barcode ->
+                                barcode.rawValue?.let { onEvent(BoxCaptureEvent.BarcodeScanned(it)) }
                             }
-                        )
-                    }
-                },
-                modifier = Modifier.size(80.dp),
-                shape = CircleShape,
-                colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                contentPadding = PaddingValues(0.dp)
-            ) {
-                Icon(Icons.Default.CameraAlt, contentDescription = "Capture", tint = Color.Black, modifier = Modifier.size(32.dp))
+                    },
+                    modifier = Modifier.fillMaxWidth().height(56.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF22d3ee))
+                ) {
+                    Icon(Icons.Default.AutoAwesome, null, tint = Color.Black)
+                    Spacer(Modifier.width(8.dp))
+                    Text("START BARCODE SCAN", color = Color.Black, fontWeight = FontWeight.Bold)
+                }
+            } else {
+                Button(
+                    onClick = {
+                        coroutineScope.launch(Dispatchers.IO) {
+                            val file = createFile(context)
+                            val options = ImageCapture.OutputFileOptions.Builder(file).build()
+                            imageCaptureUseCase.takePicture(
+                                options,
+                                ContextCompat.getMainExecutor(context),
+                                object : ImageCapture.OnImageSavedCallback {
+                                    override fun onImageSaved(output: ImageCapture.OutputFileResults) {
+                                        onEvent(BoxCaptureEvent.Capture(Uri.fromFile(file).toString()))
+                                    }
+
+                                    override fun onError(exception: ImageCaptureException) {
+                                        Log.e("BoxCapture", "Capture failed", exception)
+                                    }
+                                }
+                            )
+                        }
+                    },
+                    modifier = Modifier.size(80.dp),
+                    shape = CircleShape,
+                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
+                    contentPadding = PaddingValues(0.dp)
+                ) {
+                    Icon(
+                        Icons.Default.CameraAlt,
+                        contentDescription = "Capture",
+                        tint = Color.Black,
+                        modifier = Modifier.size(32.dp)
+                    )
+                }
             }
             
             Spacer(modifier = Modifier.height(12.dp))

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -59,10 +59,12 @@ class BoxCaptureViewModel @Inject constructor(
     val uiState: StateFlow<BoxCaptureUiState> = _uiState.asStateFlow()
 
     private val capturedUris = mutableListOf<String>()
+    private var scannedBarcode: String? = null
 
     fun onEvent(event: BoxCaptureEvent) {
         when (event) {
             is BoxCaptureEvent.Capture -> onPhotoCaptured(event.uri)
+            is BoxCaptureEvent.BarcodeScanned -> onBarcodeScanned(event.code)
             BoxCaptureEvent.Retry -> reset()
             BoxCaptureEvent.Dismiss -> { /* Handled in UI layer typically */ }
             is BoxCaptureEvent.Success -> { /* Handled in UI layer typically */ }
@@ -71,6 +73,7 @@ class BoxCaptureViewModel @Inject constructor(
 
     fun setMode(modeString: String) {
         val mode = try { CaptureMode.valueOf(modeString) } catch (e: Exception) { CaptureMode.BOX }
+        reset() // Ensure clean state when switching modes
         _uiState.value = BoxCaptureUiState.Idle(capturedUris.toList(), CaptureStep.getStepsForMode(mode).first(), mode)
     }
 
@@ -83,6 +86,12 @@ class BoxCaptureViewModel @Inject constructor(
         } else {
             analyzePhotos(mode)
         }
+    }
+
+    private fun onBarcodeScanned(code: String) {
+        scannedBarcode = code
+        val mode = (uiState.value as? BoxCaptureUiState.Idle)?.mode ?: CaptureMode.QUICK_BOX
+        analyzePhotos(mode)
     }
 
     private fun getNextStep(mode: CaptureMode): CaptureStep? {
@@ -119,9 +128,15 @@ class BoxCaptureViewModel @Inject constructor(
 
                 val prompt = content {
                     bitmaps.forEach { image(it) }
-                    val target = if (mode == CaptureMode.BOX) "product box from all sides" else "product container (front and back)"
+                    val target = when (mode) {
+                        CaptureMode.BOX -> "product box from all sides"
+                        CaptureMode.QUICK_BOX -> "essential product box angles"
+                        CaptureMode.PRODUCT -> "product container (front and back)"
+                    }
+                    val barcodeContext = if (!scannedBarcode.isNullOrBlank()) "The scanned barcode is: $scannedBarcode." else ""
+                    
                     text("""
-                        Analyze these photos of a $target.
+                        Analyze these photos of a $target. $barcodeContext
                         Extract all available information, especially the ingredients list if visible on the back, and return it in the following JSON format:
                         {
                             "name": "Product Name",
@@ -142,6 +157,7 @@ class BoxCaptureViewModel @Inject constructor(
                         }
                         Return ONLY the JSON block. If a field is unknown, omit it or use null. Be precise.
                         If this is a product container without a box, prioritize the brand and product name from the front, and ingredients/volume from the back.
+                        If a barcode is provided, use it to cross-reference your internal knowledge for higher accuracy.
                     """.trimIndent())
                 }
 

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
@@ -24,7 +24,7 @@ sealed interface BoxCaptureUiState {
 }
 
 enum class CaptureMode {
-    BOX, PRODUCT
+    BOX, PRODUCT, QUICK_BOX
 }
 
 enum class CaptureStep(val boxLabel: String, val productLabel: String = boxLabel) {
@@ -34,7 +34,8 @@ enum class CaptureStep(val boxLabel: String, val productLabel: String = boxLabel
     RIGHT("Right Side"),
     TOP("Top Side"),
     BOTTOM("Bottom Side"),
-    INGREDIENTS("Ingredients List");
+    INGREDIENTS("Ingredients List"),
+    BARCODE("Barcode Scan");
 
     fun getLabel(mode: CaptureMode): String {
         return if (mode == CaptureMode.PRODUCT) productLabel else boxLabel
@@ -43,8 +44,9 @@ enum class CaptureStep(val boxLabel: String, val productLabel: String = boxLabel
     companion object {
         fun getStepsForMode(mode: CaptureMode): List<CaptureStep> {
             return when (mode) {
-                CaptureMode.BOX -> entries
+                CaptureMode.BOX -> listOf(FRONT, BACK, LEFT, RIGHT, TOP, BOTTOM, INGREDIENTS)
                 CaptureMode.PRODUCT -> listOf(FRONT, BACK)
+                CaptureMode.QUICK_BOX -> listOf(FRONT, BACK, INGREDIENTS, BARCODE)
             }
         }
     }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
@@ -208,8 +208,48 @@ fun StitchProductBuilder(
                 HorizontalDivider(modifier = Modifier.weight(1f), color = Color.LightGray.copy(alpha = 0.3f))
             }
 
+            // Quick Scan Card
             Surface(
-                onClick = { navTo(KoColorRoute.BoxCapture()) },
+                onClick = { navTo(KoColorRoute.BoxCapture(mode = "QUICK_BOX")) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                color = Color(0xFF22d3ee).copy(alpha = 0.05f),
+                border = BorderStroke(1.dp, Color(0xFF22d3ee).copy(alpha = 0.2f))
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Surface(
+                        shape = CircleShape,
+                        color = Color(0xFF22d3ee),
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(Icons.Default.AutoAwesome, null, tint = Color.Black, modifier = Modifier.size(20.dp))
+                        }
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.applications_kocolor_features_cosmetics_quick_scan_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFF0891b2)
+                        )
+                        Text(
+                            text = stringResource(R.string.applications_kocolor_features_cosmetics_quick_scan_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Gray
+                        )
+                    }
+                    Icon(Icons.Default.ChevronRight, null, tint = Color.LightGray)
+                }
+            }
+
+            // Professional Scan Card (Full)
+            Surface(
+                onClick = { navTo(KoColorRoute.BoxCapture(mode = "BOX")) },
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(16.dp),
                 color = Color(0xFF8B5E3C).copy(alpha = 0.05f),

--- a/applications/kocolor/features/cosmetics/src/main/res/values/strings.xml
+++ b/applications/kocolor/features/cosmetics/src/main/res/values/strings.xml
@@ -240,5 +240,8 @@
     <string name="applications_kocolor_features_cosmetics_expiring_desc">The following items in your collection are approaching their estimated expiry dates. Consider prioritizing their usage or planning for replacements.</string>
 
     <string name="applications_kocolor_features_cosmetics_scan_box_title">Professional Scan</string>
-    <string name="applications_kocolor_features_cosmetics_scan_box_desc">7-angle AI analysis for boxes</string>
+    <string name="applications_kocolor_features_cosmetics_scan_box_desc">7-angle full package analysis</string>
+
+    <string name="applications_kocolor_features_cosmetics_quick_scan_title">Quick Professional Scan</string>
+    <string name="applications_kocolor_features_cosmetics_quick_scan_desc">3 pics + barcode (Fastest AI)</string>
 </resources>


### PR DESCRIPTION
Walkthrough - Quick Professional Scan (3 Pics + Barcode)
I have implemented a new "Quick Professional Scan" mode for the KoColor app. This mode streamlines the product capture process by requiring only 3 photos and a barcode scan, while keeping the full 7-step scan available for more detailed analysis.
Changes
[applications:kocolor:features:boxcapture]
[MODIFY] BoxCaptureUiState.kt
•
Added CaptureMode.QUICK_BOX.
•
Added CaptureStep.BARCODE.
•
Configured the quick mode sequence: FRONT -> BACK -> INGREDIENTS -> BARCODE.
[MODIFY] BoxCaptureViewModel.kt
•
Added state to track the scanned barcode.
•
Updated analyzePhotos to include the barcode in the Gemini prompt. This allows Gemini to use the barcode to fetch precise product data from its internal knowledge base, augmenting the visual data from the 3 photos.
[MODIFY] BoxCaptureScreen.kt
•
Integrated the GMS (Google Play Services) Barcode Scanner.
•
When the flow reaches the BARCODE step, the app now automatically launches the system barcode scanner overlay.
•
Added a "START BARCODE SCAN" button as a manual trigger for the final step.
[applications:kocolor:features:cosmetics]
[MODIFY] StitchProductBuilder.kt
•
Added a new, prominent Quick Professional Scan card (Cyan themed) above the full scan option.
•
This allows users to choose between the fast 3-pic flow and the comprehensive 7-pic flow depending on their needs.
Verification Results
Automated Tests
•
Successfully compiled the project: ./gradlew :applications:kocolor:apps:mobile:assembleDebug.
UI Layout
The "Add to Collection" screen now offers two distinct AI paths:
1.
Quick Professional Scan: 3 pics + barcode (Fastest AI).
2.
Professional Scan: 7-angle full package analysis.
Tip
Use the Quick Scan for standard products with visible barcodes. The barcode provides a high-confidence anchor for Gemini to identify the product even with fewer photos.
render_diffs(file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt) render_diffs(file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt)