### PR TITLE
refactor: elevate capture state to repository and enhance UI feedback

### DIFF
--- a/applications/kocolor/Docs/BoxCapture/walkthrough_barcode.md
+++ b/applications/kocolor/Docs/BoxCapture/walkthrough_barcode.md
@@ -1,0 +1,44 @@
+# KoColor Product Capture Refactor Walkthrough
+
+This document summarizes the comprehensive refactor of the cosmetic product capture system, shifting from a simple camera interface to an intelligent, multi-modal hybrid extraction pipeline.
+
+## 1. Multi-Modal Capture Paths
+The entry point in `StitchProductBuilder` now supports three distinct capture strategies tailored to the product type:
+
+- **Bar Scan**: Rapid UPC lookup using the local database or Open Beauty Facts (OBF).
+- **Box Scan**: For products with packaging. Includes a dynamic **3 / 7 shot toggle** inside the camera UI to switch between "Quick" (Front, Back, Ingredients) and "Pro" (All 6 sides + ingredients) modes.
+- **No Box**: Optimized for loose containers. Uses a 2-pic AI approach (Front/Back) plus an optional barcode step.
+
+## 2. Hybrid Data Intelligence
+We implemented a "Confidence Threshold" logic that coordinates database lookups and AI analysis:
+
+- **High Confidence**: If OBF returns the Brand, Name, and Ingredients, the AI is bypassed entirely for a rapid "instant add" experience.
+- **Incomplete Hit (The Yellow State)**: If the database identifies the product but lacks ingredients, the app enters **Enrichment Mode**. The "Bar Scan" button turns yellow, and the user is guided to take photos of the ingredients panel.
+- **Contextual Prompting**: The Gemini AI prompt is dynamically augmented with verified database info (e.g., "We already know this is NARS Radiant Creamy Concealer..."), allowing the LLM to focus strictly on Extracting the missing visual data.
+
+## 3. Capture Review & Local OCR
+A new "Review" screen acts as a staging area before final submission:
+
+- **Visual Manifest**: Users can see all captured photos and the scanned barcode.
+- **Local OCR Passes**: The app performs offline text extraction on the ingredients and instructions panels. The raw text is displayed for the user to verify and is passed to Gemini to improve accuracy for complex chemical names.
+- **Photo Management**: Users can delete blurry or incorrect photos directly from the review grid and jump back into the camera to retake them.
+
+## 4. Architectural Robustness (Singleton State)
+To solve lifecycle wipes during the heavy transition from the external Google Barcode Scanner:
+
+- **State Elevation**: Scan statuses (`ANALYZING`, `SUCCESS`, `FAILED`) were moved from the `CosmeticsViewModel` to the `@Singleton` `FashionSessionRepository`.
+- **Race Condition Fix**: This ensures that even if the Android system kills the UI memory while the scanner is open, the lookup results are safely preserved in Application-scoped memory and restored instantly upon return.
+
+## 5. Privacy & Community
+- **Save & Add to Online DB**: A new user-controlled toggle allows users to opt-in to contributing their high-fidelity, AI-verified scans back to the Open Beauty Facts community.
+- **Offline First**: The system remains zero-footprint and purely local by default.
+
+---
+
+### Modified Components:
+
+- [CosmeticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt): Unified state coordination and confidence logic.
+- [FashionSessionRepository.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/FashionSessionRepository.kt): Singleton source of truth for capture sessions.
+- [BoxCaptureViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt): AI prompt orchestration and local OCR management.
+- [BoxCaptureScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt): Multi-step camera UI and review staging.
+- [StitchProductBuilder.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt): Consolidated capture entry points and feedback dialogs.

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/FashionSessionRepository.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/FashionSessionRepository.kt
@@ -9,6 +9,10 @@ import javax.inject.Singleton
 
 @Singleton
 class FashionSessionRepository @Inject constructor() {
+    enum class ScanStatus {
+        IDLE, ANALYZING, SUCCESS, INCOMPLETE, FAILED
+    }
+
     private val _faceUri = MutableStateFlow<String?>(null)
     val faceUri: StateFlow<String?> = _faceUri.asStateFlow()
 
@@ -26,6 +30,9 @@ class FashionSessionRepository @Inject constructor() {
 
     private val _lastScannedCode = MutableStateFlow<String?>(null)
     val lastScannedCode: StateFlow<String?> = _lastScannedCode.asStateFlow()
+
+    private val _scanState = MutableStateFlow(ScanStatus.IDLE)
+    val scanState: StateFlow<ScanStatus> = _scanState.asStateFlow()
 
     private val _location = MutableStateFlow<String?>(null)
     val location: StateFlow<String?> = _location.asStateFlow()
@@ -63,6 +70,11 @@ class FashionSessionRepository @Inject constructor() {
         _lastScannedCode.value = code
     }
 
+    fun setScanState(status: ScanStatus) {
+        Log.d("KoColorSession", "Setting Scan State: $status")
+        _scanState.value = status
+    }
+
     fun setCosmeticDraft(item: com.zoewave.probase.core.model.ritual.CosmeticItem?) {
         Log.d("KoColorSession", "Setting Cosmetic Draft: ${item?.name}")
         _cosmeticDraft.value = item
@@ -75,6 +87,8 @@ class FashionSessionRepository @Inject constructor() {
         _shoesUri.value = null
         _clothesUri.value = null
         _capturedItemUri.value = null
+        _lastScannedCode.value = null
         _cosmeticDraft.value = null
+        _scanState.value = ScanStatus.IDLE
     }
 }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
@@ -53,7 +53,6 @@ data class CosmeticsUiState(
     val filteredItems: List<CosmeticItem> = emptyList(),
     val isLoading: Boolean = true,
     val capturedImageUri: String? = null,
-    val isAnalyzing: Boolean = false,
     val aiResult: CosmeticItem? = null,
     val draftItem: CosmeticItem = CosmeticItem(
         name = "", 
@@ -69,13 +68,15 @@ data class CosmeticsUiState(
     val categoriesMetadata: Map<String, CategoryMetadata> = emptyMap(),
     val categoryFilter: String? = null,
     val scanStatus: String? = null,
-    val isScanSuccessful: Boolean = false,
-    val isScanIncomplete: Boolean = false,
-    val lastScanFailed: Boolean = false,
+    val scanState: FashionSessionRepository.ScanStatus = FashionSessionRepository.ScanStatus.IDLE,
     val isObfContributionEnabled: Boolean = false,
     val uvIndex: Double = 0.0
 ) {
     val canContributeToObf: Boolean get() = !draftItem.batchCode.isNullOrBlank()
+    val isScanSuccessful: Boolean get() = scanState == FashionSessionRepository.ScanStatus.SUCCESS
+    val isScanIncomplete: Boolean get() = scanState == FashionSessionRepository.ScanStatus.INCOMPLETE
+    val lastScanFailed: Boolean get() = scanState == FashionSessionRepository.ScanStatus.FAILED
+    val isAnalyzing: Boolean get() = scanState == FashionSessionRepository.ScanStatus.ANALYZING
 }
 
 sealed class CosmeticsEvent {
@@ -108,16 +109,12 @@ class CosmeticsViewModel @Inject constructor(
     private val aiSettings: AiConfigurationSettings
 ) : ViewModel() {
 
-    private val _isAnalyzing = MutableStateFlow(false)
     private val _aiResult = MutableStateFlow<CosmeticItem?>(null)
     private val _searchQuery = MutableStateFlow("")
     private val _sortOption = MutableStateFlow(SortOption.NEWEST)
     private val _categoryFilter = MutableStateFlow<String?>(null)
     private val _scanStatus = MutableStateFlow<String?>(null)
-    private val _isScanSuccessful = MutableStateFlow(false)
-    private val _isScanIncomplete = MutableStateFlow(false)
     private val _isObfContributionEnabled = MutableStateFlow(false)
-    private val _lastScanFailed = MutableStateFlow(false)
     private val _uvIndex = MutableStateFlow(0.0)
 
     init {
@@ -155,32 +152,26 @@ class CosmeticsViewModel @Inject constructor(
 
     val uiState: StateFlow<CosmeticsUiState> = combine(
         cosmeticRepository.getAllCosmetics(),
-        _isAnalyzing,
         _aiResult,
         sessionRepository.cosmeticDraft.filterNotNull(),
+        sessionRepository.scanState,
         _searchQuery,
         _sortOption,
         _categoryFilter,
         _scanStatus,
-        _isScanSuccessful,
-        _isScanIncomplete,
         _isObfContributionEnabled,
-        _lastScanFailed,
         _uvIndex
     ) { array ->
         val models = array[0] as List<CosmeticItem>
-        val analyzing = array[1] as Boolean
-        val aiResult = array[2] as CosmeticItem?
-        val draft = array[3] as CosmeticItem
+        val aiResult = array[1] as CosmeticItem?
+        val draft = array[2] as CosmeticItem
+        val scanState = array[3] as FashionSessionRepository.ScanStatus
         val query = array[4] as String
         val sort = array[5] as SortOption
         val filter = array[6] as String?
         val scanStatus = array[7] as String?
-        val scanSuccessful = array[8] as Boolean
-        val scanIncomplete = array[9] as Boolean
-        val contributionEnabled = array[10] as Boolean
-        val scanFailed = array[11] as Boolean
-        val uvVal = array[12] as Double
+        val contributionEnabled = array[8] as Boolean
+        val uvVal = array[9] as Double
 
         val groupStats = models.groupBy { it.macroCategory.displayName }.mapValues { it.value.size }
         
@@ -229,7 +220,6 @@ class CosmeticsViewModel @Inject constructor(
             filteredItems = filtered,
             isLoading = false,
             capturedImageUri = draft.imageUrl,
-            isAnalyzing = analyzing,
             aiResult = aiResult,
             draftItem = draft,
             searchQuery = query,
@@ -240,10 +230,8 @@ class CosmeticsViewModel @Inject constructor(
             categoriesMetadata = categoryMetadata,
             categoryFilter = filter,
             scanStatus = scanStatus,
-            isScanSuccessful = scanSuccessful,
-            isScanIncomplete = scanIncomplete,
+            scanState = scanState,
             isObfContributionEnabled = contributionEnabled,
-            lastScanFailed = scanFailed,
             uvIndex = uvVal
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, CosmeticsUiState())
@@ -258,9 +246,6 @@ class CosmeticsViewModel @Inject constructor(
                 }
 
                 sessionRepository.reset()
-                _isScanSuccessful.value = false
-                _isScanIncomplete.value = false
-                _lastScanFailed.value = false
                 _scanStatus.value = null
             }
             is CosmeticsEvent.UpdateItem -> updateItem(event.item)
@@ -294,7 +279,7 @@ class CosmeticsViewModel @Inject constructor(
                              currentDraft.imageUrl == null && 
                              currentDraft.batchCode == null)
                 
-                if (!isEmpty || _isAnalyzing.value || _isScanSuccessful.value) return
+                if (!isEmpty || sessionRepository.scanState.value == FashionSessionRepository.ScanStatus.ANALYZING || sessionRepository.scanState.value == FashionSessionRepository.ScanStatus.SUCCESS) return
                 
                 val macro = MacroCategory.entries.firstOrNull { 
                     it.displayName.contains(event.categoryFilter ?: "", ignoreCase = true) 
@@ -319,16 +304,11 @@ class CosmeticsViewModel @Inject constructor(
                 _isObfContributionEnabled.value = event.enabled
             }
             CosmeticsEvent.ResetScanState -> {
-                _isScanSuccessful.value = false
-                _isScanIncomplete.value = false
-                _lastScanFailed.value = false
+                sessionRepository.setScanState(FashionSessionRepository.ScanStatus.IDLE)
                 _scanStatus.value = null
             }
             CosmeticsEvent.CancelDiscovery -> {
                 sessionRepository.reset()
-                _isScanSuccessful.value = false
-                _isScanIncomplete.value = false
-                _lastScanFailed.value = false
                 _scanStatus.value = null
             }
         }
@@ -348,10 +328,8 @@ class CosmeticsViewModel @Inject constructor(
 
     private fun fetchObfProduct(code: String) {
         viewModelScope.launch {
-            _isAnalyzing.value = true
+            sessionRepository.setScanState(FashionSessionRepository.ScanStatus.ANALYZING)
             _scanStatus.value = context.getString(R.string.applications_kocolor_features_cosmetics_searching_obf)
-            _lastScanFailed.value = false
-            _isScanIncomplete.value = false
             
             updateSessionDraft { it.copy(batchCode = code) }
             
@@ -410,16 +388,15 @@ class CosmeticsViewModel @Inject constructor(
                 val isComplete = hasIngredients && obfItem.name.isNotBlank() && obfItem.brand.isNotBlank()
 
                 if (isComplete) {
-                    _isScanSuccessful.value = true
+                    sessionRepository.setScanState(FashionSessionRepository.ScanStatus.SUCCESS)
                 } else {
-                    _isScanIncomplete.value = true
+                    sessionRepository.setScanState(FashionSessionRepository.ScanStatus.INCOMPLETE)
                     _scanStatus.value = "Incomplete data. Scan box to enrich."
                 }
             }.onFailure {
                 _scanStatus.value = context.getString(R.string.applications_kocolor_features_cosmetics_product_not_found_obf)
-                _lastScanFailed.value = true
+                sessionRepository.setScanState(FashionSessionRepository.ScanStatus.FAILED)
             }
-            _isAnalyzing.value = false
             
             delay(3000)
             _scanStatus.value = null
@@ -447,7 +424,7 @@ class CosmeticsViewModel @Inject constructor(
     private fun scanWithGemini() {
         val uri = sessionRepository.cosmeticDraft.value?.imageUrl ?: return
         viewModelScope.launch {
-            _isAnalyzing.value = true
+            sessionRepository.setScanState(FashionSessionRepository.ScanStatus.ANALYZING)
             _aiResult.value = null
             
             val apiKey = aiSettings.getGeminiApiKey()
@@ -479,10 +456,14 @@ class CosmeticsViewModel @Inject constructor(
                                 finish = if (aiItem.finish != Finish.UNKNOWN) aiItem.finish else current.finish
                             )
                         }
+                        sessionRepository.setScanState(FashionSessionRepository.ScanStatus.SUCCESS)
+                    } ?: run {
+                        sessionRepository.setScanState(FashionSessionRepository.ScanStatus.FAILED)
                     }
                 }
+            } else {
+                sessionRepository.setScanState(FashionSessionRepository.ScanStatus.IDLE)
             }
-            _isAnalyzing.value = false
         }
     }
 

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
@@ -4,20 +4,63 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -28,7 +71,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import com.zoewave.probase.core.model.ritual.*
+import com.zoewave.probase.core.model.ritual.ChemistryBase
+import com.zoewave.probase.core.model.ritual.CosmeticItem
+import com.zoewave.probase.core.model.ritual.Coverage
+import com.zoewave.probase.core.model.ritual.Finish
+import com.zoewave.probase.core.model.ritual.Formulation
+import com.zoewave.probase.core.model.ritual.MacroCategory
+import com.zoewave.probase.core.model.ritual.MicroCategory
 import com.zoewave.probase.features.graphics.colorpicker.ui.ColorPickerDialog
 import com.zoewave.probase.features.graphics.colorpicker.util.isColorDark
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
@@ -178,6 +227,20 @@ fun StitchProductBuilder(
         )
     }
 
+    if (uiState.lastScanFailed) {
+        AlertDialog(
+            onDismissRequest = { onEvent(CosmeticsEvent.ResetScanState) },
+            confirmButton = {
+                TextButton(onClick = { onEvent(CosmeticsEvent.ResetScanState) }) {
+                    Text(stringResource(R.string.applications_kocolor_features_cosmetics_ok), fontWeight = FontWeight.Bold)
+                }
+            },
+            title = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_product_not_found_title)) },
+            text = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_product_not_found_message)) },
+            shape = RoundedCornerShape(24.dp)
+        )
+    }
+
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -253,6 +316,35 @@ fun StitchProductBuilder(
                             Text(stringResource(R.string.applications_kocolor_features_cosmetics_add_product_image), style = MaterialTheme.typography.labelSmall, color = Color.Gray)
                         }
                     }
+
+                    // --- Scan Status Overlay ---
+                    uiState.scanStatus?.let { status ->
+                        Surface(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(16.dp),
+                            color = Color.Black.copy(alpha = 0.7f),
+                            shape = RoundedCornerShape(20.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                if (uiState.isAnalyzing) {
+                                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = Color.White)
+                                } else {
+                                    Icon(
+                                        imageVector = if (uiState.lastScanFailed) Icons.Default.ErrorOutline else Icons.Default.Info,
+                                        contentDescription = null,
+                                        tint = if (uiState.lastScanFailed) Color.Red else Color(0xFF22d3ee),
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                }
+                                Text(status, color = Color.White, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+                            }
+                        }
+                    }
                 }
             }
 
