### PR TITLE
feat: refine BoutiqueCard UI and update string resources

### DIFF
--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/components/BoutiqueCard.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/components/BoutiqueCard.kt
@@ -98,17 +98,20 @@ fun BoutiqueCard(
 
                 AnimatedVisibility(visible = isExpanded) {
                     Column {
-                        Spacer(Modifier.height(8.dp))
+                        Spacer(Modifier.height(12.dp))
                         Text(
                             text = stringResource(R.string.applications_kocolor_apps_mobile_features_home_boutique_desc),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = Color.DarkGray
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                lineHeight = 22.sp,
+                                letterSpacing = 0.2.sp
+                            ),
+                            color = Color(0xFF4A4A4A)
                         )
                         
-                        Spacer(Modifier.height(24.dp))
+                        Spacer(Modifier.height(32.dp))
                         
                         Surface(
-                            onClick = {}, // uriHandler.openUri("https://www.kocolor.com") },
+                            onClick = {}, 
                             color = Color.Transparent,
                             modifier = Modifier.fillMaxWidth()
                         ) {
@@ -118,15 +121,17 @@ fun BoutiqueCard(
                             ) {
                                 Text(
                                     text = stringResource(R.string.applications_kocolor_apps_mobile_features_home_enter_atelier),
-                                    style = MaterialTheme.typography.labelLarge,
-                                    fontWeight = FontWeight.Bold,
+                                    style = MaterialTheme.typography.labelLarge.copy(
+                                        fontWeight = FontWeight.Black,
+                                        letterSpacing = 1.sp
+                                    ),
                                     color = Color(0xFF8D6E63)
                                 )
                                 Icon(
                                     imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                                     contentDescription = null,
                                     tint = Color(0xFF8D6E63),
-                                    modifier = Modifier.size(18.dp)
+                                    modifier = Modifier.size(16.dp)
                                 )
                             }
                         }

--- a/applications/kocolor/apps/mobile/features/home/src/main/res/values/strings.xml
+++ b/applications/kocolor/apps/mobile/features/home/src/main/res/values/strings.xml
@@ -28,8 +28,8 @@
     <string name="applications_kocolor_apps_mobile_features_home_meals_ritual">Meals Ritual</string>
     <string name="applications_kocolor_apps_mobile_features_home_art_of_color">THE ART OF COLOR</string>
     <string name="applications_kocolor_apps_mobile_features_home_boutique_title">KoColor Boutique</string>
-    <string name="applications_kocolor_apps_mobile_features_home_boutique_desc">Curated Collections for the Professional Stylist.</string>
-    <string name="applications_kocolor_apps_mobile_features_home_enter_atelier">ENTER THE ATELIER</string>
+    <string name="applications_kocolor_apps_mobile_features_home_boutique_desc">Curated Collections for the Professional Stylist. Color for the most beautiful canvas (your face)</string>
+    <string name="applications_kocolor_apps_mobile_features_home_enter_atelier">ENTER THE ATELIER (coming soon)</string>
     <string name="applications_kocolor_apps_mobile_features_home_morning_ritual_default">Morning Ritual</string>
     <string name="applications_kocolor_apps_mobile_features_home_meals_ritual_default">Meals Ritual</string>
     <string name="applications_kocolor_apps_mobile_features_home_evening_ritual_default">Evening Ritual</string>


### PR DESCRIPTION
This commit updates the UI styling for the `BoutiqueCard` component and modifies associated string resources to provide more descriptive text and reflect the current development status.

- **UI Refinements**:
    - Increased vertical spacing between the card title, description, and action button for a more open layout.
    - Updated the description text style with specific line height (22.sp) and letter spacing (0.2.sp).
    - Changed the description text color from `DarkGray` to a specific hex value (`0xFF4A4A4A`).
    - Enhanced the "Enter the Atelier" button text with `FontWeight.Black` and increased letter spacing (1.sp).
    - Reduced the forward arrow icon size from 18.dp to 16.dp.
- **String Updates**:
    - Expanded the boutique description string to include more descriptive copy.
    - Appended "(coming soon)" to the "Enter the Atelier" action text.
- **Code Cleanup**:
    - Removed a commented-out `uriHandler` call in the boutique surface click listener.