### PR TITLE
Ko color scan

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,6 +6,7 @@
       <file path="$PROJECT_DIR$/applications/gotmind/features/memblox/docs" />
       <file path="$PROJECT_DIR$/applications/kocolor/Docs" />
       <file path="$PROJECT_DIR$/applications/kocolor/Site" />
+      <file path="$PROJECT_DIR$/applications/kocolor/features/boxcapture/docs" />
       <file path="$PROJECT_DIR$/applications/kocolor/images" />
       <file path="$PROJECT_DIR$/applications/rxlogic/docs" />
       <file path="$PROJECT_DIR$/features/health/docs" />

--- a/applications/kocolor/Docs/BoxCapture/walkthrough_color_capture.md
+++ b/applications/kocolor/Docs/BoxCapture/walkthrough_color_capture.md
@@ -1,0 +1,44 @@
+# KoColor Product Capture Refactor Walkthrough
+
+This document summarizes the comprehensive refactor of the cosmetic product capture system, shifting from a simple camera interface to an intelligent, multi-modal hybrid extraction pipeline.
+
+## 1. Multi-Modal Capture Paths
+The entry point in `StitchProductBuilder` now supports three distinct capture strategies tailored to the product type:
+
+- **Bar Scan**: Rapid UPC lookup using the local database or Open Beauty Facts (OBF).
+- **Box Scan**: For products with packaging. Includes a dynamic **3 / 7 shot toggle** inside the camera UI to switch between "Quick" (Front, Back, Ingredients) and "Pro" (All 6 sides + ingredients) modes.
+- **No Box**: Optimized for loose containers. Uses a 2-pic AI approach (Front/Back) plus an optional barcode step.
+
+## 2. Hybrid Data Intelligence
+We implemented a "Confidence Threshold" logic that coordinates database lookups and AI analysis:
+
+- **High Confidence**: If OBF returns the Brand, Name, and Ingredients, the AI is bypassed entirely for a rapid "instant add" experience.
+- **Incomplete Hit (The Yellow State)**: If the database identifies the product but lacks ingredients, the app enters **Enrichment Mode**. The "Bar Scan" button turns yellow, and the user is guided to take photos of the ingredients panel.
+- **Contextual Prompting**: The Gemini AI prompt is dynamically augmented with verified database info (e.g., "We already know this is NARS Radiant Creamy Concealer..."), allowing the LLM to focus strictly on Extracting the missing visual data.
+
+## 3. Capture Review & Local OCR
+A new "Review" screen acts as a staging area before final submission:
+
+- **Visual Manifest**: Users can see all captured photos and the scanned barcode.
+- **Local OCR Passes**: The app performs offline text extraction on the ingredients and instructions panels. The raw text is displayed for the user to verify and is passed to Gemini to improve accuracy for complex chemical names.
+- **Photo Management**: Users can delete blurry or incorrect photos directly from the review grid and jump back into the camera to retake them.
+
+## 4. Architectural Robustness (Singleton State)
+To solve lifecycle wipes during the heavy transition from the external Google Barcode Scanner:
+
+- **State Elevation**: Scan statuses (`ANALYZING`, `SUCCESS`, `FAILED`) were moved from the `CosmeticsViewModel` to the `@Singleton` `FashionSessionRepository`.
+- **Race Condition Fix**: This ensures that even if the Android system kills the UI memory while the scanner is open, the lookup results are safely preserved in Application-scoped memory and restored instantly upon return.
+
+## 5. Privacy & Community
+- **Save & Add to Online DB**: A new user-controlled toggle allows users to opt-in to contributing their high-fidelity, AI-verified scans back to the Open Beauty Facts community.
+- **Offline First**: The system remains zero-footprint and purely local by default.
+
+---
+
+### Modified Components:
+
+- [CosmeticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt): Unified state coordination and confidence logic.
+- [FashionSessionRepository.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/FashionSessionRepository.kt): Singleton source of truth for capture sessions.
+- [BoxCaptureViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt): AI prompt orchestration and local OCR management.
+- [BoxCaptureScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt): Multi-step camera UI and review staging.
+- [StitchProductBuilder.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt): Consolidated capture entry points and feedback dialogs.

--- a/applications/kocolor/Docs/BoxCapture/walkthrough_color_capture.md
+++ b/applications/kocolor/Docs/BoxCapture/walkthrough_color_capture.md
@@ -32,6 +32,52 @@ To solve lifecycle wipes during the heavy transition from the external Google Ba
 ## 5. Privacy & Community
 - **Save & Add to Online DB**: A new user-controlled toggle allows users to opt-in to contributing their high-fidelity, AI-verified scans back to the Open Beauty Facts community.
 - **Offline First**: The system remains zero-footprint and purely local by default.
