### PR TITLE
Ko color clean

### DIFF
--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeViewModel.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeViewModel.kt
@@ -4,12 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.core.data.repository.weather.AtmosphericRepository
 import com.zoewave.probase.core.model.ritual.BeautyRoutine
-import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.core.model.ritual.ClothingItem
 import com.zoewave.probase.core.model.ritual.CosmeticItem
 import com.zoewave.probase.core.model.ritual.FashionProfile
-import com.zoewave.probase.core.model.ritual.MacroCategory
-import com.zoewave.probase.core.model.ritual.MicroCategory
 import com.zoewave.probase.core.model.ritual.RoutineTime
 import com.zoewave.probase.core.model.weather.AtmosphericState
 import com.zoewave.probase.features.health.core.SkinInsight
@@ -17,7 +14,6 @@ import com.zoewave.probase.features.health.core.domain.GetActiveRitualUseCase
 import com.zoewave.probase.features.health.core.domain.GetHealthSummaryUseCase
 import com.zoewave.probase.features.health.core.domain.HealthSummary
 import com.zoewave.probase.features.health.core.domain.LogHydrationUseCase
-import com.zoewave.probase.kocolor.features.store.ui.StoreUiState
 import com.zoewave.probase.features.weather.ui.components.layered.LayeredWeatherMapper
 import com.zoewave.probase.features.weather.ui.components.layered.LayeredWeatherUiState
 import com.zoewave.probase.kocolor.data.FashionRepository
@@ -29,13 +25,13 @@ import com.zoewave.probase.kocolor.db.entity.ClothingItemEntity
 import com.zoewave.probase.kocolor.db.entity.CosmeticItemEntity
 import com.zoewave.probase.kocolor.db.entity.RoutineEntity
 import com.zoewave.probase.kocolor.features.routines.data.RoutineDefaults
