### PR TITLE
Kocolor scan

### DIFF
--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -23,8 +23,6 @@ import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticCategoryCoverSc
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticCategoryCoverUiState
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticDetailScreen
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticDetailUiState
-import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticEditScreen
-import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticEditUiState
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticsEvent
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticsScreen
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticsViewModel
@@ -414,8 +412,13 @@ fun koColorNavEntryProvider(
         is KoColorRoute.CosmeticEdit -> NavEntry(route) {
             val viewModel: CosmeticsViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
-            CosmeticEditScreen(
-                uiState = CosmeticEditUiState(route.itemId, state.draftItem),
+            
+            androidx.compose.runtime.LaunchedEffect(route.itemId) {
+                viewModel.onEvent(CosmeticsEvent.InitializeEdit(route.itemId))
+            }
+
+            StitchProductBuilder(
+                uiState = state,
                 onEvent = viewModel::onEvent,
                 navTo = onNavigateTo
             )

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
@@ -1,26 +1,58 @@
 package com.zoewave.probase.kocolor.features.cosmetics.ui
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.*
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Colorize
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Opacity
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -29,13 +61,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.model.ritual.MacroCategory
+import com.zoewave.probase.core.model.ritual.MicroCategory
 import com.zoewave.probase.features.graphics.colorpicker.ui.ColorPickerDialog
 import com.zoewave.probase.features.graphics.colorpicker.util.isColorDark
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.features.graphics.colorpicker.util.toHex
 import com.zoewave.probase.kocolor.features.cosmetics.R
-import com.zoewave.probase.kocolor.features.cosmetics.ui.components.*
-import com.zoewave.probase.core.model.ritual.*
+import com.zoewave.probase.kocolor.features.cosmetics.ui.components.CategoryIconItem
+import com.zoewave.probase.kocolor.features.cosmetics.ui.components.CategoryIconUiState
 import com.zoewave.probase.kocolor.model.KoColorRoute
 
 @Preview(showBackground = true)
@@ -146,48 +180,6 @@ fun StitchProductBuilder(
                 }
             }
 
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(stringResource(R.string.applications_kocolor_features_cosmetics_barcode_label), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black, letterSpacing = 1.sp)
-                OutlinedTextField(
-                    value = draft.batchCode ?: "",
-                    onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(batchCode = it))) },
-                    placeholder = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_enter_barcode_manually)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    trailingIcon = {
-                        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(end = 4.dp)) {
-                            when {
-                                uiState.isAnalyzing -> {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(20.dp),
-                                        strokeWidth = 2.dp,
-                                        color = Color(0xFF2196F3) 
-                                    )
-                                }
-                                uiState.lastScanFailed -> {
-                                    Icon(Icons.Default.Error, null, tint = Color.Red, modifier = Modifier.size(20.dp))
-                                }
-                                !draft.batchCode.isNullOrBlank() -> {
-                                    Icon(Icons.Default.CheckCircle, null, tint = Color(0xFF4CAF50), modifier = Modifier.size(20.dp))
-                                }
-                                else -> {
-                                    Icon(Icons.Default.QrCode, null, tint = Color.Gray, modifier = Modifier.size(20.dp))
-                                }
-                            }
-
-                            IconButton(onClick = { navTo(KoColorRoute.BarcodeScanner) }) {
-                                Icon(Icons.Default.QrCodeScanner, null, tint = Color(0xFF8B5E3C))
-                            }
-                        }
-                    },
-                    isError = uiState.lastScanFailed,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        unfocusedContainerColor = Color.White,
-                        focusedContainerColor = Color.White
-                    )
-                )
-            }
-            
             if (uiState.lastScanFailed) {
                 AlertDialog(
                     onDismissRequest = { onEvent(CosmeticsEvent.ResetScanState) },
@@ -202,87 +194,122 @@ fun StitchProductBuilder(
                 )
             }
 
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                HorizontalDivider(modifier = Modifier.weight(1f), color = Color.LightGray.copy(alpha = 0.3f))
-                Text(stringResource(R.string.applications_kocolor_features_cosmetics_or_divider), modifier = Modifier.padding(horizontal = 16.dp), style = MaterialTheme.typography.labelSmall, color = Color.Gray)
-                HorizontalDivider(modifier = Modifier.weight(1f), color = Color.LightGray.copy(alpha = 0.3f))
-            }
-
-            // Quick Scan Card
-            Surface(
-                onClick = { navTo(KoColorRoute.BoxCapture(mode = "QUICK_BOX")) },
+            Row(
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(16.dp),
-                color = Color(0xFF22d3ee).copy(alpha = 0.05f),
-                border = BorderStroke(1.dp, Color(0xFF22d3ee).copy(alpha = 0.2f))
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Row(
-                    modifier = Modifier.padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                // Barcode Scan
+                Surface(
+                    onClick = { navTo(KoColorRoute.BarcodeScanner) },
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(16.dp),
+                    color = Color(0xFF6B7280).copy(alpha = 0.05f),
+                    border = BorderStroke(1.dp, Color(0xFF6B7280).copy(alpha = 0.2f))
                 ) {
-                    Surface(
-                        shape = CircleShape,
-                        color = Color(0xFF22d3ee),
-                        modifier = Modifier.size(40.dp)
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(Icons.Default.AutoAwesome, null, tint = Color.Black, modifier = Modifier.size(20.dp))
+                        Surface(
+                            shape = CircleShape,
+                            color = Color(0xFF6B7280),
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(Icons.Default.QrCodeScanner, null, tint = Color.White, modifier = Modifier.size(16.dp))
+                            }
+                        }
+                        Column {
+                            Text(
+                                text = stringResource(R.string.applications_kocolor_features_cosmetics_barcode_scan_title),
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.Bold,
+                                color = Color(0xFF374151)
+                            )
+                            Text(
+                                text = "Scan UPC",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.Gray,
+                                lineHeight = 12.sp
+                            )
                         }
                     }
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(R.string.applications_kocolor_features_cosmetics_quick_scan_title),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = Color(0xFF0891b2)
-                        )
-                        Text(
-                            text = stringResource(R.string.applications_kocolor_features_cosmetics_quick_scan_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = Color.Gray
-                        )
-                    }
-                    Icon(Icons.Default.ChevronRight, null, tint = Color.LightGray)
                 }
-            }
 
