### PR TITLE
feat: initialize Rust server proxy for Gemini API and App Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ google-services-ylabz.json
 google-services-zoewave.json
 /.kotlin/
 /.idea/
+
+# Rust Backend Isolation
+/server/target/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -16,6 +16,7 @@
       <file path="$PROJECT_DIR$/features/xr/glass/docs" />
       <file path="$PROJECT_DIR$/features/xr/glass/translation/docs" />
       <file path="$PROJECT_DIR$/features/xr/glass/vision/doc" />
+      <file path="$PROJECT_DIR$/server" />
     </excludeRoots>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1.28", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+reqwest = { version = "0.11", features = ["json"] }
+jsonwebtoken = "9.2"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,21 @@
+# Stage 1: Build the Rust binary
+FROM rust:1.75-bookworm as builder
+WORKDIR /usr/src/app
+# Copy the source code
+COPY . .
+# Compile the binary in release mode
+RUN cargo build --release
+
+# Stage 2: Create the minimal production image
+FROM debian:bookworm-slim
+# Install CA certificates so reqwest can make secure HTTPS calls to the Gemini API
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /usr/local/bin
+# Copy ONLY the compiled binary from the builder stage
+COPY --from=builder /usr/src/app/target/release/server .
+
+# Expose the Cloud Run port
+EXPOSE 8080
+
+# Run the binary
+CMD ["./server"]

--- a/server/docs/implementation_plan.md
+++ b/server/docs/implementation_plan.md
@@ -1,0 +1,35 @@
+# Rust Server Proxy Implementation
+
+Implement a Rust-based serverless proxy using Axum to handle Gemini API requests and App Check verification. The server will be located in the `server/` directory at the project root, isolated from the Android Gradle build.
+
+## User Review Required
+
+> [!IMPORTANT]
+> This plan sets up the boilerplate for a Rust server. You will need to provide your Gemini API key and configure Google Cloud Run for final deployment.
+
+## Proposed Changes
+
+### [Server Component]
+
+#### [NEW] [Cargo.toml](file:///Users/developer/AndroidStudioProjects/ProBase/server/Cargo.toml)
+Defines Rust dependencies: `axum`, `tokio`, `serde`, `reqwest`, `jsonwebtoken`.
+
+#### [NEW] [main.rs](file:///Users/developer/AndroidStudioProjects/ProBase/server/src/main.rs)
+Boilerplate Axum server with a health check and a placeholder for Gemini extraction.
+
+#### [NEW] [Dockerfile](file:///Users/developer/AndroidStudioProjects/ProBase/server/Dockerfile)
+Multi-stage Dockerfile for building and running the Rust application in a container.
+
+### [Project Configuration]
+
+#### [MODIFY] [.gitignore](file:///Users/developer/AndroidStudioProjects/ProBase/.gitignore)
+Add `/server/target/` to ignore Rust build artifacts.
+
+## Verification Plan
+
+### Automated Tests
+- None at this stage (boilerplate setup).
+
+### Manual Verification
+- Verify the files are created in the correct locations.
+- The user can later run `cargo build` in the `server/` directory to verify compilation (requires Rust toolchain).

--- a/server/docs/walkthrough.md
+++ b/server/docs/walkthrough.md
@@ -1,0 +1,22 @@
+# Rust Server Setup Walkthrough
+
+I have successfully initialized the Rust server component within your monorepo.
+
+## Changes Made
+
+### Server Component
+- Created [Cargo.toml](file:///Users/developer/AndroidStudioProjects/ProBase/server/Cargo.toml) with necessary dependencies for Axum and Gemini API integration.
+- Implemented [main.rs](file:///Users/developer/AndroidStudioProjects/ProBase/server/src/main.rs) with a boilerplate Axum server, including health check and data extraction routes.
+- Added a multi-stage [Dockerfile](file:///Users/developer/AndroidStudioProjects/ProBase/server/Dockerfile) optimized for Google Cloud Run.
+
+### Project Configuration
+- Updated [.gitignore](file:///Users/developer/AndroidStudioProjects/ProBase/.gitignore) to exclude the Rust `target/` directory, preventing build artifact pollution in your repository.
+
+## Verification Results
+- All files were created in the expected locations: `/Users/developer/AndroidStudioProjects/ProBase/server/`.
+- The `.gitignore` was correctly modified.
+
+## Next Steps
+- **Exclude Directory in IDE**: In Android Studio, right-click the `server` folder and select **Mark Directory as -> Excluded** to prevent the IDE from indexing Rust build files.
+- **Implement Logic**: You can now proceed to implement the App Check verification and Gemini API calls within `main.rs`.
+- **Deployment**: Use the provided `Dockerfile` to build and deploy your container to Google Cloud Run.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,0 +1,42 @@
+use axum::{
+    routing::{get, post},
+    Router,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new()
+        .route("/health", get(health_check))
+        .route("/api/extract", post(extract_vanity_data));
+
+    // 0.0.0.0 is strictly required by Google Cloud Run
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
+    println!("Rust proxy running on port 8080...");
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn health_check() -> &'static str {
+    "Proxy is up and running securely."
+}
+
+#[derive(Deserialize)]
+struct ExtractionRequest {
+    base64_image: String,
+    prompt: String,
+}
+
+#[derive(Serialize)]
+struct ExtractionResponse {
+    status: String,
+    json_payload: String,
+}
+
+async fn extract_vanity_data(Json(_payload): Json<ExtractionRequest>) -> Json<ExtractionResponse> {
+    // TODO: Verify App Check, Inject API Key, Call Gemini
+    Json(ExtractionResponse {
+        status: "success".to_string(),
+        json_payload: "{\"brand\": \"Sample\", \"ingredients\": []}".to_string(),
+    })
+}


### PR DESCRIPTION
This commit introduces a Rust-based server component using the Axum framework to handle proxying requests to the Gemini API and performing App Check verification. The server is configured for isolation from the Android build system and optimized for deployment on Google Cloud Run.

- **Server Implementation**:
    - Created a boilerplate Axum server in `server/src/main.rs` with routes for health checks (`/health`) and data extraction (`/api/extract`).
    - Defined Rust dependencies in `server/Cargo.toml`, including `axum`, `tokio`, `serde`, `reqwest`, and `jsonwebtoken`.
- **Containerization**:
    - Added a multi-stage `Dockerfile` that builds the Rust binary and packages it into a minimal `debian:bookworm-slim` image, including CA certificates for secure HTTPS requests.
- **Documentation**:
    - Added `implementation_plan.md` and `walkthrough.md` to document the proxy architecture, deployment steps, and verification process.
- **Project Configuration**:
    - Updated `.gitignore` to exclude the Rust `target/` build directory.
    - Added the `server/` directory to the excluded roots in `.idea/misc.xml` to prevent IDE indexing of backend build artifacts.