+import com.zoewave.probase.kocolor.features.store.ui.StoreUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
@@ -165,26 +161,18 @@ class HomeViewModel @Inject constructor(
         val weather = atmosphericState.weather?.let {
             LayeredWeatherMapper.mapToUiState(it, atmosphericState.environmentalContext!!, atmosphericState.isFallback)
         }
-        
-        val popularCosmetics = if (cosmetics.isEmpty()) {
-            listOf(
-                CosmeticItem(name = "Serum Placeholder", brand = "Sample", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.SERUM, isPlaceholder = true),
-                CosmeticItem(name = "Cream Placeholder", brand = "Sample", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.MOISTURIZER, isPlaceholder = true),
-                CosmeticItem(name = "SPF Placeholder", brand = "Sample", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.SPF, isPlaceholder = true)
-            )
-        } else {
-            cosmetics.sortedByDescending { it.timestamp }.take(5).map { it.toModel() }
-        }
 
-        val popularClothing = if (clothing.isEmpty()) {
-            listOf(
-                ClothingItem(name = "T-Shirt Placeholder", brand = "Sample", category = ClothingCategory.TOPS, isPlaceholder = true),
-                ClothingItem(name = "Jeans Placeholder", brand = "Sample", category = ClothingCategory.BOTTOMS, isPlaceholder = true),
-                ClothingItem(name = "Jacket Placeholder", brand = "Sample", category = ClothingCategory.TOPS, isPlaceholder = true)
-            )
-        } else {
-            clothing.sortedByDescending { it.timestamp }.take(5).map { it.toModel() }
-        }
+        // cosmetics.sortedByDescending { it.timestamp }.take(5).map { it.toModel() }
+        val popularCosmetics = cosmetics
+            .sortedByDescending { it.timestamp }
+            .take(5)
+            .map { it.toModel()}
+
+
+        val popularClothing = clothing
+            .sortedByDescending { it.timestamp }
+            .take(5)
+            .map { it.toModel() }
 
         val cosmeticsByGroup = cosmetics.groupBy { it.macroCategory.displayName }.mapValues { it.value.size }
         val clothingByCategory = clothing.groupBy { it.category.name }.mapValues { it.value.size }
@@ -216,8 +204,8 @@ class HomeViewModel @Inject constructor(
             isDaytime = activeRitual.isDaytime,
             isLoadingRoutines = routineEntities.isEmpty(),
             beautyTip = tip,
-            totalCosmetics = if (cosmetics.isEmpty()) 3 else cosmetics.size,
-            totalClothing = if (clothing.isEmpty()) 3 else clothing.size,
+            totalCosmetics = cosmetics.size,
+            totalClothing = clothing.size,
             totalVanityValue = totalVanityValue,
             totalWardrobeValue = totalWardrobeValue,
             expiringCosmeticsCount = expiringCount,

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -84,6 +85,8 @@ sealed class BoxCaptureEvent {
     data object Retry : BoxCaptureEvent()
     data object Dismiss : BoxCaptureEvent()
     data class Success(val item: CosmeticItem) : BoxCaptureEvent()
+    data class DeletePhoto(val index: Int) : BoxCaptureEvent()
+    data class ChangeMode(val mode: CaptureMode) : BoxCaptureEvent()
 }
 
 @OptIn(ExperimentalPermissionsApi::class)
@@ -311,6 +314,28 @@ private fun CameraView(
                         fontWeight = FontWeight.Bold
                     )
                 }
+
+                if (uiState.mode == CaptureMode.BOX_PRO || uiState.mode == CaptureMode.BOX_QUICK) {
+                    Surface(
+                        color = Color.White.copy(alpha = 0.1f),
+                        shape = RoundedCornerShape(24.dp),
+                        modifier = Modifier.padding(horizontal = 8.dp)
+                    ) {
+                        Row(modifier = Modifier.padding(4.dp)) {
+                            CaptureModeChip(
+                                label = "3",
+                                isSelected = uiState.mode == CaptureMode.BOX_QUICK,
+                                onClick = { onEvent(BoxCaptureEvent.ChangeMode(CaptureMode.BOX_QUICK)) }
+                            )
+                            CaptureModeChip(
+                                label = "7",
+                                isSelected = uiState.mode == CaptureMode.BOX_PRO,
+                                onClick = { onEvent(BoxCaptureEvent.ChangeMode(CaptureMode.BOX_PRO)) }
+                            )
+                        }
+                    }
+                }
+
                 IconButton(
                     onClick = { onEvent(BoxCaptureEvent.Dismiss) },
                     modifier = Modifier.background(Color(0x33000000), CircleShape)
@@ -328,17 +353,33 @@ private fun CameraView(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             LazyRow(
-                modifier = Modifier.fillMaxWidth().height(60.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth().height(80.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
                 contentPadding = PaddingValues(horizontal = 8.dp)
             ) {
-                items(uiState.capturedUris) { uri ->
-                    AsyncImage(
-                        model = uri,
-                        contentDescription = null,
-                        modifier = Modifier.size(60.dp).clip(RoundedCornerShape(8.dp)),
-                        contentScale = ContentScale.Crop
-                    )
+                items(uiState.capturedUris.size) { index ->
+                    Box(modifier = Modifier.size(70.dp)) {
+                        AsyncImage(
+                            model = uiState.capturedUris[index],
+                            contentDescription = null,
+                            modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(12.dp)),
+                            contentScale = ContentScale.Crop
+                        )
+                        IconButton(
+                            onClick = { onEvent(BoxCaptureEvent.DeletePhoto(index)) },
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .size(24.dp)
+                                .background(Color.Black.copy(alpha = 0.6f), CircleShape)
+                        ) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = "Delete",
+                                tint = Color.White,
+                                modifier = Modifier.size(14.dp)
+                            )
+                        }
+                    }
                 }
             }
 
@@ -395,7 +436,13 @@ private fun CameraView(
             }
             
             Spacer(modifier = Modifier.height(12.dp))
-            val captureLabel = if (uiState.mode == CaptureMode.BOX) stringResource(R.string.applications_kocolor_features_boxcapture_tap_to_capture_box) else stringResource(R.string.applications_kocolor_features_boxcapture_tap_to_capture_product)
+            val captureLabel = when (uiState.mode) {
+                CaptureMode.BOX_PRO -> stringResource(R.string.applications_kocolor_features_boxcapture_tap_to_capture_box)
+                CaptureMode.BOX_QUICK -> if (uiState.step == CaptureStep.INGREDIENTS) 
+                    stringResource(R.string.applications_kocolor_features_boxcapture_tap_to_capture_ingredients)
+                    else stringResource(R.string.applications_kocolor_features_boxcapture_tap_to_capture_box)
+                CaptureMode.PRODUCT -> stringResource(R.string.applications_kocolor_features_boxcapture_tap_to_capture_product)
+            }
             Text(captureLabel, color = Color.White.copy(alpha = 0.6f), style = MaterialTheme.typography.labelSmall)
         }
     }
@@ -472,6 +519,29 @@ private fun ErrorView(
         Spacer(modifier = Modifier.height(32.dp))
         Button(onClick = onEvent, colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFf472b6))) {
             Text(stringResource(R.string.applications_kocolor_features_boxcapture_try_again), color = Color.White)
+        }
+    }
+}
+
+@Composable
+private fun CaptureModeChip(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Surface(
+        onClick = onClick,
+        color = if (isSelected) Color(0xFF22d3ee) else Color.Transparent,
+        shape = CircleShape,
+        modifier = Modifier.size(36.dp)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Bold,
+                color = if (isSelected) Color.Black else Color.White
+            )
         }
     }
 }

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -92,18 +92,38 @@ class BoxCaptureViewModel @Inject constructor(
             BoxCaptureEvent.Retry -> reset()
             BoxCaptureEvent.Dismiss -> { /* Handled in UI layer typically */ }
             is BoxCaptureEvent.Success -> { /* Handled in UI layer typically */ }
+            is BoxCaptureEvent.DeletePhoto -> {
+                if (event.index in capturedUris.indices) {
+                    capturedUris.removeAt(event.index)
+                    refreshStep()
+                }
+            }
+            is BoxCaptureEvent.ChangeMode -> {
+                val currentMode = (uiState.value as? BoxCaptureUiState.Idle)?.mode ?: CaptureMode.BOX_PRO
+                if (currentMode != event.mode) {
+                    // Only reset if we actually change
+                    capturedUris.clear()
+                    _uiState.value = BoxCaptureUiState.Idle(capturedUris.toList(), CaptureStep.getStepsForMode(event.mode).first(), event.mode)
+                }
+            }
         }
     }
 
