### PR TITLE
feat: return database ID after saving cosmetic items

### DIFF
--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/CosmeticInventoryRepository.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/CosmeticInventoryRepository.kt
@@ -6,6 +6,6 @@ import kotlinx.coroutines.flow.Flow
 interface CosmeticInventoryRepository {
     fun getAllCosmetics(): Flow<List<CosmeticItem>>
     suspend fun fetchProductByBarcode(barcode: String): Result<CosmeticItem>
-    suspend fun saveCosmeticItem(item: CosmeticItem)
+    suspend fun saveCosmeticItem(item: CosmeticItem): Long
     suspend fun deleteCosmeticItem(id: Long)
 }

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/CosmeticDao.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/CosmeticDao.kt
@@ -27,7 +27,7 @@ interface CosmeticDao {
     fun getCosmeticById(id: Long): Flow<CosmeticItemEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertCosmetic(item: CosmeticItemEntity)
+    suspend fun insertCosmetic(item: CosmeticItemEntity): Long
 
     @Update
     suspend fun updateCosmetic(item: CosmeticItemEntity)

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -98,8 +98,8 @@ class BoxCaptureViewModel @Inject constructor(
     private fun onConfirmSave() {
         val item = (uiState.value as? BoxCaptureUiState.Reviewing)?.item ?: return
         viewModelScope.launch {
-            repository.saveCosmeticItem(item)
-            _uiState.value = BoxCaptureUiState.Success(item)
+            val savedId = repository.saveCosmeticItem(item)
+            _uiState.value = BoxCaptureUiState.Success(item.copy(id = savedId))
         }
     }
 

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/CosmeticInventoryRepositoryImpl.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/CosmeticInventoryRepositoryImpl.kt
@@ -28,11 +28,12 @@ class CosmeticInventoryRepositoryImpl @Inject constructor(
         return obfRepository.fetchProductByBarcode(barcode)
     }
 
-    override suspend fun saveCosmeticItem(item: CosmeticItem) {
-        if (item.id == 0L) {
+    override suspend fun saveCosmeticItem(item: CosmeticItem): Long {
+        return if (item.id == 0L) {
             cosmeticDao.insertCosmetic(item.toEntity())
         } else {
             cosmeticDao.updateCosmetic(item.toEntity())
+            item.id
         }
     }
 


### PR DESCRIPTION
This commit updates the data layer to return the unique identifier of a cosmetic item when it is persisted. This ensures that callers, such as ViewModels, have access to the auto-generated ID immediately after an insertion.

- **Repository and DAO**:
    - Updated `CosmeticInventoryRepository` and `CosmeticDao` interfaces to return a `Long` value from save and insert operations.
    - Modified `CosmeticInventoryRepositoryImpl` to return the new row ID from `insertCosmetic` or the existing ID during an update.
- **ViewModel Update**:
    - Updated `BoxCaptureViewModel` to capture the returned ID when saving an item, ensuring the `BoxCaptureUiState.Success` state contains the item with its correct database identifier.