+# KoColor Product Capture Refactor Walkthrough
+
+This document summarizes the comprehensive refactor of the cosmetic product capture system, shifting from a simple camera interface to an intelligent, multi-modal hybrid extraction pipeline.
+
+## 1. Multi-Modal Capture Paths
+The entry point in `StitchProductBuilder` now supports three distinct capture strategies tailored to the product type:
+
+- **Bar Scan**: Rapid UPC lookup using the local database or Open Beauty Facts (OBF).
+- **Box Scan**: For products with packaging. Includes a dynamic **3 / 7 shot toggle** inside the camera UI to switch between "Quick" (Front, Back, Ingredients) and "Pro" (All 6 sides + ingredients) modes.
+- **No Box**: Optimized for loose containers. Uses a 2-pic AI approach (Front/Back) plus an optional barcode step.
+
+## 2. Hybrid Data Intelligence
+We implemented a "Confidence Threshold" logic that coordinates database lookups and AI analysis:
+
+- **High Confidence**: If OBF returns the Brand, Name, and Ingredients, the AI is bypassed entirely for a rapid "instant add" experience.
+- **Incomplete Hit (The Yellow State)**: If the database identifies the product but lacks ingredients, the app enters **Enrichment Mode**. The "Bar Scan" button turns yellow, and the user is guided to take photos of the ingredients panel.
+- **Contextual Prompting**: The Gemini AI prompt is dynamically augmented with verified database info (e.g., "We already know this is NARS Radiant Creamy Concealer..."), allowing the LLM to focus strictly on Extracting the missing visual data.
+
+## 3. Capture Review & Local OCR
+A new "Review" screen acts as a staging area before final submission:
+
+- **Visual Manifest**: Users can see all captured photos and the scanned barcode.
+- **Local OCR Passes**: The app performs offline text extraction on the ingredients and instructions panels. The raw text is displayed for the user to verify and is passed to Gemini to improve accuracy for complex chemical names.
+- **Photo Management**: Users can delete blurry or incorrect photos directly from the review grid and jump back into the camera to retake them.
+
+## 4. Architectural Robustness (Singleton State)
+To solve lifecycle wipes during the heavy transition from the external Google Barcode Scanner:
+
+- **State Elevation**: Scan statuses (`ANALYZING`, `SUCCESS`, `FAILED`) were moved from the `CosmeticsViewModel` to the `@Singleton` `FashionSessionRepository`.
+- **Race Condition Fix**: This ensures that even if the Android system kills the UI memory while the scanner is open, the lookup results are safely preserved in Application-scoped memory and restored instantly upon return.
+
+## 5. Privacy & Community
+- **Save & Add to Online DB**: A new user-controlled toggle allows users to opt-in to contributing their high-fidelity, AI-verified scans back to the Open Beauty Facts community.
+- **Offline First**: The system remains zero-footprint and purely local by default.
+
+
+
+---
+
+### Modified Components:
+
+- [CosmeticsViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt): Unified state coordination and confidence logic.
+- [FashionSessionRepository.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/FashionSessionRepository.kt): Singleton source of truth for capture sessions.
+- [BoxCaptureViewModel.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt): AI prompt orchestration and local OCR management.
+- [BoxCaptureScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt): Multi-step camera UI and review staging.
+- [StitchProductBuilder.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt): Consolidated capture entry points and feedback dialogs.
 
 ---
 

--- a/applications/kocolor/Docs/BoxCapture/walkthrough_color_capture.md
+++ b/applications/kocolor/Docs/BoxCapture/walkthrough_color_capture.md
@@ -68,6 +68,12 @@ To solve lifecycle wipes during the heavy transition from the external Google Ba
 - **Offline First**: The system remains zero-footprint and purely local by default.
 
 
+## 6. AI-Driven Color Calibration**
+To combat inaccurate color sampling caused by environmental lighting and shadows, the color extraction pipeline has been shifted from a deterministic to a probabilistic model:
+
+- **Guided Sampling:** The manual UI color picker (sampling reticle) now functions strictly as a "User Color Hint" rather than a hardcoded truth.
+- **The Discrepancy Rule:** The system utilizes Gemini's crossmodal reasoning to evaluate the user's color hint against the physical packaging and embedded industry knowledge. If a discrepancy is detected (e.g., the reticle sampled a shadow), the AI overrides the user input and returns the true, accurate cosmetic hex code.
+- **Consistent Persona:** The LLM is anchored as a "Professional Cosmetic Analyzer" to prioritize technical accuracy over simply validating the user's manual input.
 
 ---
 

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/CosmeticMapper.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/CosmeticMapper.kt
@@ -55,6 +55,34 @@ fun CosmeticItemEntity.toModel(): CosmeticItem = CosmeticItem(
     isFdaChecked = isFdaChecked
 )
 