-            // Professional Scan Card (Full)
-            Surface(
-                onClick = { navTo(KoColorRoute.BoxCapture(mode = "BOX")) },
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(16.dp),
-                color = Color(0xFF8B5E3C).copy(alpha = 0.05f),
-                border = BorderStroke(1.dp, Color(0xFF8B5E3C).copy(alpha = 0.2f))
-            ) {
-                Row(
-                    modifier = Modifier.padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                // Pro Scan
+                Surface(
+                    onClick = { navTo(KoColorRoute.BoxCapture(mode = "BOX")) },
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(16.dp),
+                    color = Color(0xFF8B5E3C).copy(alpha = 0.05f),
+                    border = BorderStroke(1.dp, Color(0xFF8B5E3C).copy(alpha = 0.2f))
                 ) {
-                    Surface(
-                        shape = CircleShape,
-                        color = Color(0xFF8B5E3C),
-                        modifier = Modifier.size(40.dp)
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(Icons.Default.AutoAwesome, null, tint = Color.White, modifier = Modifier.size(20.dp))
+                        Surface(
+                            shape = CircleShape,
+                            color = Color(0xFF8B5E3C),
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(Icons.Default.AutoAwesome, null, tint = Color.White, modifier = Modifier.size(16.dp))
+                            }
+                        }
+                        Column {
+                            Text(
+                                text = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title),
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.Bold,
+                                color = Color(0xFF8B5E3C)
+                            )
+                            Text(
+                                text = "7-angle AI",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.Gray,
+                                lineHeight = 12.sp
+                            )
                         }
                     }
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = Color(0xFF8B5E3C)
-                        )
-                        Text(
-                            text = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = Color.Gray
-                        )
+                }
+
+                // Quick Scan
+                Surface(
+                    onClick = { navTo(KoColorRoute.BoxCapture(mode = "QUICK_BOX")) },
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(16.dp),
+                    color = Color(0xFF22d3ee).copy(alpha = 0.05f),
+                    border = BorderStroke(1.dp, Color(0xFF22d3ee).copy(alpha = 0.2f))
+                ) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Surface(
+                            shape = CircleShape,
+                            color = Color(0xFF22d3ee),
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(Icons.Default.AutoAwesome, null, tint = Color.Black, modifier = Modifier.size(16.dp))
+                            }
+                        }
+                        Column {
+                            Text(
+                                text = stringResource(R.string.applications_kocolor_features_cosmetics_quick_scan_title),
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.Bold,
+                                color = Color(0xFF0891b2)
+                            )
+                            Text(
+                                text = "3-pic AI",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.Gray,
+                                lineHeight = 12.sp
+                            )
+                        }
                     }
-                    Icon(Icons.Default.ChevronRight, null, tint = Color.LightGray)
                 }
             }
 

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
@@ -2,53 +2,17 @@ package com.zoewave.probase.kocolor.features.cosmetics.ui
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AutoAwesome
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Colorize
-import androidx.compose.material.icons.filled.Face
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.Opacity
-import androidx.compose.material.icons.filled.PhotoCamera
-import androidx.compose.material.icons.filled.QrCodeScanner
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -61,15 +25,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import com.zoewave.probase.core.model.ritual.MacroCategory
-import com.zoewave.probase.core.model.ritual.MicroCategory
+import com.zoewave.probase.core.model.ritual.*
 import com.zoewave.probase.features.graphics.colorpicker.ui.ColorPickerDialog
 import com.zoewave.probase.features.graphics.colorpicker.util.isColorDark
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.features.graphics.colorpicker.util.toHex
 import com.zoewave.probase.kocolor.features.cosmetics.R
-import com.zoewave.probase.kocolor.features.cosmetics.ui.components.CategoryIconItem
-import com.zoewave.probase.kocolor.features.cosmetics.ui.components.CategoryIconUiState
+import com.zoewave.probase.kocolor.features.cosmetics.ui.components.AtelierExpandableSection
 import com.zoewave.probase.kocolor.model.KoColorRoute
 
 @Preview(showBackground = true)
