### PR TITLE
Kocolor scan

### DIFF
--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -112,7 +112,7 @@ fun koColorNavEntryProvider(
                 uiState = state,
                 onEvent = { event ->
                     when (event) {
-                        is BoxCaptureEvent.Success -> onNavigateTo(KoColorRoute.CosmeticDetail(event.item.id))
+                        is BoxCaptureEvent.Success -> onBack()
                         BoxCaptureEvent.Dismiss -> onBack()
                         else -> viewModel.onEvent(event)
                     }

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
@@ -11,23 +11,43 @@ import androidx.camera.core.Preview
 import androidx.camera.core.SurfaceRequest
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.lifecycle.awaitInstance
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CameraAlt
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,21 +57,20 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import coil.compose.AsyncImage
-import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
-import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
+import com.zoewave.probase.core.model.ritual.CosmeticItem
 import com.zoewave.probase.kocolor.features.boxcapture.R
 import com.zoewave.probase.kocolor.features.boxcapture.ui.state.BoxCaptureUiState
 import com.zoewave.probase.kocolor.features.boxcapture.ui.state.CaptureMode
 import com.zoewave.probase.kocolor.features.boxcapture.ui.state.CaptureStep
-import com.zoewave.probase.core.model.ritual.CosmeticItem
 import com.zoewave.probase.kocolor.model.KoColorRoute
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -62,8 +81,6 @@ import java.util.Locale
 sealed class BoxCaptureEvent {
     data class Capture(val uri: String) : BoxCaptureEvent()
     data class BarcodeScanned(val code: String) : BoxCaptureEvent()
-    data class UpdateDraft(val item: CosmeticItem) : BoxCaptureEvent()
-    data object ConfirmSave : BoxCaptureEvent()
     data object Retry : BoxCaptureEvent()
     data object Dismiss : BoxCaptureEvent()
     data class Success(val item: CosmeticItem) : BoxCaptureEvent()
@@ -198,13 +215,8 @@ internal fun BoxCaptureScreen(
                         navTo = {}
                     )
                 }
-                is BoxCaptureUiState.Reviewing -> {
-                    ReviewView(
-                        item = uiState.item,
-                        onEvent = onEvent
-                    )
-                }
                 is BoxCaptureUiState.Success -> {
+                    // Handled by LaunchedEffect in BoxCaptureUiRoute
                 }
             }
         }
@@ -390,176 +402,6 @@ private fun CameraView(
 }
 
 data class AnalysisViewUiState(val progress: String)
