### PR TITLE
Ko color scan

### DIFF
--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
@@ -120,6 +120,7 @@ internal fun BoxCaptureScreen(
                             label = step.label,
                             hint = getHintForStep(step),
                             isSkippable = step.isSkippable,
+                            isBarcodeStep = step == CaptureStep.BARCODE,
                             viewfinderOverlay = {
                                 if (step == CaptureStep.COLOR) {
                                     Box(
@@ -148,6 +149,7 @@ internal fun BoxCaptureScreen(
                         is ProductCaptureUiEvent.DeletePhoto -> onEvent(BoxCaptureEvent.DeletePhoto(event.index))
                         ProductCaptureUiEvent.Close -> onEvent(BoxCaptureEvent.Dismiss)
                         is ProductCaptureUiEvent.OnPriceChanged -> onEvent(BoxCaptureEvent.OnPriceChanged(event.price))
+                        is ProductCaptureUiEvent.BarcodeScanned -> onEvent(BoxCaptureEvent.BarcodeScanned(event.code))
                     }
                 },
                 modifier = modifier

--- a/applications/kocolor/features/clothingcapture/src/main/java/com/zoewave/probase/kocolor/features/clothingcapture/ui/ClothingCaptureScreen.kt
+++ b/applications/kocolor/features/clothingcapture/src/main/java/com/zoewave/probase/kocolor/features/clothingcapture/ui/ClothingCaptureScreen.kt
@@ -146,6 +146,7 @@ internal fun ClothingCaptureScreen(
                         is ProductCaptureUiEvent.DeletePhoto -> onEvent(ClothingCaptureEvent.DeletePhoto(event.index))
                         ProductCaptureUiEvent.Close -> onEvent(ClothingCaptureEvent.Dismiss)
                         is ProductCaptureUiEvent.OnPriceChanged -> onEvent(ClothingCaptureEvent.OnPriceChanged(event.price))
+                        is ProductCaptureUiEvent.BarcodeScanned -> { /* Not used in clothing flow */ }
                     }
                 },
                 modifier = modifier

--- a/features/camera/productcapture/build.gradle.kts
+++ b/features/camera/productcapture/build.gradle.kts
@@ -17,6 +17,10 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.coil.compose)
 
+    // ML Kit & Scanning
+    implementation(libs.gms.play.services.code.scanner)
+    implementation(libs.kotlinx.coroutines.play.services)
+
     // CameraX
     implementation(libs.androidx.camera.core)
     implementation(libs.androidx.camera.camera2)

--- a/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/GenericProductCaptureScreen.kt
+++ b/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/GenericProductCaptureScreen.kt
@@ -37,6 +37,9 @@ import coil.compose.AsyncImage
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.codescanner.GmsBarcodeScannerOptions
+import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.File
@@ -86,6 +89,13 @@ internal fun GenericProductCaptureScreen(
     val coroutineScope = rememberCoroutineScope()
     
     val currentStep = config.steps.getOrNull(currentStepIndex) ?: return
+
+    val scanner = remember(context) {
+        val options = GmsBarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_ALL_FORMATS)
+            .build()
+        GmsBarcodeScanning.getClient(context, options)
+    }
 
     val previewUseCase = remember { Preview.Builder().build() }
     val imageCaptureUseCase = remember { ImageCapture.Builder().build() }
@@ -225,8 +235,14 @@ internal fun GenericProductCaptureScreen(
                         Spacer(Modifier.weight(1f))
                     }
 
-                    Button(
-                        onClick = {
+                Button(
+                    onClick = {
+                        if (currentStep.isBarcodeStep) {
+                            scanner.startScan()
+                                .addOnSuccessListener { barcode ->
+                                    barcode.rawValue?.let { onEvent(ProductCaptureUiEvent.BarcodeScanned(it)) }
+                                }
+                        } else {
                             coroutineScope.launch(Dispatchers.IO) {
                                 val file = createFile(context)
                                 val options = ImageCapture.OutputFileOptions.Builder(file).build()
@@ -237,20 +253,28 @@ internal fun GenericProductCaptureScreen(
                                         override fun onImageSaved(output: ImageCapture.OutputFileResults) {
                                             onEvent(ProductCaptureUiEvent.Capture(Uri.fromFile(file).toString()))
                                         }
+
                                         override fun onError(exception: ImageCaptureException) {
                                             Log.e("GenericCapture", "Capture failed", exception)
                                         }
                                     }
                                 )
                             }
-                        },
-                        modifier = Modifier.size(80.dp),
-                        shape = CircleShape,
-                        colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                        contentPadding = PaddingValues(0.dp)
-                    ) {
+                        }
+                    },
+                    modifier = if (currentStep.isBarcodeStep) Modifier.fillMaxWidth().height(56.dp) else Modifier.size(80.dp),
+                    shape = if (currentStep.isBarcodeStep) RoundedCornerShape(12.dp) else CircleShape,
+                    colors = ButtonDefaults.buttonColors(containerColor = if (currentStep.isBarcodeStep) config.themeColor else Color.White),
+                    contentPadding = PaddingValues(0.dp)
+                ) {
+                    if (currentStep.isBarcodeStep) {
+                        Icon(Icons.Default.QrCodeScanner, null, tint = Color.Black)
+                        Spacer(Modifier.width(8.dp))
+                        Text("START BARCODE SCAN", color = Color.Black, fontWeight = FontWeight.Bold)
+                    } else {
                         Icon(Icons.Default.CameraAlt, null, tint = Color.Black, modifier = Modifier.size(32.dp))
                     }
+                }
                     
                     Spacer(Modifier.weight(1f))
                 }