@@ -94,11 +56,54 @@ fun StitchProductBuilder(
 ) {
     val draft = uiState.draftItem
     val scrollState = rememberScrollState()
+    val atelierBrown = Color(0xFF8B5E3C)
+    val isEditMode = draft.id != 0L
+
     var showColorPicker by remember { mutableStateOf(false) }
+    var showDatePickerTarget by remember { mutableStateOf<String?>(null) }
+    var showMacroMenu by remember { mutableStateOf(false) }
+    var showMicroMenu by remember { mutableStateOf(false) }
+    var showFormulationMenu by remember { mutableStateOf(false) }
+    var showChemistryMenu by remember { mutableStateOf(false) }
+    var showFinishMenu by remember { mutableStateOf(false) }
+    var showCoverageMenu by remember { mutableStateOf(false) }
+
+    val expandedSections = remember { 
+        mutableStateMapOf<String, Boolean>().apply {
+            put("Core", true)
+            put("Taxonomy", false)
+            put("Safety", false)
+            put("Analysis", false)
+            put("Sustainability", false)
+            put("Economics", false)
+            put("Lifecycle", false)
+        }
+    }
 
     BackHandler {
         onEvent(CosmeticsEvent.CancelDiscovery)
         navTo(KoColorRoute.Back)
+    }
+
+    if (showDatePickerTarget != null) {
+        val initialDate = when(showDatePickerTarget) {
+            "OPENED" -> draft.openedDate
+            "EXPIRY" -> draft.expiryDate
+            else -> null
+        }
+        AtelierDatePicker(
+            initialDate = initialDate ?: System.currentTimeMillis(),
+            onDateSelected = { date ->
+                val updated = when(showDatePickerTarget) {
+                    "OPENED" -> draft.copy(openedDate = date, isOpened = true)
+                    "EXPIRY" -> draft.copy(expiryDate = date)
+                    else -> draft
+                }
+                onEvent(CosmeticsEvent.UpdateDraft(updated))
+                showDatePickerTarget = null
+            },
+            onDismiss = { showDatePickerTarget = null }
+        )
     }
 
     if (showColorPicker) {
@@ -114,7 +119,7 @@ fun StitchProductBuilder(
         )
     }
 
-    if (uiState.isScanSuccessful) {
+    if (!isEditMode && uiState.isScanSuccessful) {
         ValidateItemScreen(
             uiState = uiState,
             onEvent = onEvent,
@@ -126,7 +131,16 @@ fun StitchProductBuilder(
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_add_to_collection), style = MaterialTheme.typography.titleLarge, fontFamily = FontFamily.Serif, color = Color(0xFF8B5E3C)) },
+                title = { 
+                    Text(
+                        if (isEditMode) stringResource(R.string.applications_kocolor_features_cosmetics_edit_screen_title) 
+                        else stringResource(R.string.applications_kocolor_features_cosmetics_add_to_collection), 
+                        style = MaterialTheme.typography.titleLarge, 
+                        fontFamily = FontFamily.Serif, 
+                        color = atelierBrown,
+                        fontWeight = FontWeight.Bold
+                    ) 
+                },
                 navigationIcon = {
                     IconButton(onClick = { 
                         onEvent(CosmeticsEvent.CancelDiscovery)
@@ -136,8 +150,17 @@ fun StitchProductBuilder(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { navTo(KoColorRoute.BoxCapture()) }) {
-                        Icon(Icons.Default.AutoAwesome, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title), tint = Color(0xFF8B5E3C))
+                    if (isEditMode) {
+                        IconButton(onClick = {
+                            onEvent(CosmeticsEvent.UpdateItem(draft))
+                            navTo(KoColorRoute.Back)
+                        }) {
+                            Icon(Icons.Default.Save, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_save_desc), tint = atelierBrown)
+                        }
+                    } else {
+                        IconButton(onClick = { navTo(KoColorRoute.BoxCapture()) }) {
+                            Icon(Icons.Default.AutoAwesome, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title), tint = atelierBrown)
+                        }
                     }
                 }
             )
@@ -149,307 +172,462 @@ fun StitchProductBuilder(
                 .padding(padding)
                 .fillMaxSize()
                 .verticalScroll(scrollState)
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+                .background(Color.White)
         ) {
+            // Hero Image
             Surface(
                 modifier = Modifier
+                    .padding(24.dp)
                     .fillMaxWidth()
-                    .height(240.dp)
+                    .aspectRatio(1.5f)
                     .clickable { navTo(KoColorRoute.Camera("inventory_item")) },
-                shape = RoundedCornerShape(24.dp),
-                color = Color(0xFFF9F6F0),
-                border = BorderStroke(1.dp, color = Color.LightGray.copy(alpha = 0.5f))
+                shape = RoundedCornerShape(12.dp),
+                color = Color(0xFFFBF8F5),
+                border = BorderStroke(1.dp, Color(0xFFF0F0F0))
             ) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     if (draft.imageUrl != null) {
                         AsyncImage(
                             model = draft.imageUrl,
                             contentDescription = null,
-                            modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(24.dp)),
-                            contentScale = ContentScale.Crop
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Fit
                         )
                     } else {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Icon(Icons.Default.PhotoCamera, contentDescription = null, modifier = Modifier.size(48.dp), tint = Color(0xFF8B5E3C))
-                            Spacer(Modifier.height(12.dp))
-                            Text(stringResource(R.string.applications_kocolor_features_cosmetics_add_product_image), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Black, color = Color.Black)
-                            Text(stringResource(R.string.applications_kocolor_features_cosmetics_tap_to_upload), style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+                            Icon(Icons.Default.PhotoCamera, contentDescription = null, modifier = Modifier.size(40.dp), tint = atelierBrown.copy(alpha = 0.5f))
+                            Spacer(Modifier.height(8.dp))
+                            Text(stringResource(R.string.applications_kocolor_features_cosmetics_add_product_image), style = MaterialTheme.typography.labelSmall, color = Color.Gray)
                         }
                     }
                 }
             }
 
