### PR TITLE
feat: introduce product review flow and local OCR for ingredients

### DIFF
--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/data/LocalProductAnalyzer.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/data/LocalProductAnalyzer.kt
@@ -18,17 +18,21 @@ class LocalProductAnalyzer @Inject constructor() {
         val allText = mutableListOf<String>()
 
         for (bitmap in bitmaps) {
-            val image = InputImage.fromBitmap(bitmap, 0)
-            try {
-                val result = recognizer.process(image).await()
-                allText.add(result.text)
-            } catch (e: Exception) {
-                // Skip failed images
-            }
+            allText.add(extractText(bitmap))
         }
 
         val combinedText = allText.joinToString("\n")
         return heuristicGuess(combinedText)
+    }
+
+    suspend fun extractText(bitmap: Bitmap): String {
+        val image = InputImage.fromBitmap(bitmap, 0)
+        return try {
+            val result = recognizer.process(image).await()
+            result.text
+        } catch (e: Exception) {
+            ""
+        }
     }
 
     private fun heuristicGuess(text: String): CosmeticItem {

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
@@ -11,12 +11,15 @@ import androidx.camera.core.Preview
 import androidx.camera.core.SurfaceRequest
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.lifecycle.awaitInstance
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CameraAlt
@@ -57,6 +60,8 @@ import java.util.Locale
 sealed class BoxCaptureEvent {
     data class Capture(val uri: String) : BoxCaptureEvent()
     data class BarcodeScanned(val code: String) : BoxCaptureEvent()
+    data class UpdateDraft(val item: CosmeticItem) : BoxCaptureEvent()
+    data object ConfirmSave : BoxCaptureEvent()
     data object Retry : BoxCaptureEvent()
     data object Dismiss : BoxCaptureEvent()
     data class Success(val item: CosmeticItem) : BoxCaptureEvent()
@@ -189,6 +194,12 @@ internal fun BoxCaptureScreen(
                         uiState = ErrorViewUiState(uiState.message),
                         onEvent = { onEvent(BoxCaptureEvent.Retry) },
                         navTo = {}
+                    )
+                }
+                is BoxCaptureUiState.Reviewing -> {
+                    ReviewView(
+                        item = uiState.item,
+                        onEvent = onEvent
                     )
                 }
                 is BoxCaptureUiState.Success -> {
@@ -377,6 +388,117 @@ private fun CameraView(
 }
 
 data class AnalysisViewUiState(val progress: String)
+
+@Composable
+private fun ReviewView(
+    item: CosmeticItem,
+    onEvent: (BoxCaptureEvent) -> Unit
+) {
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF0f172a))
+            .verticalScroll(scrollState)
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        Text(
+            "REVIEW PRODUCT",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = Color.White
+        )
+
+        // Front Image
+        Surface(
+            modifier = Modifier
+                .size(200.dp)
+                .clip(RoundedCornerShape(16.dp)),
+            color = Color.White.copy(alpha = 0.05f),
+            border = BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+        ) {
+            AsyncImage(
+                model = item.imageUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        }
+
+        ReviewTextField(
+            label = "Product Name",
+            value = item.name,
+            onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(name = it))) }
+        )
+
+        ReviewTextField(
+            label = "Brand",
+            value = item.brand,
+            onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(brand = it))) }
+        )
+
+        ReviewTextField(
+            label = "Barcode / Batch Code",
+            value = item.batchCode ?: "",
+            onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(batchCode = it))) }
+        )
+
+        ReviewTextField(
+            label = "Ingredients (Auto-Extracted)",
+            value = item.instructions ?: "", // Instructions used for ingredients text
+            onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(instructions = it))) },
+            singleLine = false,
+            minLines = 5
+        )
+
+        Spacer(Modifier.height(20.dp))
+
+        Button(
+            onClick = { onEvent(BoxCaptureEvent.ConfirmSave) },
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF22d3ee))
+        ) {
+            Text("CONFIRM & SAVE", color = Color.Black, fontWeight = FontWeight.Bold)
+        }
+        
+        TextButton(onClick = { onEvent(BoxCaptureEvent.Dismiss) }) {
+            Text("Discard", color = Color.White.copy(alpha = 0.6f))
+        }
+
+        Spacer(Modifier.height(40.dp))
+    }
+}
+
+@Composable
+private fun ReviewTextField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    singleLine: Boolean = true,
+    minLines: Int = 1
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = Color(0xFF22d3ee), fontWeight = FontWeight.Bold)
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            singleLine = singleLine,
+            minLines = minLines,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedTextColor = Color.White,
+                unfocusedTextColor = Color.White,
+                focusedBorderColor = Color(0xFF22d3ee),
+                unfocusedBorderColor = Color.White.copy(alpha = 0.2f),
+                cursorColor = Color(0xFF22d3ee)
+            )
+        )
+    }
+}
 
 @Composable
 private fun AnalysisView(

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -71,9 +71,23 @@ class BoxCaptureViewModel @Inject constructor(
         when (event) {
             is BoxCaptureEvent.Capture -> onPhotoCaptured(event.uri)
             is BoxCaptureEvent.BarcodeScanned -> onBarcodeScanned(event.code)
+            is BoxCaptureEvent.UpdateDraft -> onUpdateDraft(event.item)
+            BoxCaptureEvent.ConfirmSave -> onConfirmSave()
             BoxCaptureEvent.Retry -> reset()
             BoxCaptureEvent.Dismiss -> { /* Handled in UI layer typically */ }
             is BoxCaptureEvent.Success -> { /* Handled in UI layer typically */ }
+        }
+    }
+
+    private fun onUpdateDraft(item: CosmeticItem) {
+        _uiState.value = BoxCaptureUiState.Reviewing(item)
+    }
+
+    private fun onConfirmSave() {
+        val item = (uiState.value as? BoxCaptureUiState.Reviewing)?.item ?: return
+        viewModelScope.launch {
+            repository.saveCosmeticItem(item)
+            _uiState.value = BoxCaptureUiState.Success(item)
         }
     }
 
@@ -181,9 +195,26 @@ class BoxCaptureViewModel @Inject constructor(
                 
                 if (jsonText != null) {
                     Log.d(TAG, "Received response from Gemini: $jsonText")
-                    val item = parseJsonToCosmeticItem(jsonText)
-                    repository.saveCosmeticItem(item)
-                    _uiState.value = BoxCaptureUiState.Success(item)
+                    var item = parseJsonToCosmeticItem(jsonText)
+                    
+                    // Pre-fill Front Image and Barcode
+                    item = item.copy(
+                        imageUrl = capturedUris.firstOrNull(),
+                        batchCode = scannedBarcode ?: item.batchCode
+                    )
+
+                    // Local OCR for Ingredients if in Quick Mode
+                    if (mode == CaptureMode.QUICK_BOX && capturedUris.size >= 3) {
+                        val ingredientsBitmap = loadBitmapFromUri(Uri.parse(capturedUris[2]))
+                        if (ingredientsBitmap != null) {
+                            val localIngredients = localAnalyzer.extractText(ingredientsBitmap)
+                            if (localIngredients.isNotBlank()) {
+                                item = item.copy(instructions = localIngredients) // Instructions used for ingredients in model
+                            }
+                        }
+                    }
+
+                    _uiState.value = BoxCaptureUiState.Reviewing(item)
                 } else {
                     Log.e(TAG, "Gemini returned null text in response.")
                     _uiState.value = BoxCaptureUiState.Error("Failed to extract data from images.")

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
@@ -14,6 +14,10 @@ sealed interface BoxCaptureUiState {
         val progress: String = "Initializing AI..."
     ) : BoxCaptureUiState
 
+    data class Reviewing(
+        val item: CosmeticItem
+    ) : BoxCaptureUiState
+
     data class Success(
         val item: CosmeticItem
     ) : BoxCaptureUiState


### PR DESCRIPTION
This commit adds a manual review step to the box capture process, allowing users to verify and edit AI-extracted product details before saving. It also enhances the analysis pipeline by incorporating local OCR for ingredient extraction.

- **Review Flow**:
    - Added `Reviewing` state to `BoxCaptureUiState`.
    - Implemented `ReviewView` and `ReviewTextField` in `BoxCaptureScreen` to provide a form-based interface for editing product name, brand, barcode, and ingredients.
    - Added `UpdateDraft` and `ConfirmSave` events to handle user edits and final persistence.

- **Analysis Enhancements**:
    - Refactored `LocalProductAnalyzer` to expose a standalone `extractText` function for specific bitmap processing.
    - Updated `BoxCaptureViewModel` to transition to the review state instead of saving immediately after AI analysis.
    - Implemented local OCR fallback for ingredients in `QUICK_BOX` mode, utilizing the `LocalProductAnalyzer` to extract text from secondary images.
    - Improved data mapping by pre-filling image URLs and scanned barcodes into the draft item.

- **UI/UX**:
    - Added scrolling support and styled form fields to the review screen for better accessibility on smaller displays.
    - Integrated `Confirm & Save` and `Discard` actions to the capture lifecycle.