+    private fun refreshStep() {
+        val mode = (uiState.value as? BoxCaptureUiState.Idle)?.mode ?: CaptureMode.BOX_PRO
+        val currentStep = getNextStep(mode) ?: CaptureStep.BARCODE // Fallback
+        _uiState.value = BoxCaptureUiState.Idle(capturedUris.toList(), currentStep, mode)
+    }
+
     fun setMode(modeString: String) {
-        val mode = try { CaptureMode.valueOf(modeString) } catch (e: Exception) { CaptureMode.BOX }
+        val mode = try { CaptureMode.valueOf(modeString) } catch (e: Exception) { CaptureMode.BOX_PRO }
         reset() // Ensure clean state when switching modes
         _uiState.value = BoxCaptureUiState.Idle(capturedUris.toList(), CaptureStep.getStepsForMode(mode).first(), mode)
     }
 
     private fun onPhotoCaptured(uri: String) {
         capturedUris.add(uri)
-        val mode = (uiState.value as? BoxCaptureUiState.Idle)?.mode ?: CaptureMode.BOX
+        val mode = (uiState.value as? BoxCaptureUiState.Idle)?.mode ?: CaptureMode.BOX_PRO
         val nextStep = getNextStep(mode)
         if (nextStep != null) {
             _uiState.value = BoxCaptureUiState.Idle(capturedUris.toList(), nextStep, mode)
@@ -114,7 +134,7 @@ class BoxCaptureViewModel @Inject constructor(
 
     private fun onBarcodeScanned(code: String) {
         scannedBarcode = code
-        val mode = (uiState.value as? BoxCaptureUiState.Idle)?.mode ?: CaptureMode.QUICK_BOX
+        val mode = (uiState.value as? BoxCaptureUiState.Idle)?.mode ?: CaptureMode.BOX_QUICK
         analyzePhotos(mode)
     }
 
@@ -151,7 +171,7 @@ class BoxCaptureViewModel @Inject constructor(
 
                 // --- Hybrid Analysis: Local OCR for Ingredients ---
                 var localIngredientsOcr = ""
-                val ingredientsIndex = if (mode == CaptureMode.QUICK_BOX) 2 else 6 // Specific steps
+                val ingredientsIndex = if (mode == CaptureMode.BOX_QUICK) 2 else 6 // Specific steps
                 if (capturedUris.size > ingredientsIndex) {
                     val ingredientsBitmap = loadBitmapFromUri(Uri.parse(capturedUris[ingredientsIndex]))
                     if (ingredientsBitmap != null) {
@@ -171,8 +191,8 @@ class BoxCaptureViewModel @Inject constructor(
                 val prompt = content {
                     bitmaps.forEach { image(it) }
                     val target = when (mode) {
-                        CaptureMode.BOX -> "product box from all sides"
-                        CaptureMode.QUICK_BOX -> "essential product box angles"
+                        CaptureMode.BOX_PRO -> "product box from all sides"
+                        CaptureMode.BOX_QUICK -> "essential product box angles"
                         CaptureMode.PRODUCT -> "product container (front and back)"
                     }
                     val barcodeContext = if (!scannedBarcode.isNullOrBlank()) "The scanned barcode is: $scannedBarcode." else ""
@@ -252,6 +272,7 @@ class BoxCaptureViewModel @Inject constructor(
             }
         }
     }
+
 
     private suspend fun runLocalAnalysis() {
         _uiState.value = BoxCaptureUiState.Analyzing(capturedUris.toList(), "Running Local AI (Offline)...")
@@ -340,7 +361,7 @@ class BoxCaptureViewModel @Inject constructor(
     }
 
     fun reset() {
-        val mode = (uiState.value as? BoxCaptureUiState.Idle)?.mode ?: CaptureMode.BOX
+        val mode = (uiState.value as? BoxCaptureUiState.Idle)?.mode ?: CaptureMode.BOX_PRO
         capturedUris.clear()
         _uiState.value = BoxCaptureUiState.Idle(emptyList(), CaptureStep.getStepsForMode(mode).first(), mode)
     }

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
@@ -6,7 +6,7 @@ sealed interface BoxCaptureUiState {
     data class Idle(
         val capturedUris: List<String> = emptyList(),
         val currentStep: CaptureStep = CaptureStep.FRONT,
-        val mode: CaptureMode = CaptureMode.BOX
+        val mode: CaptureMode = CaptureMode.BOX_PRO
     ) : BoxCaptureUiState
 
     data class Analyzing(
@@ -24,7 +24,7 @@ sealed interface BoxCaptureUiState {
 }
 
 enum class CaptureMode {
-    BOX, PRODUCT, QUICK_BOX
+    BOX_PRO, BOX_QUICK, PRODUCT
 }
 
 enum class CaptureStep(val boxLabel: String, val productLabel: String = boxLabel) {
@@ -44,9 +44,9 @@ enum class CaptureStep(val boxLabel: String, val productLabel: String = boxLabel
     companion object {
         fun getStepsForMode(mode: CaptureMode): List<CaptureStep> {
             return when (mode) {
-                CaptureMode.BOX -> listOf(FRONT, BACK, LEFT, RIGHT, TOP, BOTTOM, INGREDIENTS)
-                CaptureMode.PRODUCT -> listOf(FRONT, BACK)
-                CaptureMode.QUICK_BOX -> listOf(FRONT, BACK, INGREDIENTS, BARCODE)
+                CaptureMode.BOX_PRO -> listOf(FRONT, BACK, LEFT, RIGHT, TOP, BOTTOM, BARCODE)
+                CaptureMode.BOX_QUICK -> listOf(FRONT, BACK, INGREDIENTS, BARCODE)
+                CaptureMode.PRODUCT -> listOf(FRONT, BACK, BARCODE)
             }
         }
     }

--- a/applications/kocolor/features/boxcapture/src/main/res/values/strings.xml
+++ b/applications/kocolor/features/boxcapture/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="applications_kocolor_features_boxcapture_close">Close</string>
     <string name="applications_kocolor_features_boxcapture_tap_to_capture_box">TAP TO CAPTURE BOX</string>
     <string name="applications_kocolor_features_boxcapture_tap_to_capture_product">TAP TO CAPTURE PRODUCT</string>
+    <string name="applications_kocolor_features_boxcapture_tap_to_capture_ingredients">CAPTURE INGREDIENTS</string>
     <string name="applications_kocolor_features_boxcapture_gemini_analyzing">GEMINI ANALYZING</string>
     <string name="applications_kocolor_features_boxcapture_local_analyzing">LOCAL AI ANALYZING</string>
     <string name="applications_kocolor_features_boxcapture_offline_mode_desc">OFFLINE MODE: Accuracy may be lower. You can refine details after extraction.</string>

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
@@ -6,19 +6,30 @@ import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.core.data.repository.AiConfigurationSettings
-import com.zoewave.probase.kocolor.data.mapper.toEntity
-import com.zoewave.probase.kocolor.data.mapper.toModel
+import com.zoewave.probase.core.model.ritual.CosmeticItem
+import com.zoewave.probase.core.model.ritual.Finish
+import com.zoewave.probase.core.model.ritual.Formulation
+import com.zoewave.probase.core.model.ritual.MacroCategory
+import com.zoewave.probase.core.model.ritual.MicroCategory
+import com.zoewave.probase.core.network.repository.weather.WeatherRepo
 import com.zoewave.probase.kocolor.data.repository.CosmeticInventoryRepository
 import com.zoewave.probase.kocolor.data.repository.FashionSessionRepository
 import com.zoewave.probase.kocolor.features.analyzer.data.AnalyzerEngine
-import com.zoewave.probase.core.model.ritual.*
-import com.zoewave.probase.kocolor.features.fda.data.repository.FdaRepository
-import com.zoewave.probase.core.network.repository.weather.WeatherRepo
 import com.zoewave.probase.kocolor.features.cosmetics.R
+import com.zoewave.probase.kocolor.features.fda.data.repository.FdaRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -159,18 +170,9 @@ class CosmeticsViewModel @Inject constructor(
         val scanFailed = array[9] as Boolean
         val uvVal = array[10] as Double
 
-        val displayedItems = if (models.isEmpty()) {
-            listOf(
-                CosmeticItem(name = "Serum Placeholder", brand = "Placeholder", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.SERUM, isPlaceholder = true),
-                CosmeticItem(name = "Foundation Placeholder", brand = "Placeholder", macroCategory = MacroCategory.COMPLEXION, microCategory = MicroCategory.FOUNDATION, isPlaceholder = true),
-                CosmeticItem(name = "Blush Placeholder", brand = "Placeholder", macroCategory = MacroCategory.DIMENSION, microCategory = MicroCategory.BLUSH, isPlaceholder = true),
-                CosmeticItem(name = "Lipstick Placeholder", brand = "Placeholder", macroCategory = MacroCategory.LIPS, microCategory = MicroCategory.LIPSTICK, isPlaceholder = true)
-            )
-        } else models
-
-        val groupStats = displayedItems.groupBy { it.macroCategory.displayName }.mapValues { it.value.size }
+        val groupStats = models.groupBy { it.macroCategory.displayName }.mapValues { it.value.size }
         
-        val categoryMetadata = displayedItems.groupBy { it.macroCategory.displayName }.mapValues { (name, items) ->
+        val categoryMetadata = models.groupBy { it.macroCategory.displayName }.mapValues { (name, items) ->
             val macro = items.firstOrNull()?.macroCategory
             val representativeItem = items.filter { it.imageUrl != null }.maxByOrNull { it.usageCount } ?: items.maxByOrNull { it.usageCount }
             val brands = items.map { it.brand }.groupBy { it }.mapValues { it.value.size }
@@ -179,8 +181,8 @@ class CosmeticsViewModel @Inject constructor(
             val averageFill = if (fillLevels.isEmpty()) null else fillLevels.average()
 
             CategoryMetadata(
-                itemCount = if (models.isEmpty()) 1 else items.size,
-                totalValue = if (models.isEmpty()) 0.0 else items.sumOf { it.price ?: 0.0 },
+                itemCount = items.size,
+                totalValue = items.sumOf { it.price ?: 0.0 },
                 representativeImageUrl = representativeItem?.imageUrl,
                 representativeColorHex = representativeItem?.colorHex,
                 leadingBrand = leadingBrand,
@@ -196,7 +198,7 @@ class CosmeticsViewModel @Inject constructor(
             } ?: false
         }
 
-        val filtered = displayedItems.filter {
+        val filtered = models.filter {
             it.name.contains(query, ignoreCase = true) || 
             it.brand.contains(query, ignoreCase = true) ||
             it.microCategory.displayName.contains(query, ignoreCase = true) ||
@@ -211,7 +213,7 @@ class CosmeticsViewModel @Inject constructor(
         }
 
         CosmeticsUiState(
-            items = displayedItems,
+            items = models,
             filteredItems = filtered,
             isLoading = false,
             capturedImageUri = draft.imageUrl,
@@ -220,7 +222,7 @@ class CosmeticsViewModel @Inject constructor(
             draftItem = draft,
             searchQuery = query,
             sortOption = sort,
-            totalCosmetics = if (models.isEmpty()) 4 else models.size,
+            totalCosmetics = models.size,
             expiringCosmeticsCount = expiringCount,
             cosmeticsByGroup = groupStats,
             categoriesMetadata = categoryMetadata,

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -230,7 +231,7 @@ fun StitchProductBuilder(
                     .padding(24.dp)
                     .fillMaxWidth()
                     .aspectRatio(1.5f)
-                    .clickable { navTo(KoColorRoute.Camera("inventory_item")) },
+                    .clickable { navTo(KoColorRoute.BoxCapture(mode = "PRODUCT")) },
                 shape = RoundedCornerShape(12.dp),
                 color = Color(0xFFFBF8F5),
                 border = BorderStroke(1.dp, Color(0xFFF0F0F0))
@@ -255,11 +256,13 @@ fun StitchProductBuilder(
 
             // Capture Row
             Row(
-                modifier = Modifier.padding(horizontal = 24.dp).fillMaxWidth(),
+                modifier = Modifier
+                    .padding(horizontal = 24.dp)
+                    .fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 CaptureButton(
-                    title = stringResource(R.string.applications_kocolor_features_cosmetics_barcode_scan_title),
+                    title = "Bar Scan",
                     subtitle = "Scan UPC",
                     icon = Icons.Default.QrCodeScanner,
                     color = Color(0xFF6B7280),
@@ -267,19 +270,19 @@ fun StitchProductBuilder(
                     modifier = Modifier.weight(1f)
                 )
                 CaptureButton(
-                    title = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title),
-                    subtitle = "7-angle AI",
+                    title = "Box Scan",
+                    subtitle = "3 or 7 pics",
                     icon = Icons.Default.AutoAwesome,
                     color = atelierBrown,
-                    onClick = { navTo(KoColorRoute.BoxCapture(mode = "BOX")) },
+                    onClick = { navTo(KoColorRoute.BoxCapture(mode = "BOX_QUICK")) },
                     modifier = Modifier.weight(1f)
                 )
                 CaptureButton(
-                    title = stringResource(R.string.applications_kocolor_features_cosmetics_quick_scan_title),
-                    subtitle = "3-pic AI",
-                    icon = Icons.Default.AutoAwesome,
-                    color = Color(0xFF22d3ee),
-                    onClick = { navTo(KoColorRoute.BoxCapture(mode = "QUICK_BOX")) },
+                    title = "No Box",
+                    subtitle = "2-pic AI",
+                    icon = Icons.Default.PhotoCamera,
+                    color = Color(0xFFf472b6),
+                    onClick = { navTo(KoColorRoute.BoxCapture(mode = "PRODUCT")) },
                     modifier = Modifier.weight(1f)
                 )
             }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductGridCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductGridCard.kt
@@ -30,13 +30,8 @@ fun CosmeticProductGridCard(
     val item = uiState
     val onClick = { navTo(KoColorRoute.CosmeticDetail(item.id)) }
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(0.75f)
-            .clickable(enabled = !item.isPlaceholder) { onClick() }
-            .alpha(if (item.isPlaceholder) 0.5f else 1.0f),
-        shape = RoundedCornerShape(24.dp),
-        colors = if (item.isPlaceholder) CardDefaults.cardColors(containerColor = Color.LightGray) else CardDefaults.cardColors()
+        modifier = Modifier.fillMaxWidth().aspectRatio(0.75f).clickable { onClick() },
+        shape = RoundedCornerShape(24.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             if (item.imageUrl != null) {

--- a/applications/kocolor/features/cosmetics/src/main/res/values/strings.xml
+++ b/applications/kocolor/features/cosmetics/src/main/res/values/strings.xml
@@ -245,4 +245,7 @@
 
     <string name="applications_kocolor_features_cosmetics_quick_scan_title">Quk Scan</string>
     <string name="applications_kocolor_features_cosmetics_quick_scan_desc">3 pics + barcode (Fastest AI)</string>
+
+    <string name="applications_kocolor_features_cosmetics_no_box_scan_title">No Box</string>
+    <string name="applications_kocolor_features_cosmetics_no_box_scan_desc">2-pic AI (front/back)</string>
 </resources>

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
@@ -94,19 +94,10 @@ class WardrobeViewModel @Inject constructor(
         wardrobeRepository.getAllClothing(),
         _draftItem
     ) { models, draft ->
-        val displayedItems = if (models.isEmpty()) {
-            listOf(
-                ClothingItem(name = "Archival Blazer", brand = "Placeholder", category = ClothingCategory.TOPS, isPlaceholder = true),
-                ClothingItem(name = "Structural Trouser", brand = "Placeholder", category = ClothingCategory.BOTTOMS, isPlaceholder = true),
-                ClothingItem(name = "Performance Loafer", brand = "Placeholder", category = ClothingCategory.SHOES, isPlaceholder = true),
-                ClothingItem(name = "Curated Accessory", brand = "Placeholder", category = ClothingCategory.ACCESSORIES, isPlaceholder = true)
-            )
-        } else models
-
         val totalInvestment = models.sumOf { it.price ?: 0.0 }
-        val itemsByCategory = displayedItems.groupBy { it.category.name }.mapValues { it.value.size }
+        val itemsByCategory = models.groupBy { it.category.name }.mapValues { it.value.size }
         
-        val categoryMetadata = displayedItems.groupBy { it.category.name }.mapValues { (name, items) ->
+        val categoryMetadata = models.groupBy { it.category.name }.mapValues { (name, items) ->
             val cat = items.firstOrNull()?.category
             val representativeItem = items.filter { it.imageUrl != null }.maxByOrNull { it.timestamp } ?: items.maxByOrNull { it.timestamp }
             val brands = items.mapNotNull { it.brand }.groupBy { it }.mapValues { it.value.size }
@@ -115,8 +106,8 @@ class WardrobeViewModel @Inject constructor(
             val averageUsage = if (usages.isEmpty()) null else usages.average()
 
             CategoryMetadata(
-                itemCount = if (models.isEmpty()) 1 else items.size,
-                totalValue = if (models.isEmpty()) 0.0 else items.sumOf { it.price ?: 0.0 },
+                itemCount = items.size,
+                totalValue = items.sumOf { it.price ?: 0.0 },
                 representativeImageUrl = representativeItem?.imageUrl,
                 representativeColorHex = representativeItem?.colorHex,
                 leadingBrand = leadingBrand,
@@ -126,11 +117,11 @@ class WardrobeViewModel @Inject constructor(
         }
 
         WardrobeUiState(
-            items = displayedItems,
+            items = models,
             isLoading = false,
             draftItem = draft,
             totalInvestment = totalInvestment,
-            totalItems = if (models.isEmpty()) 4 else models.size,
+            totalItems = models.size,
             itemsByCategory = itemsByCategory,
             categoriesMetadata = categoryMetadata
         )

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/ClothingProductGridCard.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/ClothingProductGridCard.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -28,13 +27,8 @@ fun ClothingProductGridCard(uiState: ClothingItem, navTo: (KoColorRoute) -> Unit
     val item = uiState
     val onClick = { navTo(KoColorRoute.WardrobeDetail(item.id)) }
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(0.75f)
-            .clickable(enabled = !item.isPlaceholder) { onClick() }
-            .alpha(if (item.isPlaceholder) 0.5f else 1.0f),
-        shape = RoundedCornerShape(24.dp),
-        colors = if (item.isPlaceholder) CardDefaults.cardColors(containerColor = Color.LightGray) else CardDefaults.cardColors()
+        modifier = Modifier.fillMaxWidth().aspectRatio(0.75f).clickable { onClick() },
+        shape = RoundedCornerShape(24.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             if (item.imageUrl != null) {

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeCard.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeCard.kt
@@ -45,11 +45,9 @@ fun WardrobeCard(
     val contentColor = if (isDark) Color.White else Color.Black
 
     ElevatedCard(
-        modifier = modifier
-            .clickable(enabled = !uiState.isPlaceholder) { navTo(KoColorRoute.WardrobeDetail(uiState.id)) }
-            .alpha(if (uiState.isPlaceholder) 0.5f else 1.0f),
+        modifier = modifier.clickable { navTo(KoColorRoute.WardrobeDetail(uiState.id)) },
         shape = RoundedCornerShape(24.dp),
-        colors = CardDefaults.elevatedCardColors(containerColor = if (uiState.isPlaceholder) Color.LightGray else bgColor)
+        colors = CardDefaults.elevatedCardColors(containerColor = bgColor)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             if (uiState.imageUrl != null) {

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
@@ -391,13 +391,8 @@ fun RecentClothingCard(uiState: ClothingItem, modifier: Modifier = Modifier, onE
     val item = uiState
     val onClick = { navTo(KoColorRoute.WardrobeDetail(item.id)) }
     Card(
-        modifier = modifier
-            .width(220.dp)
-            .aspectRatio(0.8f)
-            .clickable(enabled = !item.isPlaceholder) { onClick() }
-            .alpha(if (item.isPlaceholder) 0.5f else 1.0f),
-        shape = RoundedCornerShape(28.dp),
-        colors = if (item.isPlaceholder) CardDefaults.cardColors(containerColor = Color.LightGray) else CardDefaults.cardColors()
+        modifier = modifier.width(220.dp).aspectRatio(0.8f).clickable { onClick() },
+        shape = RoundedCornerShape(28.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             if (item.imageUrl != null) {

--- a/core/model/src/main/java/com/zoewave/probase/core/model/ritual/ClothingItem.kt
+++ b/core/model/src/main/java/com/zoewave/probase/core/model/ritual/ClothingItem.kt
@@ -50,8 +50,7 @@ data class ClothingItem(
     val koColorGroup: String? = null,     // Semantic group
 
     // --- Usage & Performance ---
-    val usageCount: Int = 0,
-    val isPlaceholder: Boolean = false
+    val usageCount: Int = 0
 ) {
     /** Cost per single wear. */
     val costPerUse: Double?

--- a/core/model/src/main/java/com/zoewave/probase/core/model/ritual/CosmeticItem.kt
+++ b/core/model/src/main/java/com/zoewave/probase/core/model/ritual/CosmeticItem.kt
@@ -274,8 +274,7 @@ data class CosmeticItem(
     val fdaClinicalWarnings: List<String> = emptyList(),
     val fdaTopReactions: List<String> = emptyList(),
     val fdaActiveIngredients: List<String> = emptyList(),
-    val isFdaChecked: Boolean = false,
-    val isPlaceholder: Boolean = false
+    val isFdaChecked: Boolean = false
 ) {
     /** 
      * Calculated estimated expiration based on PAO and opened date. 


### PR DESCRIPTION
Key Refinements:
1.
Three-Button Interface: Simplified the "Add to Collection" screen in   StitchProductBuilder.kt to use three primary buttons:
◦
Bar Scan: Rapid UPC lookup.
◦
Box Scan: For products with packaging (now with a 3 or 7 pic toggle).
◦
No Box: Optimized for product containers without a box (2-pic AI).
2.
Dynamic Mode Switching: Inside the camera interface (  BoxCaptureScreen.kt), I've added a "3 / 7" toggle in the top bar. Users can now switch between Quick mode (3 photos + barcode) and Pro mode (6 photos/all sides + barcode) on the fly without leaving the camera.
3.
Visual Photo Management:
◦
The horizontal photo preview at the bottom now displays a trash icon on each captured image.
◦
This allows users to delete accidental or blurry shots immediately.
◦
The capture sequence automatically resets to the correct step when a photo is removed.
4.
Hero Image Shortcut: Tapping the main "Add Product Image" area now automatically launches the No Box (2-pic AI) path, providing a fast way to start capturing.
These changes provide a cleaner entry point while giving the user total control over the capture depth once the camera is open.