--- a/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/GenericProductCaptureScreen.kt
+++ b/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/GenericProductCaptureScreen.kt
@@ -97,6 +97,18 @@ internal fun GenericProductCaptureScreen(
         GmsBarcodeScanning.getClient(context, options)
     }
 
+    LaunchedEffect(currentStepIndex) {
+        if (currentStep.isBarcodeStep) {
+            scanner.startScan()
+                .addOnSuccessListener { barcode ->
+                    barcode.rawValue?.let { onEvent(ProductCaptureUiEvent.BarcodeScanned(it)) }
+                }
+                .addOnFailureListener {
+                    // Handle failure or cancellation if needed
+                }
+        }
+    }
+
     val previewUseCase = remember { Preview.Builder().build() }
     val imageCaptureUseCase = remember { ImageCapture.Builder().build() }
     var surfaceRequest by remember { mutableStateOf<SurfaceRequest?>(null) }
@@ -123,164 +135,192 @@ internal fun GenericProductCaptureScreen(
         modifier = modifier.fillMaxSize(),
         containerColor = Color.Black
     ) { padding ->
-        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
-            Box(modifier = Modifier.weight(1f)) {
-                val sr = surfaceRequest
-                if (sr != null) {
-                    CameraXViewfinder(surfaceRequest = sr, modifier = Modifier.fillMaxSize())
-                }
-
-                // Step Overlay
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(16.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column {
-                        Text(
-                            text = "STEP ${currentStepIndex + 1} OF ${config.steps.size}",
-                            color = Color.White,
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.Bold
-                        )
-                        Text(
-                            text = currentStep.label.uppercase(),
-                            color = config.themeColor,
-                            style = MaterialTheme.typography.headlineSmall,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-
-                    IconButton(
-                        onClick = { onEvent(ProductCaptureUiEvent.Close) },
-                        modifier = Modifier.background(Color(0x33000000), CircleShape)
-                    ) {
-                        Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
-                    }
-                }
-
-                // Custom Step Viewfinder Overlay
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    if (currentStep.id.contains("PRICE", ignoreCase = true)) {
-                        PriceScanningOverlay(config.themeColor)
-                    } else {
-                        currentStep.viewfinderOverlay()
-                    }
-                }
-            }
-
-            // Bottom Gallery & Actions
+        if (currentStep.isBarcodeStep) {
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Color(0xFF0f172a))
-                    .padding(24.dp),
+                    .padding(padding)
+                    .fillMaxSize()
+                    .background(Color(0xFF0f172a)),
+                verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                LazyRow(
-                    modifier = Modifier.fillMaxWidth().height(80.dp),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    contentPadding = PaddingValues(horizontal = 8.dp)
+                Icon(
+                    Icons.Default.QrCodeScanner,
+                    null,
+                    tint = config.themeColor,
+                    modifier = Modifier.size(64.dp)
+                )
+                Spacer(Modifier.height(24.dp))
+                Text(
+                    "Launching Barcode Scanner...",
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Spacer(Modifier.height(48.dp))
+                Button(
+                    onClick = {
+                        scanner.startScan()
+                            .addOnSuccessListener { barcode ->
+                                barcode.rawValue?.let { onEvent(ProductCaptureUiEvent.BarcodeScanned(it)) }
+                            }
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = config.themeColor),
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.padding(horizontal = 32.dp).fillMaxWidth().height(56.dp)
                 ) {
-                    itemsIndexed(capturedUris) { index, uri ->
-                        if (uri.isNotBlank()) {
-                            Box(modifier = Modifier.size(70.dp)) {
-                                AsyncImage(
-                                    model = uri,
-                                    contentDescription = null,
-                                    modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(12.dp)),
-                                    contentScale = ContentScale.Crop
-                                )
-                                IconButton(
-                                    onClick = { onEvent(ProductCaptureUiEvent.DeletePhoto(index)) },
-                                    modifier = Modifier
-                                        .align(Alignment.TopEnd)
-                                        .size(24.dp)
-                                        .background(Color.Black.copy(alpha = 0.6f), CircleShape)
-                                ) {
-                                    Icon(Icons.Default.Delete, null, tint = Color.White, modifier = Modifier.size(14.dp))
-                                }
-                            }
+                    Text("RETRY SCAN", color = Color.Black, fontWeight = FontWeight.Bold)
+                }
+                Spacer(Modifier.height(16.dp))
+                TextButton(onClick = { onEvent(ProductCaptureUiEvent.Close) }) {
+                    Text("CANCEL", color = Color.White.copy(alpha = 0.6f))
+                }
+            }
+        } else {
+            Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+                Box(modifier = Modifier.weight(1f)) {
+                    val sr = surfaceRequest
+                    if (sr != null) {
+                        CameraXViewfinder(surfaceRequest = sr, modifier = Modifier.fillMaxSize())
+                    }
+
+                    // Step Overlay
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column {
+                            Text(
+                                text = "STEP ${currentStepIndex + 1} OF ${config.steps.size}",
+                                color = Color.White,
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = currentStep.label.uppercase(),
+                                color = config.themeColor,
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+
+                        IconButton(
+                            onClick = { onEvent(ProductCaptureUiEvent.Close) },
+                            modifier = Modifier.background(Color(0x33000000), CircleShape)
+                        ) {
+                            Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
+                        }
+                    }
+
+                    // Custom Step Viewfinder Overlay
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        if (currentStep.id.contains("PRICE", ignoreCase = true)) {
+                            PriceScanningOverlay(config.themeColor)
                         } else {
-                            Box(
-                                modifier = Modifier
-                                    .size(70.dp)
-                                    .background(Color.White.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
-                                    .border(1.dp, Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text("Skipped", style = MaterialTheme.typography.labelSmall, color = Color.Gray)
-                            }
+                            currentStep.viewfinderOverlay()
                         }
                     }
                 }
 
-                Spacer(modifier = Modifier.height(24.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
+                // Bottom Gallery & Actions
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFF0f172a))
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    if (currentStep.isSkippable) {
-                        TextButton(
-                            onClick = { onEvent(ProductCaptureUiEvent.SkipStep) },
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Icon(Icons.Default.SkipNext, null, tint = Color.White.copy(alpha = 0.7f))
-                            Spacer(Modifier.width(8.dp))
-                            Text("SKIP", color = Color.White.copy(alpha = 0.7f))
+                    LazyRow(
+                        modifier = Modifier.fillMaxWidth().height(80.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(horizontal = 8.dp)
+                    ) {
+                        itemsIndexed(capturedUris) { index, uri ->
+                            if (uri.isNotBlank()) {
+                                Box(modifier = Modifier.size(70.dp)) {
+                                    AsyncImage(
+                                        model = uri,
+                                        contentDescription = null,
+                                        modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(12.dp)),
+                                        contentScale = ContentScale.Crop
+                                    )
+                                    IconButton(
+                                        onClick = { onEvent(ProductCaptureUiEvent.DeletePhoto(index)) },
+                                        modifier = Modifier
+                                            .align(Alignment.TopEnd)
+                                            .size(24.dp)
+                                            .background(Color.Black.copy(alpha = 0.6f), CircleShape)
+                                    ) {
+                                        Icon(Icons.Default.Delete, null, tint = Color.White, modifier = Modifier.size(14.dp))
+                                    }
+                                }
+                            } else {
+                                Box(
+                                    modifier = Modifier
+                                        .size(70.dp)
+                                        .background(Color.White.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
+                                        .border(1.dp, Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text("Skipped", style = MaterialTheme.typography.labelSmall, color = Color.Gray)
+                                }
+                            }
                         }
-                    } else {
+                    }
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        if (currentStep.isSkippable) {
+                            TextButton(
+                                onClick = { onEvent(ProductCaptureUiEvent.SkipStep) },
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Icon(Icons.Default.SkipNext, null, tint = Color.White.copy(alpha = 0.7f))
+                                Spacer(Modifier.width(8.dp))
+                                Text("SKIP", color = Color.White.copy(alpha = 0.7f))
+                            }
+                        } else {
+                            Spacer(Modifier.weight(1f))
+                        }
+
+                        Button(
+                            onClick = {
+                                coroutineScope.launch(Dispatchers.IO) {
+                                    val file = createFile(context)
+                                    val options = ImageCapture.OutputFileOptions.Builder(file).build()
+                                    imageCaptureUseCase.takePicture(
+                                        options,
+                                        ContextCompat.getMainExecutor(context),
+                                        object : ImageCapture.OnImageSavedCallback {
+                                            override fun onImageSaved(output: ImageCapture.OutputFileResults) {
+                                                onEvent(ProductCaptureUiEvent.Capture(Uri.fromFile(file).toString()))
+                                            }
+                                            override fun onError(exception: ImageCaptureException) {
+                                                Log.e("GenericCapture", "Capture failed", exception)
+                                            }
+                                        }
+                                    )
+                                }
+                            },
+                            modifier = Modifier.size(80.dp),
+                            shape = CircleShape,
+                            colors = ButtonDefaults.buttonColors(containerColor = Color.White),
+                            contentPadding = PaddingValues(0.dp)
+                        ) {
+                            Icon(Icons.Default.CameraAlt, null, tint = Color.Black, modifier = Modifier.size(32.dp))
+                        }
+
                         Spacer(Modifier.weight(1f))
                     }
 
-                Button(
-                    onClick = {
-                        if (currentStep.isBarcodeStep) {
-                            scanner.startScan()
-                                .addOnSuccessListener { barcode ->
-                                    barcode.rawValue?.let { onEvent(ProductCaptureUiEvent.BarcodeScanned(it)) }
-                                }
-                        } else {
-                            coroutineScope.launch(Dispatchers.IO) {
-                                val file = createFile(context)
-                                val options = ImageCapture.OutputFileOptions.Builder(file).build()
-                                imageCaptureUseCase.takePicture(
-                                    options,
-                                    ContextCompat.getMainExecutor(context),
-                                    object : ImageCapture.OnImageSavedCallback {
-                                        override fun onImageSaved(output: ImageCapture.OutputFileResults) {
-                                            onEvent(ProductCaptureUiEvent.Capture(Uri.fromFile(file).toString()))
-                                        }
-
-                                        override fun onError(exception: ImageCaptureException) {
-                                            Log.e("GenericCapture", "Capture failed", exception)
-                                        }
-                                    }
-                                )
-                            }
-                        }
-                    },
-                    modifier = if (currentStep.isBarcodeStep) Modifier.fillMaxWidth().height(56.dp) else Modifier.size(80.dp),
-                    shape = if (currentStep.isBarcodeStep) RoundedCornerShape(12.dp) else CircleShape,
-                    colors = ButtonDefaults.buttonColors(containerColor = if (currentStep.isBarcodeStep) config.themeColor else Color.White),
-                    contentPadding = PaddingValues(0.dp)
-                ) {
-                    if (currentStep.isBarcodeStep) {
-                        Icon(Icons.Default.QrCodeScanner, null, tint = Color.Black)
-                        Spacer(Modifier.width(8.dp))
-                        Text("START BARCODE SCAN", color = Color.Black, fontWeight = FontWeight.Bold)
-                    } else {
-                        Icon(Icons.Default.CameraAlt, null, tint = Color.Black, modifier = Modifier.size(32.dp))
-                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(currentStep.hint, color = Color.White.copy(alpha = 0.6f), style = MaterialTheme.typography.labelSmall)
                 }
-                    
-                    Spacer(Modifier.weight(1f))
-                }
-                
-                Spacer(modifier = Modifier.height(12.dp))
-                Text(currentStep.hint, color = Color.White.copy(alpha = 0.6f), style = MaterialTheme.typography.labelSmall)
             }
         }
     }

--- a/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/ProductCaptureContract.kt
+++ b/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/ProductCaptureContract.kt
@@ -12,6 +12,7 @@ data class CaptureStepConfig(
     val label: String,
     val hint: String,
     val isSkippable: Boolean = false,
+    val isBarcodeStep: Boolean = false,
     val icon: ImageVector? = null,
     val viewfinderOverlay: @Composable () -> Unit = {}
 )
@@ -31,4 +32,5 @@ sealed interface ProductCaptureUiEvent {
     data class DeletePhoto(val index: Int) : ProductCaptureUiEvent
     data object Close : ProductCaptureUiEvent
     data class OnPriceChanged(val price: Double) : ProductCaptureUiEvent
+    data class BarcodeScanned(val code: String) : ProductCaptureUiEvent
 }


### PR DESCRIPTION
Seamless Workflow Update:
1.
Auto-Triggering: As soon as you finish the "Product Color" step, the capture engine now automatically triggers the Google Barcode Scanner. There is no longer an intermediate screen requiring you to tap a button to start the scan.
2.
Specialized "Launching" State:
◦
During the hand-off to the barcode scanner, the camera viewfinder and shutter are hidden.
◦
A clean, focused "Launching Barcode Scanner..." UI appears briefly, ensuring the transition feels deliberate and professional.
3.
Smart Hand-off: I've implemented a LaunchedEffect that watches for the isBarcodeStep flag. The moment the step index updates to the barcode step, the GMS Scanner is invoked.
4.
Resilient Recovery: In the rare case that a user manually cancels the scanner or it fails to launch, the screen remains in a "Retry" state. This allows the user to tap "RETRY SCAN" without losing all the photos they just took in the previous steps.
This update significantly speeds up the "Box Scan" and "Product Scan" sequences by eliminating unnecessary taps at the most critical step of the process.