+/**
+ * Maps the rich [CosmeticItem] model to a flat payload suitable for 
+ * uploading to the Open Beauty Facts (OBF) community database.
+ */
+fun CosmeticItem.toObfPayload(): Map<String, String> {
+    return mutableMapOf<String, String>().apply {
+        put("product_name", name)
+        put("brands", brand)
+        put("barcode", batchCode ?: "")
+        put("ingredients_text", ingredients.joinToString(", "))
+        put("quantity", volume ?: "")
+        put("categories", "${macroCategory.displayName}, ${microCategory.displayName}")
+        
+        // Technical facets flattened back to readable tags
+        val tags = mutableListOf<String>()
+        if (formulation != com.zoewave.probase.core.model.ritual.Formulation.UNKNOWN) tags.add(formulation.name.lowercase())
+        if (finish != com.zoewave.probase.core.model.ritual.Finish.UNKNOWN) tags.add(finish.name.lowercase())
+        if (chemistryBase != com.zoewave.probase.core.model.ritual.ChemistryBase.UNKNOWN) tags.add(chemistryBase.name.lowercase())
+        
+        if (tags.isNotEmpty()) {
+            put("labels", tags.joinToString(", "))
+        }
+
+        if (isVegan == true) put("labels", (get("labels")?.let { "$it, " } ?: "") + "vegan")
+        if (isCrueltyFree == true) put("labels", (get("labels")?.let { "$it, " } ?: "") + "cruelty-free")
+    }
+}
+
 fun CosmeticItem.toEntity(): CosmeticItemEntity = CosmeticItemEntity(
     id = id,
     name = name,

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/CosmeticDao.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/CosmeticDao.kt
@@ -5,6 +5,7 @@ import androidx.room3.Insert
 import androidx.room3.OnConflictStrategy
 import androidx.room3.Query
 import androidx.room3.Update
+import com.zoewave.probase.core.model.ritual.MicroCategory
 import com.zoewave.probase.kocolor.db.entity.CosmeticItemEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -21,7 +22,7 @@ interface CosmeticDao {
     fun getAllCosmeticsFEFO(): Flow<List<CosmeticItemEntity>>
 
     @Query("SELECT * FROM cosmetic_items WHERE microCategory = :microCategory ORDER BY timestamp DESC")
-    fun getCosmeticsByMicroCategory(microCategory: String): Flow<List<CosmeticItemEntity>>
+    fun getCosmeticsByMicroCategory(microCategory: MicroCategory): Flow<List<CosmeticItemEntity>>
 
     @Query("SELECT * FROM cosmetic_items WHERE id = :id")
     fun getCosmeticById(id: Long): Flow<CosmeticItemEntity?>

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -351,7 +351,14 @@ class BoxCaptureViewModel @Inject constructor(
                         CaptureMode.PRODUCT -> "product container (front and back)"
                     }
                     val barcodeContext = if (!scannedBarcode.isNullOrBlank()) "The scanned barcode is: $scannedBarcode." else ""
-                    val colorContext = if (!manualColor.isNullOrBlank()) "The confirmed hex color code is: $manualColor." else "Analyze the photos and estimate the most accurate hex code of the actual makeup shade."
+                    val colorContext = if (!manualColor.isNullOrBlank()) {
+                        """
+                        USER COLOR HINT: The user sampled the color $manualColor from the photo.
+                        CRITICAL INSTRUCTION: Use this hint as a starting point, but VALIDATE it against the visual evidence and your internal knowledge of this specific product's shade. If the user's hex code appears incorrect due to lighting or sampling error, you MUST provide the true, accurate hex code for this makeup shade.
+                        """.trimIndent()
+                    } else {
+                        "Analyze the photos and identify the most accurate representative hex code for this specific product and shade name."
+                    }
                     
                     val enrichmentContext = obfEnrichmentData?.let {
                         """


### PR DESCRIPTION
1. Fixed DAO Type Mismatch
Updated   CosmeticDao.kt to use the MicroCategory enum directly in the getCosmeticsByMicroCategory query. This allows Room to use the established Type Converters for a cleaner, type-safe data access layer.
2. Verified and Applied Type Converters
Confirmed that the   KoColorDatabase.kt is properly annotated with @TypeConverters(FashionConverters::class). This ensures Room can correctly serialize complex types like Enums and String Lists into SQLite-compatible formats.
3. Built the OBF Data Mapper
Implemented a new toObfPayload() extension function in   CosmeticMapper.kt. This mapper flattens our rich, expert-status facets (like formulation, finish, and chemistryBase) into the raw, tag-based format expected by the Open Beauty Facts community database.
How the Mapper handles the data:
•
Categories: Concatenates Macro and Micro categories for better discoverability online.
•
Technical Tags: Converts formulation and finish Enums into lowercase tags.
•
Privacy & Ethics: Preserves and formats isVegan and isCrueltyFree flags as standard OBF labels.
These changes are now live and verified by a successful build of the :applications:kocolor:apps:mobile project.