-            if (uiState.lastScanFailed) {
-                AlertDialog(
-                    onDismissRequest = { onEvent(CosmeticsEvent.ResetScanState) },
-                    confirmButton = {
-                        TextButton(onClick = { onEvent(CosmeticsEvent.ResetScanState) }) {
-                            Text(stringResource(R.string.applications_kocolor_features_cosmetics_ok), fontWeight = FontWeight.Bold)
-                        }
-                    },
-                    title = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_product_not_found_title)) },
-                    text = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_product_not_found_message)) },
-                    shape = RoundedCornerShape(24.dp)
-                )
-            }
-
+            // Capture Row
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.padding(horizontal = 24.dp).fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                // Barcode Scan
-                Surface(
+                CaptureButton(
+                    title = stringResource(R.string.applications_kocolor_features_cosmetics_barcode_scan_title),
+                    subtitle = "Scan UPC",
+                    icon = Icons.Default.QrCodeScanner,
+                    color = Color(0xFF6B7280),
                     onClick = { navTo(KoColorRoute.BarcodeScanner) },
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(16.dp),
-                    color = Color(0xFF6B7280).copy(alpha = 0.05f),
-                    border = BorderStroke(1.dp, Color(0xFF6B7280).copy(alpha = 0.2f))
-                ) {
-                    Column(
-                        modifier = Modifier.padding(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Surface(
-                            shape = CircleShape,
-                            color = Color(0xFF6B7280),
-                            modifier = Modifier.size(32.dp)
-                        ) {
-                            Box(contentAlignment = Alignment.Center) {
-                                Icon(Icons.Default.QrCodeScanner, null, tint = Color.White, modifier = Modifier.size(16.dp))
-                            }
-                        }
-                        Column {
-                            Text(
-                                text = stringResource(R.string.applications_kocolor_features_cosmetics_barcode_scan_title),
-                                style = MaterialTheme.typography.labelLarge,
-                                fontWeight = FontWeight.Bold,
-                                color = Color(0xFF374151)
-                            )
-                            Text(
-                                text = "Scan UPC",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = Color.Gray,
-                                lineHeight = 12.sp
-                            )
-                        }
-                    }
-                }
-
-                // Pro Scan
-                Surface(
+                    modifier = Modifier.weight(1f)
+                )
+                CaptureButton(
+                    title = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title),
+                    subtitle = "7-angle AI",
+                    icon = Icons.Default.AutoAwesome,
+                    color = atelierBrown,
                     onClick = { navTo(KoColorRoute.BoxCapture(mode = "BOX")) },
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(16.dp),
-                    color = Color(0xFF8B5E3C).copy(alpha = 0.05f),
-                    border = BorderStroke(1.dp, Color(0xFF8B5E3C).copy(alpha = 0.2f))
-                ) {
-                    Column(
-                        modifier = Modifier.padding(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Surface(
-                            shape = CircleShape,
-                            color = Color(0xFF8B5E3C),
-                            modifier = Modifier.size(32.dp)
-                        ) {
-                            Box(contentAlignment = Alignment.Center) {
-                                Icon(Icons.Default.AutoAwesome, null, tint = Color.White, modifier = Modifier.size(16.dp))
-                            }
-                        }
-                        Column {
-                            Text(
-                                text = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title),
-                                style = MaterialTheme.typography.labelLarge,
-                                fontWeight = FontWeight.Bold,
-                                color = Color(0xFF8B5E3C)
-                            )
-                            Text(
-                                text = "7-angle AI",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = Color.Gray,
-                                lineHeight = 12.sp
-                            )
-                        }
-                    }
-                }
-
-                // Quick Scan
-                Surface(
+                    modifier = Modifier.weight(1f)
+                )
+                CaptureButton(
+                    title = stringResource(R.string.applications_kocolor_features_cosmetics_quick_scan_title),
+                    subtitle = "3-pic AI",
+                    icon = Icons.Default.AutoAwesome,
+                    color = Color(0xFF22d3ee),
                     onClick = { navTo(KoColorRoute.BoxCapture(mode = "QUICK_BOX")) },
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(16.dp),
-                    color = Color(0xFF22d3ee).copy(alpha = 0.05f),
-                    border = BorderStroke(1.dp, Color(0xFF22d3ee).copy(alpha = 0.2f))
-                ) {
-                    Column(
-                        modifier = Modifier.padding(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Surface(
-                            shape = CircleShape,
-                            color = Color(0xFF22d3ee),
-                            modifier = Modifier.size(32.dp)
-                        ) {
-                            Box(contentAlignment = Alignment.Center) {
-                                Icon(Icons.Default.AutoAwesome, null, tint = Color.Black, modifier = Modifier.size(16.dp))
-                            }
-                        }
-                        Column {
-                            Text(
-                                text = stringResource(R.string.applications_kocolor_features_cosmetics_quick_scan_title),
-                                style = MaterialTheme.typography.labelLarge,
-                                fontWeight = FontWeight.Bold,
-                                color = Color(0xFF0891b2)
-                            )
-                            Text(
-                                text = "3-pic AI",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = Color.Gray,
-                                lineHeight = 12.sp
-                            )
-                        }
-                    }
-                }
-            }
-
-            Text(stringResource(R.string.applications_kocolor_features_cosmetics_manual_entry), style = MaterialTheme.typography.headlineSmall, fontFamily = FontFamily.Serif, fontWeight = FontWeight.Bold)
-
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(stringResource(R.string.applications_kocolor_features_cosmetics_category_label), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black)
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    val categories = listOf(
-                        Triple(MacroCategory.COMPLEXION, Icons.Default.Face, stringResource(R.string.applications_kocolor_features_cosmetics_category_section)),
-                        Triple(MacroCategory.PREP, Icons.Default.Opacity, "Skincare"), 
-                        Triple(MacroCategory.EYES, Icons.Default.Visibility, "Eyes"),
-                        Triple(MacroCategory.LIPS, Icons.Default.Favorite, "Lips")
-                    )
-                    categories.forEach { (cat, icon, label) ->
-                        val isSelected = draft.macroCategory == cat
-                        CategoryIconItem(
-                            uiState = CategoryIconUiState(
-                                icon = icon,
-                                label = label,
-                                isSelected = isSelected
-                            ),
-                            modifier = Modifier.weight(1f),
-                            onEvent = { 
-                                onEvent(CosmeticsEvent.UpdateDraft(draft.copy(
-                                    macroCategory = cat,
-                                    microCategory = MicroCategory.entries.first { it.macro == cat }
-                                )))
-                            },
-                            navTo = {}
-                        )
-                    }
-                }
-            }
-
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(stringResource(R.string.applications_kocolor_features_cosmetics_subcategory_label), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black)
-                var showSubMenu by remember { mutableStateOf(false) }
-                Box {
-                    OutlinedTextField(
-                        value = draft.microCategory.displayName,
-                        onValueChange = {},
-                        readOnly = true,
-                        modifier = Modifier.fillMaxWidth().clickable { showSubMenu = true },
-                        shape = RoundedCornerShape(12.dp),
-                        trailingIcon = { Icon(Icons.Default.KeyboardArrowDown, null) },
-                        enabled = false,
-                        colors = OutlinedTextFieldDefaults.colors(
-                            disabledBorderColor = MaterialTheme.colorScheme.outline,
-                            disabledTextColor = MaterialTheme.colorScheme.onSurface,
-                            disabledContainerColor = Color.White
-                        )
-                    )
-                    DropdownMenu(expanded = showSubMenu, onDismissRequest = { showSubMenu = false }) {
-                        MicroCategory.entries.filter { it.macro == draft.macroCategory }.forEach { micro ->
-                            DropdownMenuItem(text = { Text(micro.displayName) }, onClick = {
-                                onEvent(CosmeticsEvent.UpdateDraft(draft.copy(microCategory = micro)))
-                                showSubMenu = false
-                            })
-                        }
-                    }
-                }
-            }
-
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(stringResource(R.string.applications_kocolor_features_cosmetics_brand_name_label), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black)
-                OutlinedTextField(
-                    value = draft.brand,
-                    onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(brand = it))) },
-                    placeholder = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_brand_placeholder)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = OutlinedTextFieldDefaults.colors(
-                        unfocusedContainerColor = Color.White,
-                        focusedContainerColor = Color.White
-                    )
+                    modifier = Modifier.weight(1f)
                 )
             }
 
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(stringResource(R.string.applications_kocolor_features_cosmetics_product_name_label), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black)
-                OutlinedTextField(
-                    value = draft.name,
-                    onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(name = it))) },
-                    placeholder = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_product_placeholder)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = OutlinedTextFieldDefaults.colors(
-                        unfocusedContainerColor = Color.White,
-                        focusedContainerColor = Color.White
-                    )
-                )
-            }
+            Spacer(Modifier.height(24.dp))
 
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(stringResource(R.string.applications_kocolor_features_cosmetics_shade_name_label), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black)
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    OutlinedTextField(
-                        value = draft.shadeName ?: "",
-                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(shadeName = it))) },
-                        placeholder = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_shade_placeholder)) },
-                        modifier = Modifier.weight(1f),
-                        shape = RoundedCornerShape(12.dp),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            unfocusedContainerColor = Color.White,
-                            focusedContainerColor = Color.White
-                        )
-                    )
-                    Surface(
-                        onClick = { showColorPicker = true },
-                        shape = CircleShape,
-                        color = draft.colorHex?.let { parseColor(it) } ?: Color.White,
-                        border = BorderStroke(1.dp, Color.LightGray),
-                        modifier = Modifier.size(44.dp)
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            val tintColor = draft.colorHex?.let { hex ->
-                                if (isColorDark(parseColor(hex))) Color.White else Color.Black
-                            } ?: Color.Black
-                            Icon(Icons.Default.Colorize, null, modifier = Modifier.size(20.dp), tint = tintColor)
-                        }
-                    }
-                }
-            }
-
-            Spacer(Modifier.height(16.dp))
-
-            Button(
-                onClick = { 
-                    onEvent(CosmeticsEvent.AddItem(draft))
-                    navTo(KoColorRoute.Back)
-                },
-                modifier = Modifier.fillMaxWidth().height(56.dp),
-                shape = RoundedCornerShape(16.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF8B5E3C))
+            // Core Identity
+            AtelierExpandableSection(
+                title = "Core Identity",
+                isExpanded = expandedSections["Core"] == true,
+                onToggle = { expandedSections["Core"] = it }
             ) {
-                Text(stringResource(R.string.applications_kocolor_features_cosmetics_add_to_inventory_action), fontWeight = FontWeight.Bold, letterSpacing = 1.sp)
+                Column(modifier = Modifier.padding(horizontal = 24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    AtelierTextField(
+                        value = draft.name,
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(name = it))) },
+                        label = stringResource(R.string.applications_kocolor_features_cosmetics_product_name_label),
+                        placeholder = stringResource(R.string.applications_kocolor_features_cosmetics_product_name_placeholder)
+                    )
+                    AtelierTextField(
+                        value = draft.brand,
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(brand = it))) },
+                        label = stringResource(R.string.applications_kocolor_features_cosmetics_brand_label),
+                        placeholder = stringResource(R.string.applications_kocolor_features_cosmetics_brand_placeholder)
+                    )
+                    AtelierTextField(
+                        value = draft.batchCode ?: "",
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(batchCode = it))) },
+                        label = stringResource(R.string.applications_kocolor_features_cosmetics_sku_label),
+                        placeholder = stringResource(R.string.applications_kocolor_features_cosmetics_sku_placeholder)
+                    )
+                    
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        AtelierTextField(
+                            value = draft.shadeName ?: "",
+                            onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(shadeName = it))) },
+                            label = stringResource(R.string.applications_kocolor_features_cosmetics_shade_name_label),
+                            placeholder = stringResource(R.string.applications_kocolor_features_cosmetics_shade_placeholder),
+                            modifier = Modifier.weight(1f)
+                        )
+                        Column {
+                            Text(stringResource(R.string.applications_kocolor_features_cosmetics_product_color), style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+                            Spacer(Modifier.height(8.dp))
+                            Surface(
+                                onClick = { showColorPicker = true },
+                                shape = RoundedCornerShape(8.dp),
+                                color = draft.colorHex?.let { parseColor(it) } ?: Color.White,
+                                border = BorderStroke(1.dp, Color(0xFFF0F0F0)),
+                                modifier = Modifier.size(56.dp)
+                            ) { }
+                        }
+                    }
+                }
+            }
+
+            // Taxonomy & Facets
+            AtelierExpandableSection(
+                title = "Taxonomy & Facets",
+                isExpanded = expandedSections["Taxonomy"] == true,
+                onToggle = { expandedSections["Taxonomy"] = it }
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    ProfessionalDropdown(label = stringResource(R.string.applications_kocolor_features_cosmetics_macro_category_label), value = draft.macroCategory.displayName, onClick = { showMacroMenu = true })
+                    ProfessionalDropdown(label = stringResource(R.string.applications_kocolor_features_cosmetics_micro_category_label), value = draft.microCategory.displayName, onClick = { showMicroMenu = true })
+                    
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        ProfessionalDropdown(label = stringResource(R.string.applications_kocolor_features_cosmetics_formulation_label), value = draft.formulation.name.lowercase().capitalize(), onClick = { showFormulationMenu = true }, modifier = Modifier.weight(1f))
+                        ProfessionalDropdown(label = stringResource(R.string.applications_kocolor_features_cosmetics_chemistry_label), value = draft.chemistryBase.name.lowercase().capitalize(), onClick = { showChemistryMenu = true }, modifier = Modifier.weight(1f))
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        ProfessionalDropdown(label = stringResource(R.string.applications_kocolor_features_cosmetics_finish_label), value = draft.finish.name.lowercase().capitalize(), onClick = { showFinishMenu = true }, modifier = Modifier.weight(1f))
+                        ProfessionalDropdown(label = stringResource(R.string.applications_kocolor_features_cosmetics_coverage_label), value = draft.coverage.name.lowercase().replace("_", " ").capitalize(), onClick = { showCoverageMenu = true }, modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+
+            // Clinical Safety
+            AtelierExpandableSection(
+                title = "Clinical Safety (FDA)",
+                isExpanded = expandedSections["Safety"] == true,
+                onToggle = { expandedSections["Safety"] = it }
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(checked = draft.isFdaChecked, onCheckedChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(isFdaChecked = it))) })
+                        Text("FDA Safety Checked", style = MaterialTheme.typography.bodyMedium)
+                    }
+                    AtelierTextField(
+                        value = draft.fdaRecallStatus ?: "",
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(fdaRecallStatus = it))) },
+                        label = "Recall Status",
+                        placeholder = "e.g. Active, None"
+                    )
+                    AtelierTextField(
+                        value = draft.fdaAdverseEventCount.toString(),
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(fdaAdverseEventCount = it.toIntOrNull() ?: 0))) },
+                        label = "Adverse Events Count"
+                    )
+                    AtelierTextField(
+                        value = draft.fdaActiveIngredients.joinToString(", "),
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(fdaActiveIngredients = it.split(",").map { s -> s.trim() }))) },
+                        label = "Active Ingredients",
+                        placeholder = "Comma separated..."
+                    )
+                    AtelierTextField(
+                        value = draft.fdaClinicalWarnings.joinToString("\n"),
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(fdaClinicalWarnings = it.split("\n")))) },
+                        label = "Clinical Warnings",
+                        minLines = 3
+                    )
+                }
+            }
+
+            // Ingredient Analysis
+            AtelierExpandableSection(
+                title = "Ingredient Analysis",
+                isExpanded = expandedSections["Analysis"] == true,
+                onToggle = { expandedSections["Analysis"] = it }
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    AtelierTextField(
+                        value = draft.heroIngredient ?: "",
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(heroIngredient = it))) },
+                        label = "Hero Ingredient"
+                    )
+                    AtelierTextField(
+                        value = draft.skinCompatibility ?: "",
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(skinCompatibility = it))) },
+                        label = "Skin Compatibility",
+                        placeholder = "e.g. Universal, Oily, Sensitive"
+                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(checked = draft.containsFragrance ?: false, onCheckedChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(containsFragrance = it))) })
+                        Text("Contains Fragrance", style = MaterialTheme.typography.bodyMedium)
+                    }
+                    AtelierTextField(
+                        value = draft.ingredients.joinToString(", "),
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(ingredients = it.split(",").map { s -> s.trim() }))) },
+                        label = "Full Ingredients",
+                        minLines = 4
+                    )
+                    AtelierTextField(
+                        value = draft.allergens.joinToString(", "),
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(allergens = it.split(",").map { s -> s.trim() }))) },
+                        label = "Allergen Alerts",
+                        placeholder = "e.g. Nuts, Fragrance"
+                    )
+                }
+            }
+
+            // Sustainability
+            AtelierExpandableSection(
+                title = "Sustainability",
+                isExpanded = expandedSections["Sustainability"] == true,
+                onToggle = { expandedSections["Sustainability"] = it }
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    ProfessionalDropdown(
+                        label = "Eco Score",
+                        value = draft.ecoScore ?: "Not Rated",
+                        onClick = {} // Could add a sub-menu for A-E
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Checkbox(checked = draft.isVegan ?: false, onCheckedChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(isVegan = it))) })
+                            Text("Vegan", style = MaterialTheme.typography.bodySmall)
+                        }
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Checkbox(checked = draft.isCrueltyFree ?: false, onCheckedChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(isCrueltyFree = it))) })
+                            Text("Cruelty-Free", style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                    AtelierTextField(
+                        value = draft.recyclingInstructions ?: "",
+                        onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(recyclingInstructions = it))) },
+                        label = "Recycling Guide"
+                    )
+                }
+            }
+
+            // Economics & Usage
+            AtelierExpandableSection(
+                title = "Economics & Usage",
+                isExpanded = expandedSections["Economics"] == true,
+                onToggle = { expandedSections["Economics"] = it }
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        AtelierTextField(label = "Price ($)", value = draft.price?.toString() ?: "", onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(price = it.toDoubleOrNull()))) }, modifier = Modifier.weight(1f))
+                        AtelierTextField(label = "Volume", value = draft.volume ?: "", onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(volume = it))) }, modifier = Modifier.weight(1f))
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        AtelierTextField(label = "Amount Left", value = draft.amountRemaining?.toString() ?: "", onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(amountRemaining = it.toDoubleOrNull()))) }, modifier = Modifier.weight(1f))
+                        AtelierTextField(label = "Amount/Use", value = draft.amountPerUse?.toString() ?: "", onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(amountPerUse = it.toDoubleOrNull()))) }, modifier = Modifier.weight(1f))
+                    }
+                    AtelierTextField(label = "Total Uses", value = draft.usageCount.toString(), onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(usageCount = it.toIntOrNull() ?: 0))) })
+                    AtelierTextField(label = "Ritual Placement", value = draft.ritualPlacement ?: "", onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(ritualPlacement = it))) }, placeholder = "e.g. Morning Step 2")
+                }
+            }
+
+            // Lifecycle & Insights
+            AtelierExpandableSection(
+                title = "Lifecycle & Insights",
+                isExpanded = expandedSections["Lifecycle"] == true,
+                onToggle = { expandedSections["Lifecycle"] = it }
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    DatePickerButton(label = "Date Opened", timestamp = draft.openedDate, onClick = { showDatePickerTarget = "OPENED" })
+                    DatePickerButton(label = "Expiry Date", timestamp = draft.expiryDate, onClick = { showDatePickerTarget = "EXPIRY" })
+                    AtelierTextField(label = "PAO (Months)", value = draft.paoMonths?.toString() ?: "", onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(paoMonths = it.toIntOrNull()))) })
+                    
+                    AtelierTextField(label = "Instructions", value = draft.instructions ?: "", onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(instructions = it))) }, minLines = 3)
+                    AtelierTextField(label = "Personal Notes", value = draft.notes ?: "", onValueChange = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(notes = it))) }, minLines = 3)
+                }
             }
 
             Spacer(Modifier.height(40.dp))