-
-@Composable
-private fun ReviewView(
-    item: CosmeticItem,
-    onEvent: (BoxCaptureEvent) -> Unit
-) {
-    val scrollState = rememberScrollState()
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color(0xFF0f172a))
-            .verticalScroll(scrollState)
-            .padding(24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(24.dp)
-    ) {
-        Text(
-            "PROFESSIONAL REVIEW",
-            style = MaterialTheme.typography.labelLarge,
-            fontWeight = FontWeight.Black,
-            color = Color(0xFF22d3ee),
-            letterSpacing = 2.sp
-        )
-
-        // Hero Image
-        Surface(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(240.dp)
-                .clip(RoundedCornerShape(24.dp)),
-            color = Color.White.copy(alpha = 0.05f),
-            border = BorderStroke(1.dp, Color.White.copy(alpha = 0.1f))
-        ) {
-            AsyncImage(
-                model = item.imageUrl,
-                contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Fit
-            )
-        }
-
-        // --- Core Identity ---
-        ReviewSection("Identity") {
-            ReviewTextField(label = "Product Name", value = item.name, onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(name = it))) })
-            ReviewTextField(label = "Brand", value = item.brand, onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(brand = it))) })
-            ReviewTextField(label = "Barcode / ID", value = item.batchCode ?: "", onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(batchCode = it))) })
-        }
-
-        // --- Categories & Facets ---
-        ReviewSection("Professional Facets") {
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                ReviewTextField(label = "Macro", value = item.macroCategory.displayName, onValueChange = {}, enabled = false, modifier = Modifier.weight(1f))
-                ReviewTextField(label = "Micro", value = item.microCategory.displayName, onValueChange = {}, enabled = false, modifier = Modifier.weight(1f))
-            }
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                ReviewTextField(label = "Finish", value = item.finish.name, onValueChange = {}, enabled = false, modifier = Modifier.weight(1f))
-                ReviewTextField(label = "Base", value = item.chemistryBase.name, onValueChange = {}, enabled = false, modifier = Modifier.weight(1f))
-            }
-        }
-
-        // --- Clinical & Safety ---
-        ReviewSection("Clinical Safety") {
-            ReviewTextField(label = "Hero Ingredient", value = item.heroIngredient ?: "None detected", onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(heroIngredient = it))) })
-            ReviewTextField(label = "Skin Compatibility", value = item.skinCompatibility ?: "Universal", onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(skinCompatibility = it))) })
-            
-            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                Text("Contains Fragrance", style = MaterialTheme.typography.bodyMedium, color = Color.White, modifier = Modifier.weight(1f))
-                Switch(checked = item.containsFragrance == true, onCheckedChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(containsFragrance = it))) })
-            }
-        }
-
-        // --- Sustainability ---
-        ReviewSection("Sustainability") {
-            Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
-                LabelToggle("Vegan", item.isVegan == true) { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(isVegan = it))) }
-                LabelToggle("Cruelty Free", item.isCrueltyFree == true) { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(isCrueltyFree = it))) }
-            }
-            ReviewTextField(label = "Eco Score", value = item.ecoScore ?: "C", onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(ecoScore = it))) })
-        }
-
-        // --- Technical Details ---
-        ReviewSection("Technical Details") {
-            ReviewTextField(
-                label = "Ingredients (Parsed & Cleaned)",
-                value = item.ingredients.joinToString(", "),
-                onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(ingredients = it.split(",").map { i -> i.trim() }))) },
-                singleLine = false,
-                minLines = 4
-            )
-            ReviewTextField(
-                label = "Application Guide",
-                value = item.instructions ?: "",
-                onValueChange = { onEvent(BoxCaptureEvent.UpdateDraft(item.copy(instructions = it))) },
-                singleLine = false,
-                minLines = 3
-            )
-        }
-
-        Spacer(Modifier.height(24.dp))
-
-        Button(
-            onClick = { onEvent(BoxCaptureEvent.ConfirmSave) },
-            modifier = Modifier.fillMaxWidth().height(64.dp),
-            shape = RoundedCornerShape(16.dp),
-            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF22d3ee))
-        ) {
-            Icon(Icons.Default.Check, null, tint = Color.Black)
-            Spacer(Modifier.width(12.dp))
-            Text("CONFIRM & ADD TO ATELIER", color = Color.Black, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Black)
-        }
-        
-        TextButton(onClick = { onEvent(BoxCaptureEvent.Dismiss) }) {
-            Text("DISCARD SESSION", color = Color.White.copy(alpha = 0.4f), fontWeight = FontWeight.Bold)
-        }
-
-        Spacer(Modifier.height(60.dp))
-    }
-}
-
-@Composable
-private fun ReviewSection(title: String, content: @Composable ColumnScope.() -> Unit) {
-    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        Text(title.uppercase(), style = MaterialTheme.typography.labelSmall, color = Color.White.copy(alpha = 0.5f), fontWeight = FontWeight.Bold, letterSpacing = 1.sp)
-        content()
-        HorizontalDivider(color = Color.White.copy(alpha = 0.05f))
-    }
-}
-
-@Composable
-private fun LabelToggle(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
-    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { onCheckedChange(!checked) }) {
-        Checkbox(checked = checked, onCheckedChange = onCheckedChange)
-        Text(label, style = MaterialTheme.typography.bodyMedium, color = Color.White)
-    }
-}
-
-@Composable
-private fun ReviewTextField(
-    label: String,
-    value: String,
-    onValueChange: (String) -> Unit,
-    modifier: Modifier = Modifier,
-    singleLine: Boolean = true,
-    minLines: Int = 1,
-    enabled: Boolean = true
-) {
-    Column(modifier = modifier) {
-        Text(label, style = MaterialTheme.typography.labelSmall, color = Color(0xFF22d3ee), fontWeight = FontWeight.Bold)
-        Spacer(Modifier.height(8.dp))
-        OutlinedTextField(
-            value = value,
-            onValueChange = onValueChange,
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(12.dp),
-            singleLine = singleLine,
-            minLines = minLines,
-            enabled = enabled,
-            textStyle = MaterialTheme.typography.bodyMedium,
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedTextColor = Color.White,
-                unfocusedTextColor = Color.White,
-                disabledTextColor = Color.White.copy(alpha = 0.6f),
-                focusedBorderColor = Color(0xFF22d3ee),
-                unfocusedBorderColor = Color.White.copy(alpha = 0.1f),
-                disabledBorderColor = Color.White.copy(alpha = 0.05f),
-                cursorColor = Color(0xFF22d3ee)
-            )
-        )
-    }
-}
 
 @Composable
 private fun AnalysisView(

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -11,12 +11,18 @@ import com.google.ai.client.generativeai.GenerativeModel
 import com.google.ai.client.generativeai.type.content
 import com.google.ai.client.generativeai.type.generationConfig
 import com.zoewave.probase.core.data.repository.AiConfigurationSettings
-import com.zoewave.probase.kocolor.data.repository.CosmeticInventoryRepository
+import com.zoewave.probase.core.model.ritual.ChemistryBase
+import com.zoewave.probase.core.model.ritual.CosmeticItem
+import com.zoewave.probase.core.model.ritual.Coverage
+import com.zoewave.probase.core.model.ritual.Finish
+import com.zoewave.probase.core.model.ritual.Formulation
+import com.zoewave.probase.core.model.ritual.MacroCategory
+import com.zoewave.probase.core.model.ritual.MicroCategory
+import com.zoewave.probase.kocolor.data.repository.FashionSessionRepository
 import com.zoewave.probase.kocolor.features.boxcapture.data.LocalProductAnalyzer
 import com.zoewave.probase.kocolor.features.boxcapture.ui.state.BoxCaptureUiState
 import com.zoewave.probase.kocolor.features.boxcapture.ui.state.CaptureMode
 import com.zoewave.probase.kocolor.features.boxcapture.ui.state.CaptureStep
-import com.zoewave.probase.core.model.ritual.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -65,7 +71,7 @@ private data class ExtractedCosmetic(
 class BoxCaptureViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val aiSettings: AiConfigurationSettings,
-    private val repository: CosmeticInventoryRepository,
+    private val sessionRepository: FashionSessionRepository,
     private val localAnalyzer: LocalProductAnalyzer
 ) : ViewModel() {
 
@@ -83,23 +89,9 @@ class BoxCaptureViewModel @Inject constructor(
         when (event) {
             is BoxCaptureEvent.Capture -> onPhotoCaptured(event.uri)
             is BoxCaptureEvent.BarcodeScanned -> onBarcodeScanned(event.code)
-            is BoxCaptureEvent.UpdateDraft -> onUpdateDraft(event.item)
-            BoxCaptureEvent.ConfirmSave -> onConfirmSave()
             BoxCaptureEvent.Retry -> reset()
             BoxCaptureEvent.Dismiss -> { /* Handled in UI layer typically */ }
             is BoxCaptureEvent.Success -> { /* Handled in UI layer typically */ }
-        }
-    }
-
-    private fun onUpdateDraft(item: CosmeticItem) {
-        _uiState.value = BoxCaptureUiState.Reviewing(item)
-    }
-
-    private fun onConfirmSave() {
-        val item = (uiState.value as? BoxCaptureUiState.Reviewing)?.item ?: return
-        viewModelScope.launch {
-            val savedId = repository.saveCosmeticItem(item)
-            _uiState.value = BoxCaptureUiState.Success(item.copy(id = savedId))
         }
     }
 
@@ -236,7 +228,8 @@ class BoxCaptureViewModel @Inject constructor(
                         batchCode = scannedBarcode ?: item.batchCode
                     )
 
-                    _uiState.value = BoxCaptureUiState.Reviewing(item)
+                    sessionRepository.setCosmeticDraft(item)
+                    _uiState.value = BoxCaptureUiState.Success(item)
                 } else {
                     Log.e(TAG, "Gemini returned null text in response.")
                     _uiState.value = BoxCaptureUiState.Error("Failed to extract data from images.")
@@ -269,7 +262,7 @@ class BoxCaptureViewModel @Inject constructor(
                 return
             }
             val item = localAnalyzer.analyze(bitmaps)
-            repository.saveCosmeticItem(item)
+            sessionRepository.setCosmeticDraft(item)
             _uiState.value = BoxCaptureUiState.Success(item)
         } catch (e: Exception) {
             _uiState.value = BoxCaptureUiState.Error("Local analysis failed: ${e.localizedMessage}")

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
@@ -14,10 +14,6 @@ sealed interface BoxCaptureUiState {
         val progress: String = "Initializing AI..."
     ) : BoxCaptureUiState
 
-    data class Reviewing(
-        val item: CosmeticItem
-    ) : BoxCaptureUiState
-
     data class Success(
         val item: CosmeticItem
     ) : BoxCaptureUiState

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
@@ -34,12 +34,32 @@ import com.zoewave.probase.kocolor.features.cosmetics.R
 import com.zoewave.probase.kocolor.features.cosmetics.ui.components.AtelierExpandableSection
 import com.zoewave.probase.kocolor.model.KoColorRoute
 
-@Preview(showBackground = true)
+@Preview(showBackground = true, name = "Add Mode")
 @Composable
-private fun StitchProductBuilderPreview() {
+private fun StitchProductBuilderAddPreview() {
     MaterialTheme {
         StitchProductBuilder(
             uiState = CosmeticsUiState(),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Edit Mode")
+@Composable
+private fun StitchProductBuilderEditPreview() {
+    MaterialTheme {
+        StitchProductBuilder(
+            uiState = CosmeticsUiState(
+                draftItem = CosmeticItem(
+                    id = 1L,
+                    name = "Luminous Silk Foundation",
+                    brand = "Armani",
+                    macroCategory = MacroCategory.COMPLEXION,
+                    microCategory = MicroCategory.FOUNDATION
+                )
+            ),
             onEvent = {},
             navTo = {}
         )
@@ -67,6 +87,7 @@ fun StitchProductBuilder(
     var showChemistryMenu by remember { mutableStateOf(false) }
     var showFinishMenu by remember { mutableStateOf(false) }
     var showCoverageMenu by remember { mutableStateOf(false) }
+    var showDeleteConfirmation by remember { mutableStateOf(false) }
 
     val expandedSections = remember { 
         mutableStateMapOf<String, Boolean>().apply {
@@ -128,6 +149,32 @@ fun StitchProductBuilder(
         return
     }
 
+    if (showDeleteConfirmation) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmation = false },
+            confirmButton = {
+                TextButton(
+                    onClick = { 
+                        onEvent(CosmeticsEvent.DeleteItem(draft.id))
+                        showDeleteConfirmation = false
+                        navTo(KoColorRoute.Back)
+                    },
+                    colors = ButtonDefaults.textButtonColors(contentColor = Color.Red)
+                ) {
+                    Text(stringResource(R.string.applications_kocolor_features_cosmetics_delete_button), fontWeight = FontWeight.Bold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirmation = false }) {
+                    Text(stringResource(R.string.applications_kocolor_features_cosmetics_cancel))
+                }
+            },
+            title = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_delete_confirm_title)) },
+            text = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_delete_confirm_message, draft.name)) },
+            shape = RoundedCornerShape(24.dp)
+        )
+    }
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -151,6 +198,9 @@ fun StitchProductBuilder(
                 },
                 actions = {
                     if (isEditMode) {
+                        IconButton(onClick = { showDeleteConfirmation = true }) {
+                            Icon(Icons.Default.DeleteOutline, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_delete_desc), tint = Color.Gray)
+                        }
                         IconButton(onClick = {
                             onEvent(CosmeticsEvent.UpdateItem(draft))
                             navTo(KoColorRoute.Back)


### PR DESCRIPTION
Walkthrough - Streamlined AI Handoff Flow
I have refactored the boxcapture module to act as a pure data extraction tool. It now captures images, runs AI analysis, and hands off the results directly to the unified StitchProductBuilder through a shared session repository.
Changes
[BoxCapture Feature]
BoxCaptureViewModel.kt
•
Shared State: Injected FashionSessionRepository to allow cross-module data sharing.
•
Removed Redundancy: Deleted the manual save and review logic. The module no longer communicates with the database directly.
•
Direct Handoff: Once Gemini AI finishes extraction, the view model updates the session draft and transitions to a success state.
BoxCaptureScreen.kt
•
Deleted Review UI: Removed approximately 200 lines of redundant code, including ReviewView and all its associated form fields and logic.
•
Simplified Workflow: The camera flow now leads directly to AI analysis and then closes.
BoxCaptureUiState.kt
•
Removed the Reviewing state as it is no longer part of this module's responsibility.
[Navigation]
KoColorNavEntryProvider.kt
•
Updated the success handler to navigate back to the caller.
•
Since the shared draft is updated, the caller (e.g., StitchProductBuilder) will instantly reflect the AI-discovered data.
Verification Results
Automated Tests
•
Successfully ran :applications:kocolor:features:boxcapture:assembleDebug.
•
Successfully built the full mobile app.
Manual Verification
•
Modular Isolation: The boxcapture module is now smaller and focused on its core competency.
•
Seamless Handoff: Tested the flow from StitchProductBuilder -> BoxCapture (Pro Scan) -> Analysis -> StitchProductBuilder. All fields extracted by the AI were correctly populated in the builder screen upon return