### PR TITLE
refactor: expand time range for sleep session retrieval in HealthSess…

### DIFF
--- a/core/data/src/main/java/com/zoewave/probase/core/data/service/health/HealthSessionManager.kt
+++ b/core/data/src/main/java/com/zoewave/probase/core/data/service/health/HealthSessionManager.kt
@@ -620,15 +620,13 @@ class HealthSessionManager(private val context: Context) {
     }
 
     suspend fun readSleepSessions(): List<SleepSessionData> {
-        val lastDay = ZonedDateTime.now().truncatedTo(ChronoUnit.DAYS)
-            .minusDays(1)
-            .withHour(12)
-        val firstDay = lastDay.minusDays(7)
+        val now = ZonedDateTime.now()
+        val firstDay = now.minusDays(7).truncatedTo(ChronoUnit.DAYS)
 
         val sessions = mutableListOf<SleepSessionData>()
         val sleepSessionRequest = ReadRecordsRequest(
             recordType = SleepSessionRecord::class,
-            timeRangeFilter = TimeRangeFilter.between(firstDay.toInstant(), lastDay.toInstant()),
+            timeRangeFilter = TimeRangeFilter.between(firstDay.toInstant(), now.toInstant()),
             ascendingOrder = false
         )
         val sleepSessions = healthConnectClient.readRecords(sleepSessionRequest)


### PR DESCRIPTION
…ionManager

This commit updates the sleep session query logic to include more recent data by adjusting the time range filter.

- **Time Range Logic**:
    - Updated `readSleepSessions` to query data from the last seven days up to the current timestamp (`now`).
    - Removed the previous logic that truncated the search range to 12:00 PM of the prior day.
    - Simplified the calculation of the start date by truncating the seven-day lookback directly from the current time.
- **Filter Updates**:
    - Adjusted `TimeRangeFilter` to use `now.toInstant()` as the end bound, ensuring sessions recorded today are included in the results.