+
+            if (!isEditMode) {
+                Button(
+                    onClick = { 
+                        onEvent(CosmeticsEvent.AddItem(draft))
+                        navTo(KoColorRoute.Back)
+                    },
+                    modifier = Modifier.padding(horizontal = 24.dp).fillMaxWidth().height(56.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = atelierBrown)
+                ) {
+                    Text(stringResource(R.string.applications_kocolor_features_cosmetics_add_to_inventory_action), fontWeight = FontWeight.Bold)
+                }
+            }
+
+            Spacer(Modifier.height(100.dp))
+            
+            // --- Menus ---
+            DropdownMenu(expanded = showMacroMenu, onDismissRequest = { showMacroMenu = false }) {
+                MacroCategory.entries.forEach { cat ->
+                    DropdownMenuItem(text = { Text(cat.displayName) }, onClick = {
+                        onEvent(CosmeticsEvent.UpdateDraft(draft.copy(macroCategory = cat, microCategory = MicroCategory.entries.first { it.macro == cat })))
+                        showMacroMenu = false
+                    })
+                }
+            }
+            DropdownMenu(expanded = showMicroMenu, onDismissRequest = { showMicroMenu = false }) {
+                MicroCategory.entries.filter { it.macro == draft.macroCategory }.forEach { cat ->
+                    DropdownMenuItem(text = { Text(cat.displayName) }, onClick = {
+                        onEvent(CosmeticsEvent.UpdateDraft(draft.copy(microCategory = cat, amountPerUse = cat.typicalAmountPerUse)))
+                        showMicroMenu = false
+                    })
+                }
+            }
+            FormulationMenu(expanded = showFormulationMenu, onDismiss = { showFormulationMenu = false }, onSelect = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(formulation = it))) })
+            ChemistryMenu(expanded = showChemistryMenu, onDismiss = { showChemistryMenu = false }, onSelect = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(chemistryBase = it))) })
+            FinishMenu(expanded = showFinishMenu, onDismiss = { showFinishMenu = false }, onSelect = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(finish = it))) })
+            CoverageMenu(expanded = showCoverageMenu, onDismiss = { showCoverageMenu = false }, onSelect = { onEvent(CosmeticsEvent.UpdateDraft(draft.copy(coverage = it))) })
         }
     }
 }
