### PR TITLE
feat: implement color palette extraction and selection in BoxCapture

### DIFF
--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/data/LocalProductAnalyzer.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/data/LocalProductAnalyzer.kt
@@ -36,39 +36,51 @@ class LocalProductAnalyzer @Inject constructor() {
     }
 
     /**
-     * Extracts the dominant color from the center of the bitmap.
-     * Useful for giving a "guess" during the Product Color step.
+     * Extracts a palette of dominant colors from the bitmap.
+     * Samples different regions to give the user better options.
      */
-    fun extractDominantColor(bitmap: Bitmap): String {
-        val centerX = bitmap.width / 2
-        val centerY = bitmap.height / 2
-        val radius = (bitmap.width * 0.1f).toInt().coerceAtLeast(10)
+    fun extractColorPalette(bitmap: Bitmap): List<String> {
+        val width = bitmap.width
+        val height = bitmap.height
+        
+        // Sample points: Center, Center-Top, Center-Bottom, Left-Mid, Right-Mid
+        val points = listOf(
+            Pair(width / 2, height / 2),
+            Pair(width / 2, height / 3),
+            Pair(width / 2, (height * 2) / 3),
+            Pair(width / 3, height / 2),
+            Pair((width * 2) / 3, height / 2)
+        )
 
-        // Sample a small 20x20 area in the center
-        var rTotal = 0L
-        var gTotal = 0L
-        var bTotal = 0L
-        var count = 0
+        val palette = mutableSetOf<String>()
+        val radius = (width * 0.05f).toInt().coerceAtLeast(5)
 
-        for (x in (centerX - radius)..(centerX + radius)) {
-            for (y in (centerY - radius)..(centerY + radius)) {
-                if (x in 0 until bitmap.width && y in 0 until bitmap.height) {
-                    val pixel = bitmap.getPixel(x, y)
-                    rTotal += android.graphics.Color.red(pixel)
-                    gTotal += android.graphics.Color.green(pixel)
-                    bTotal += android.graphics.Color.blue(pixel)
-                    count++
+        for (point in points) {
+            val (centerX, centerY) = point
+            var rTotal = 0L
+            var gTotal = 0L
+            var bTotal = 0L
+            var count = 0
+
+            for (x in (centerX - radius)..(centerX + radius)) {
+                for (y in (centerY - radius)..(centerY + radius)) {
+                    if (x in 0 until width && y in 0 until height) {
+                        val pixel = bitmap.getPixel(x, y)
+                        rTotal += android.graphics.Color.red(pixel)
+                        gTotal += android.graphics.Color.green(pixel)
+                        bTotal += android.graphics.Color.blue(pixel)
+                        count++
+                    }
                 }
+            }
+
+            if (count > 0) {
+                val hex = String.format("#%02X%02X%02X", (rTotal / count).toInt(), (gTotal / count).toInt(), (bTotal / count).toInt())
+                palette.add(hex)
             }
         }
 
-        if (count == 0) return "#808080"
-
-        val r = (rTotal / count).toInt()
-        val g = (gTotal / count).toInt()
-        val b = (bTotal / count).toInt()
-
-        return String.format("#%02X%02X%02X", r, g, b)
+        return palette.toList().take(5)
     }
 
     private fun heuristicGuess(text: String): CosmeticItem {

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
@@ -202,7 +202,8 @@ internal fun BoxCaptureScreen(
                     ColorConfirmationView(
                         uiState = ColorConfirmationViewUiState(
                             photoUri = uiState.capturedUris.last { it.isNotBlank() },
-                            suggestedColorHex = uiState.suggestedColorHex
+                            suggestedColors = uiState.suggestedColors,
+                            selectedColorHex = uiState.selectedColorHex
                         ),
                         onEvent = onEvent
                     )
@@ -740,7 +741,8 @@ private fun OcrTextArea(text: String) {
 
 data class ColorConfirmationViewUiState(
     val photoUri: String,
-    val suggestedColorHex: String
+    val suggestedColors: List<String>,
+    val selectedColorHex: String
 )
 
 @Composable
@@ -752,7 +754,7 @@ private fun ColorConfirmationView(
 
     if (showColorPicker) {
         ColorPickerDialog(
-            initialColor = parseColor(uiState.suggestedColorHex),
+            initialColor = parseColor(uiState.selectedColorHex),
             onColorSelected = { 
                 onEvent(BoxCaptureEvent.OnColorSelected(it.toHex())) 
                 showColorPicker = false
@@ -777,7 +779,7 @@ private fun ColorConfirmationView(
             fontWeight = FontWeight.Bold
         )
         Text(
-            text = "Dominant shade detected from photo",
+            text = "Select the best shade from the photo",
             color = Color.White.copy(alpha = 0.6f),
             style = MaterialTheme.typography.bodySmall
         )
@@ -797,9 +799,9 @@ private fun ColorConfirmationView(
                 contentScale = ContentScale.Crop
             )
             
-            // Color Circle Overlay
+            // Selected Color Circle Overlay
             Surface(
-                color = parseColor(uiState.suggestedColorHex),
+                color = parseColor(uiState.selectedColorHex),
                 shape = CircleShape,
                 modifier = Modifier
                     .align(Alignment.Center)
@@ -809,7 +811,32 @@ private fun ColorConfirmationView(
             ) {}
         }
 
-        Spacer(Modifier.height(48.dp))
+        Spacer(Modifier.height(32.dp))
+
+        // Color Options Palette
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth().height(60.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp)
+        ) {
+            itemsIndexed(uiState.suggestedColors) { _, hex ->
+                val isSelected = hex == uiState.selectedColorHex
+                Surface(
+                    onClick = { onEvent(BoxCaptureEvent.OnColorSelected(hex)) },
+                    color = parseColor(hex),
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier
+                        .size(50.dp)
+                        .border(
+                            width = if (isSelected) 2.dp else 1.dp,
+                            color = if (isSelected) Color.White else Color.White.copy(alpha = 0.2f),
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                ) {}
+            }
+        }
+
+        Spacer(Modifier.height(32.dp))
 
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -126,14 +126,14 @@ class BoxCaptureViewModel @Inject constructor(
                     _uiState.value = current.copy(extractedColorHex = event.hex)
                 } else if (uiState.value is BoxCaptureUiState.ColorConfirmation) {
                     val cc = uiState.value as BoxCaptureUiState.ColorConfirmation
-                    _uiState.value = cc.copy(suggestedColorHex = event.hex)
+                    _uiState.value = cc.copy(selectedColorHex = event.hex)
                 }
             }
             BoxCaptureEvent.ConfirmColor -> {
                 val current = (uiState.value as? BoxCaptureUiState.ColorConfirmation) ?: return
                 val nextStep = getNextStep(current.mode)
                 if (nextStep != null) {
-                    _uiState.value = BoxCaptureUiState.Idle(current.capturedUris, nextStep, current.mode, current.suggestedColorHex)
+                    _uiState.value = BoxCaptureUiState.Idle(current.capturedUris, nextStep, current.mode, current.selectedColorHex)
                 } else {
                     prepareReview(current.mode)
                 }
@@ -208,13 +208,14 @@ class BoxCaptureViewModel @Inject constructor(
         val mode = current.mode
         
         if (current.currentStep == CaptureStep.COLOR) {
-            // Auto-extract color from the photo
+            // Auto-extract color palette from the photo
             viewModelScope.launch {
                 val bitmap = loadBitmapFromUri(Uri.parse(uri))
-                val colorHex = if (bitmap != null) localAnalyzer.extractDominantColor(bitmap) else "#808080"
+                val suggestedColors = if (bitmap != null) localAnalyzer.extractColorPalette(bitmap) else listOf("#808080")
                 _uiState.value = BoxCaptureUiState.ColorConfirmation(
                     capturedUris = capturedUris.toList(),
-                    suggestedColorHex = colorHex,
+                    suggestedColors = suggestedColors,
+                    selectedColorHex = suggestedColors.firstOrNull() ?: "#808080",
                     mode = mode
                 )
             }
@@ -272,7 +273,6 @@ class BoxCaptureViewModel @Inject constructor(
             val steps = CaptureStep.getStepsForMode(mode)
             val ingredientsIdx = steps.indexOf(CaptureStep.INGREDIENTS)
             val instructionsIdx = steps.indexOf(CaptureStep.INSTRUCTIONS)
-            val colorIdx = steps.indexOf(CaptureStep.COLOR)
 
             localIngredientsOcr = if (ingredientsIdx != -1 && ingredientsIdx in capturedUris.indices) {
                 val uri = capturedUris[ingredientsIdx]
@@ -351,7 +351,7 @@ class BoxCaptureViewModel @Inject constructor(
                         CaptureMode.PRODUCT -> "product container (front and back)"
                     }
                     val barcodeContext = if (!scannedBarcode.isNullOrBlank()) "The scanned barcode is: $scannedBarcode." else ""
-                    val colorContext = if (!manualColor.isNullOrBlank()) "The user-selected product color is: $manualColor." else "Please identify the best representative color for this product from the photos."
+                    val colorContext = if (!manualColor.isNullOrBlank()) "The confirmed hex color code is: $manualColor." else "Analyze the photos and estimate the most accurate hex code of the actual makeup shade."
                     
                     val enrichmentContext = obfEnrichmentData?.let {
                         """
@@ -367,6 +367,7 @@ class BoxCaptureViewModel @Inject constructor(
                     val instructionsContext = if (localInstructionsOcr.isNotBlank()) "LOCAL OCR EXTRACTED TEXT FROM INSTRUCTIONS/BACK PANEL:\n$localInstructionsOcr\n---" else ""
                     
                     text("""
+                        You are a professional cosmetic analyzer for the "KoColor Boutique" app. 
                         Analyze these photos of a $target. $barcodeContext
                         $enrichmentContext
                         $colorContext
@@ -401,7 +402,7 @@ class BoxCaptureViewModel @Inject constructor(
                             "fdaClinicalWarnings": ["Warning 1", "..."],
                             "fdaActiveIngredients": ["Active 1", "..."]
                         }
-                        Be extremely precise. If a field is unknown, use null.
+                        Be extremely precise, especially with the colorHex code. If a field is unknown, use null.
                     """.trimIndent())
                 }
 

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/state/BoxCaptureUiState.kt
@@ -17,7 +17,8 @@ sealed interface BoxCaptureUiState {
 
     data class ColorConfirmation(
         val capturedUris: List<String>,
-        val suggestedColorHex: String,
+        val suggestedColors: List<String>,
+        val selectedColorHex: String,
         val mode: CaptureMode
     ) : BoxCaptureUiState
 


### PR DESCRIPTION
This commit enhances the product color detection process by replacing single-point extraction with a multi-region palette sampling method. Users can now choose from several suggested colors instead of relying on a single automated guess.

- **Color Analysis**:
    - Refactored `LocalProductAnalyzer` to replace `extractDominantColor` with `extractColorPalette`.
    - Implemented a multi-point sampling strategy (Center, Top, Bottom, Left, Right) to generate a palette of up to 5 unique hex colors.
- **UI Enhancements**:
    - Updated `ColorConfirmationView` to display a horizontal scrollable list (`LazyRow`) of suggested colors.
    - Added visual feedback for the selected color using a border highlight and a central preview overlay.
    - Updated UI strings to guide users to "Select the best shade" rather than just showing a detected one.
- **State & ViewModel Logic**:
    - Updated `BoxCaptureUiState` to store a list of `suggestedColors` and a single `selectedColorHex`.
    - Modified `BoxCaptureViewModel` to trigger palette extraction after photo capture and default the selection to the first sampled color.
- **AI Prompt Refinement**:
    - Updated the LLM analysis prompt to emphasize the importance of the user-confirmed hex code.
    - Added a professional persona description to the analyzer prompt for more consistent results.