@@ -266,6 +358,7 @@ fun StitchProductBuilder(
                 CaptureButton(
                     title = "Bar Scan",
                     subtitle = when {
+                        uiState.isAnalyzing -> "Analyzing..."
                         uiState.lastScanFailed -> "Not Found"
                         uiState.isScanIncomplete -> "Enrich Data"
                         else -> "Scan UPC"
@@ -274,10 +367,15 @@ fun StitchProductBuilder(
                     color = when {
                         uiState.lastScanFailed -> Color(0xFFEF4444) // Red
                         uiState.isScanIncomplete -> Color(0xFFF59E0B) // Yellow/Amber
+                        uiState.isAnalyzing -> Color(0xFF22d3ee) // Cyan
                         else -> Color(0xFF6B7280) // Gray
                     },
-                    onClick = { navTo(KoColorRoute.BarcodeScanner) },
-                    modifier = Modifier.weight(1f)
+                    onClick = { 
+                        onEvent(CosmeticsEvent.ResetScanState)
+                        navTo(KoColorRoute.BarcodeScanner) 
+                    },
+                    modifier = Modifier.weight(1f),
+                    isLoading = uiState.isAnalyzing
                 )
                 CaptureButton(
                     title = "Box Scan",
@@ -568,7 +666,8 @@ private fun CaptureButton(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     color: Color,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false
 ) {
     Surface(
         onClick = onClick,
@@ -580,7 +679,11 @@ private fun CaptureButton(
         Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Surface(shape = CircleShape, color = color, modifier = Modifier.size(32.dp)) {
                 Box(contentAlignment = Alignment.Center) {
-                    Icon(icon, null, tint = if (isColorDark(color)) Color.White else Color.Black, modifier = Modifier.size(16.dp))
+                    if (isLoading) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = Color.White)
+                    } else {
+                        Icon(icon, null, tint = if (isColorDark(color)) Color.White else Color.Black, modifier = Modifier.size(16.dp))
+                    }
                 }
             }
             Column {


### PR DESCRIPTION
This commit refactors the cosmetic product capture system by moving scan status logic to a singleton repository to ensure state persistence across lifecycle events and provides enhanced visual feedback during the scanning process.

- **State Management**:
    - Introduced a `ScanStatus` enum (`IDLE`, `ANALYZING`, `SUCCESS`, `INCOMPLETE`, `FAILED`) in `FashionSessionRepository`.
    - Elevated scan state from `CosmeticsViewModel` to `FashionSessionRepository` to prevent state loss during external scanner transitions.
    - Updated `CosmeticsViewModel` to derive UI state directly from the repository's scan status.

- **UI Enhancements in StitchProductBuilder**:
    - Added a dynamic scan status overlay on the product image container, featuring a `CircularProgressIndicator` during analysis and status icons for results.
    - Enhanced "Bar Scan" button with state-aware subtitles (e.g., "Analyzing...", "Enrich Data", "Not Found") and color-coding (Cyan, Amber, Red).
    - Implemented a failure alert dialog to notify users when a product lookup fails.
    - Integrated a loading indicator directly into the `CaptureButton` icon slot.

- **Documentation**:
    - Added `walkthrough_barcode.md` detailing the multi-modal capture paths (Bar, Box, No Box), hybrid data intelligence logic, and local OCR capabilities.

- **Code Cleanup**:
    - Refactored `StitchProductBuilder.kt` to use specific imports instead of wildcard imports.
    - Simplified `CosmeticsUiState` by replacing multiple boolean flags with a single `scanState` source of truth.