### PR TITLE
feat: add skin insights and alert-based health status to dashboard

### DIFF
--- a/applications/kocolor/apps/mobile/core/src/main/java/com/zoewave/probase/kocolor/mobile/core/ui/health/StyleHealthDashboard.kt
+++ b/applications/kocolor/apps/mobile/core/src/main/java/com/zoewave/probase/kocolor/mobile/core/ui/health/StyleHealthDashboard.kt
@@ -145,14 +145,19 @@ fun StyleHealthDashboard(
                         uiState = SummaryMetricUiState(
                             icon = Icons.Rounded.Favorite,
                             label = stringResource(R.string.applications_kocolor_apps_mobile_core_health_vitals),
-                            value = if (uiState.latestHeartRate != null) stringResource(R.string.applications_kocolor_apps_mobile_core_health_vitals_normal) else stringResource(R.string.applications_kocolor_apps_mobile_core_health_vitals_syncing),
-                            color = if (uiState.latestHeartRate != null) Color(0xFF4CAF50) else Color.Gray
+                            value = if (uiState.alerts.isEmpty()) stringResource(R.string.applications_kocolor_apps_mobile_core_health_optimal) 
+                                    else stringResource(R.string.applications_kocolor_apps_mobile_core_health_alerts_format, uiState.alerts.size),
+                            color = if (uiState.alerts.isEmpty()) Color(0xFF4CAF50) else Color(0xFFF44336)
                         ),
                         onEvent = {},
                         navTo = {}
                     )
                 }
             }
+        }
+
+        if (uiState.alerts.isNotEmpty()) {
+            SkinInsightsSection(uiState.alerts)
         }
 
         HydrationWaterDropCard(
@@ -229,6 +234,77 @@ data class SummaryMetricUiState(
     val value: String,
     val color: Color
 )
+
+@Composable
+private fun SkinInsightsSection(insights: List<com.zoewave.probase.features.health.core.SkinInsight>) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.applications_kocolor_apps_mobile_core_health_skin_insights),
+            style = MaterialTheme.typography.titleLarge,
+            fontFamily = FontFamily.Serif,
+            fontWeight = FontWeight.Bold
+        )
+
+        insights.forEach { insight ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White),
+                border = androidx.compose.foundation.BorderStroke(1.dp, Color.Black.copy(alpha = 0.05f))
+            ) {
+                Row(
+                    modifier = Modifier.padding(20.dp),
+                    verticalAlignment = Alignment.Top,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Surface(
+                        color = if (insight.severity > 0.7f) Color(0xFFF44336).copy(alpha = 0.1f) else Color(0xFFFF9800).copy(alpha = 0.1f),
+                        shape = CircleShape,
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                Icons.Rounded.Favorite,
+                                null,
+                                modifier = Modifier.size(20.dp),
+                                tint = if (insight.severity > 0.7f) Color(0xFFF44336) else Color(0xFFFF9800)
+                            )
+                        }
+                    }
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = insight.trigger,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFF2C2420)
+                        )
+                        Text(
+                            text = insight.manifestation,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Gray,
+                            fontWeight = FontWeight.Medium
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Surface(
+                            color = Color(0xFFF9F7F2),
+                            shape = RoundedCornerShape(12.dp)
+                        ) {
+                            Text(
+                                text = "✨ " + insight.recommendation,
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.padding(12.dp),
+                                color = Color(0xFF4A4444)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
 
 @Composable
 private fun SummaryMetricItem(

--- a/applications/kocolor/apps/mobile/core/src/main/res/values/strings.xml
+++ b/applications/kocolor/apps/mobile/core/src/main/res/values/strings.xml
@@ -42,4 +42,7 @@
     <string name="applications_kocolor_apps_mobile_core_health_bpm">BPM</string>
     <string name="applications_kocolor_apps_mobile_core_health_lx">LX</string>
     <string name="applications_kocolor_apps_mobile_core_health_sleep_duration_format">%1$dh %2$dm</string>
+    <string name="applications_kocolor_apps_mobile_core_health_skin_insights">Skin Insights</string>
+    <string name="applications_kocolor_apps_mobile_core_health_alerts_format">%1$d Alerts</string>
+    <string name="applications_kocolor_apps_mobile_core_health_optimal">Optimal</string>
 </resources>


### PR DESCRIPTION
This commit enhances the health dashboard by replacing the basic heart rate status with a more comprehensive alert-based health summary and adding a new section for detailed skin insights.

- **Dashboard UI Updates**:
    - Updated the "Vitals" metric card to display "Optimal" when there are no alerts, or a specific alert count when issues are detected.
    - The card color now dynamically shifts from green (optimal) to red (alerts present) based on the presence of health alerts.
    - Added a conditional `SkinInsightsSection` that appears when health alerts are present in the UI state.
- **New Components**:
    - Implemented `SkinInsightsSection`, a private composable that renders a list of `SkinInsight` objects.
    - Each insight is displayed in a styled card featuring the trigger, manifestation, severity-based color coding, and a specific recommendation.
- **String Resources**:
    - Added new string resources for "Skin Insights" header, "Optimal" status, and a plural-ready "Alerts" format.