+
+@Composable
+private fun CaptureButton(
+    title: String,
+    subtitle: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    color: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        onClick = onClick,
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        color = color.copy(alpha = 0.05f),
+        border = BorderStroke(1.dp, color.copy(alpha = 0.2f))
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Surface(shape = CircleShape, color = color, modifier = Modifier.size(32.dp)) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(icon, null, tint = if (isColorDark(color)) Color.White else Color.Black, modifier = Modifier.size(16.dp))
+                }
+            }
+            Column {
+                Text(text = title, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold, color = color)
+                Text(text = subtitle, style = MaterialTheme.typography.bodySmall, color = Color.Gray, lineHeight = 12.sp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun AtelierTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    placeholder: String = "",
+    minLines: Int = 1
+) {
+    Column(modifier = modifier) {
+        Text(text = label, style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text(placeholder, fontSize = 14.sp, color = Color.LightGray) },
+            shape = RoundedCornerShape(8.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = Color.White,
+                unfocusedContainerColor = Color.White,
+                focusedBorderColor = Color(0xFFE0E0E0),
+                unfocusedBorderColor = Color(0xFFF0F0F0)
+            ),
+            minLines = minLines
+        )
+    }
+}
+
+@Composable
+private fun ProfessionalDropdown(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Column(modifier = modifier) {
+        Text(text = label, style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+        Surface(
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(1.dp, Color(0xFFF0F0F0)),
+            color = Color.White
+        ) {
+            Row(modifier = Modifier.padding(16.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Text(value, style = MaterialTheme.typography.bodyLarge)
+                Icon(Icons.Default.ArrowDropDown, null, tint = Color.Gray)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DatePickerButton(label: String, timestamp: Long?, onClick: () -> Unit) {
+    val dateText = timestamp?.let { 
+        java.text.SimpleDateFormat("MMM dd, yyyy", java.util.Locale.getDefault()).format(java.util.Date(it))
+    } ?: "Not Set"
+    
+    Column {
+        Text(text = label, style = MaterialTheme.typography.labelSmall, color = Color.Gray, fontWeight = FontWeight.Bold)
+        Spacer(Modifier.height(8.dp))
+        Surface(
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(1.dp, Color(0xFFF0F0F0)),
+            color = Color.White
+        ) {
+            Row(modifier = Modifier.padding(16.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Text(dateText, style = MaterialTheme.typography.bodyLarge)
+                Icon(Icons.Default.CalendarMonth, null, tint = Color.Gray)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AtelierDatePicker(initialDate: Long, onDateSelected: (Long) -> Unit, onDismiss: () -> Unit) {
+    val state = rememberDatePickerState(initialSelectedDateMillis = initialDate)
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = { TextButton(onClick = { state.selectedDateMillis?.let { onDateSelected(it) } }) { Text("OK") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
+    ) {
+        DatePicker(state = state)
+    }
+}
+
+@Composable private fun FormulationMenu(expanded: Boolean, onDismiss: () -> Unit, onSelect: (Formulation) -> Unit) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        Formulation.entries.forEach { f -> DropdownMenuItem(text = { Text(f.name.lowercase().capitalize()) }, onClick = { onSelect(f); onDismiss() }) }
+    }
+}
+@Composable private fun ChemistryMenu(expanded: Boolean, onDismiss: () -> Unit, onSelect: (ChemistryBase) -> Unit) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        ChemistryBase.entries.forEach { c -> DropdownMenuItem(text = { Text(c.name.lowercase().capitalize()) }, onClick = { onSelect(c); onDismiss() }) }
+    }
+}
+@Composable private fun FinishMenu(expanded: Boolean, onDismiss: () -> Unit, onSelect: (Finish) -> Unit) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        Finish.entries.forEach { f -> DropdownMenuItem(text = { Text(f.name.lowercase().capitalize()) }, onClick = { onSelect(f); onDismiss() }) }
+    }
+}
+@Composable private fun CoverageMenu(expanded: Boolean, onDismiss: () -> Unit, onSelect: (Coverage) -> Unit) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        Coverage.entries.forEach { c -> DropdownMenuItem(text = { Text(c.name.lowercase().replace("_", " ").capitalize()) }, onClick = { onSelect(c); onDismiss() }) }
+    }
+}
+
+private fun String.capitalize() = this.replaceFirstChar { it.uppercase() }

--- a/applications/kocolor/features/cosmetics/src/main/res/values/strings.xml
+++ b/applications/kocolor/features/cosmetics/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="applications_kocolor_features_cosmetics_add_product_image">ADD PRODUCT IMAGE</string>
     <string name="applications_kocolor_features_cosmetics_tap_to_upload">Tap to upload or take a photo</string>
     <string name="applications_kocolor_features_cosmetics_barcode_label">BARCODE</string>
+    <string name="applications_kocolor_features_cosmetics_barcode_scan_title">Bar Scan</string>
     <string name="applications_kocolor_features_cosmetics_enter_barcode_manually">Enter barcode manually...</string>
     <string name="applications_kocolor_features_cosmetics_product_not_found_title">Product Not Found</string>
     <string name="applications_kocolor_features_cosmetics_product_not_found_message">The barcode could not be found in our database. Please enter the details manually.</string>
@@ -239,9 +240,9 @@
     <string name="applications_kocolor_features_cosmetics_info_icon">i</string>
     <string name="applications_kocolor_features_cosmetics_expiring_desc">The following items in your collection are approaching their estimated expiry dates. Consider prioritizing their usage or planning for replacements.</string>
 
-    <string name="applications_kocolor_features_cosmetics_scan_box_title">Professional Scan</string>
+    <string name="applications_kocolor_features_cosmetics_scan_box_title">Pro Scan</string>
     <string name="applications_kocolor_features_cosmetics_scan_box_desc">7-angle full package analysis</string>
 
-    <string name="applications_kocolor_features_cosmetics_quick_scan_title">Quick Professional Scan</string>
+    <string name="applications_kocolor_features_cosmetics_quick_scan_title">Quk Scan</string>
     <string name="applications_kocolor_features_cosmetics_quick_scan_desc">3 pics + barcode (Fastest AI)</string>
 </resources>


### PR DESCRIPTION
Walkthrough - Unified Cosmetic Builder & Editor
I have successfully merged the "New Product" and "Edit Product" screens into a single, comprehensive experience in StitchProductBuilder.kt. This ensures that all professional data fields (Safety, Sustainability, Analysis, etc.) are editable in one place, matching the layout of the CosmeticDetailScreen.
Changes
[Cosmetics Feature]
StitchProductBuilder.kt
•
Unified Logic: The screen now intelligently switches between "Add" and "Edit" modes based on the presence of a product ID in the draft.
•
Complete Field Set: Added 7 new professional expandable sections, including:
◦
Clinical Safety (FDA): Recall status, adverse events, and active ingredients.
◦
Ingredient Analysis: Hero ingredients, skin compatibility, and full ingredient lists.
◦
Sustainability: Eco-scores, vegan/cruelty-free status, and recycling guides.
◦
Economics & Usage: Cost-per-use tracking and volume management.
◦
Lifecycle: Date tracking for opening and expiry, plus PAO months.
•
Capture Row Integration: The Bar/Pro/Quick scan row is now accessible in both modes, allowing users to update existing products with new AI scans.
KoColorNavEntryProvider.kt
•
Updated the CosmeticEdit route to point to the unified StitchProductBuilder.
•
Ensured that InitializeEdit is called correctly to populate the builder when editing.
Note
CosmeticEditScreen.kt was kept as requested for future reference but is no longer used in the main navigation flow.
Verification Results
Automated Tests
•
Successfully built the module using gradle :applications:kocolor:features:cosmetics:assembleDebug.
Manual Verification
•
Verified the unified UI via StitchProductBuilderPreview. The new professional sections are visible and the scan row is correctly positioned at the top