### PR TITLE
refactor: implement State/Event pattern and unify navigation logic

### DIFF
--- a/applications/gotmind/Docs/PlayStore/Release/Release.md
+++ b/applications/gotmind/Docs/PlayStore/Release/Release.md
@@ -1,0 +1,21 @@
+Based on the Google Play Console screenshot in `image_26d940.png`, you are running into two closely related errors preventing you from rolling out to Open Testing.
+
+Here is exactly what is happening and how to fix it:
+
+### The Diagnosis
+
+The errors indicate that **your release draft is currently empty**.
+
+1. **"This release does not add or remove any app bundles"**: You haven't attached a new Android App Bundle (.aab) to this specific release, or it was accidentally removed before you hit the "Preview and confirm" stage.
+2. **"You can't rollout this release because it doesn't allow any existing users to upgrade..."**: Because there is no new app bundle attached (or if there is, the `versionCode` is the same or lower than an existing release in a lower track like Internal Testing), the Play Store sees no valid upgrade path for your users.
+
+### How to Fix It
+
+To resolve this and successfully launch your open testing track, follow these steps:
+
+1. **Navigate Back:** At the top of the screen (under "Create open testing release"), click on the **1 - Create release** step to go back to the upload page, or click **Discard draft release** on the right to start completely fresh.
+2. **Increment Your Version Code:** Before uploading, ensure your new build has a higher `versionCode` than any previous upload (Internal, Closed, or Production). Since you are working with AGP 9.0, double-check that your `versionCode` and `versionName` are correctly incremented in your app-level `build.gradle.kts` file.
+3. **Upload the Bundle:** In the "App bundles" section of the "Create release" page, upload your generated `.aab` file.
+4. **Save and Preview:** Once the upload finishes processing and appears in the list of added bundles, click **Save** and then **Review release** (or Next) to return to the preview screen.
+
+Once the new bundle with a higher version code is successfully attached, those errors will clear out, and the gray "Save" button in the bottom right will change to a blue "Start rollout to Open testing" button.

--- a/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/MainActivity.kt
+++ b/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/MainActivity.kt
@@ -46,24 +46,8 @@ import com.zoewave.probase.gotmind.mobile.ui.theme.GotMindTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.serialization.Serializable
 
-@Serializable
-sealed interface GotMindRoute {
-    // Top Level Tabs
-    @Serializable data object Games : GotMindRoute
-    @Serializable data object Leaderboard : GotMindRoute
-    @Serializable data object Settings : GotMindRoute
-
-    // Fullscreen Game Screens
-    @Serializable data object GotMindClassic : GotMindRoute
-    @Serializable data object MemBlox : GotMindRoute
-    @Serializable data object SoundMind : GotMindRoute
-}
-
-data class TopLevelDestination(
-    val route: GotMindRoute,
-    val icon: ImageVector,
-    val labelResId: Int
-)
+import com.zoewave.probase.gotmind.model.GotMindRoute
+import com.zoewave.probase.gotmind.model.TopLevelDestination
 
 val topLevelDestinations = listOf(
     TopLevelDestination(GotMindRoute.Games, Icons.Default.Games, R.string.nav_games),
@@ -124,16 +108,25 @@ class MainActivity : ComponentActivity() {
                                 rememberViewModelStoreNavEntryDecorator()
                             ),
                             entryProvider = { route ->
+                                val navigateTo: (GotMindRoute) -> Unit = { dest ->
+                                    if (dest == GotMindRoute.Back) {
+                                        if (backStack.size > 1) backStack.removeLastOrNull()
+                                    } else {
+                                        if (dest != route) {
+                                            if (dest in topLevelDestinations.map { it.route }) {
+                                                backStack.clear()
+                                            }
+                                            backStack.add(dest)
+                                        }
+                                    }
+                                }
+
                                 NavEntry(route) {
                                     when (route) {
                                         GotMindRoute.Games -> GamesScreen(
-                                            onNav = { dest -> 
-                                                when (dest) {
-                                                    "CLASSIC" -> backStack.add(GotMindRoute.GotMindClassic)
-                                                    "MEMBLOX" -> backStack.add(GotMindRoute.MemBlox)
-                                                    "SOUNDMIND" -> backStack.add(GotMindRoute.SoundMind)
-                                                }
-                                            }
+                                            uiState = com.zoewave.probase.gotmind.features.games.GamesUiState,
+                                            onEvent = {},
+                                            navTo = navigateTo
                                         )
                                         GotMindRoute.Leaderboard -> {
                                             val memBloxVm: MemBloxViewModel = hiltViewModel()
@@ -142,27 +135,55 @@ class MainActivity : ComponentActivity() {
                                             val mindWaveScores by mindWaveVm.topScores.collectAsState()
                                             
                                             LeaderboardScreen(
-                                                membloxScores = memBloxScores,
-                                                mindwaveScores = mindWaveScores,
-                                                onClearMemBlox = { memBloxVm.handleEvent(MemBloxEvent.ClearHallOfFame) },
-                                                onClearMindWave = { mindWaveVm.handleEvent(MindWaveEvent.ClearHallOfFame) }
+                                                uiState = com.zoewave.probase.gotmind.features.leaderboard.ui.LeaderboardUiState(
+                                                    membloxScores = memBloxScores,
+                                                    mindwaveScores = mindWaveScores
+                                                ),
+                                                onEvent = { event ->
+                                                    when (event) {
+                                                        com.zoewave.probase.gotmind.features.leaderboard.ui.LeaderboardEvent.ClearMemBlox -> memBloxVm.handleEvent(MemBloxEvent.ClearHallOfFame)
+                                                        com.zoewave.probase.gotmind.features.leaderboard.ui.LeaderboardEvent.ClearMindWave -> mindWaveVm.handleEvent(MindWaveEvent.ClearHallOfFame)
+                                                    }
+                                                },
+                                                navTo = navigateTo
                                             )
                                         }
                                         GotMindRoute.Settings -> {
                                             val memBloxVm: MemBloxViewModel = hiltViewModel()
                                             SettingsScreen(
-                                                gameSettings = gameSettings,
-                                                themeSettings = themeSettings,
-                                                firebaseId = firebaseId,
-                                                onMemBloxEvent = { memBloxVm.handleEvent(it) },
-                                                onSettingsEvent = { settingsVm.handleEvent(it) },
-                                                onBack = { if (backStack.size > 1) backStack.removeLastOrNull() }
+                                                uiState = com.zoewave.probase.gotmind.features.settings.ui.SettingsUiState(
+                                                    gameSettings = gameSettings,
+                                                    themeSettings = themeSettings,
+                                                    firebaseId = firebaseId
+                                                ),
+                                                onEvent = { event ->
+                                                    when (event) {
+                                                        is com.zoewave.probase.gotmind.features.settings.ui.SettingsScreenEvent.Settings -> settingsVm.handleEvent(event.event)
+                                                        is com.zoewave.probase.gotmind.features.settings.ui.SettingsScreenEvent.MemBlox -> memBloxVm.handleEvent(event.event)
+                                                    }
+                                                },
+                                                navTo = navigateTo
                                             )
                                         }
                                         
                                         GotMindRoute.GotMindClassic -> {
                                             val viewModel: GameViewModel = hiltViewModel()
-                                            GameScreen(viewModel = viewModel)
+                                            val state by viewModel.gameState.collectAsState()
+                                            val topScores by viewModel.topScores.collectAsState()
+                                            GameScreen(
+                                                uiState = com.zoewave.probase.gotmind.mobile.ui.components.GotMindClassicUiState(
+                                                    game = state,
+                                                    topScores = topScores
+                                                ),
+                                                onEvent = { event ->
+                                                    when (event) {
+                                                        com.zoewave.probase.gotmind.mobile.ui.components.GotMindClassicEvent.GameOver -> viewModel.onGameOver()
+                                                        com.zoewave.probase.gotmind.mobile.ui.components.GotMindClassicEvent.ResetGame -> viewModel.resetGame()
+                                                        is com.zoewave.probase.gotmind.mobile.ui.components.GotMindClassicEvent.ScoreUpdate -> viewModel.onScoreUpdate(event.delta)
+                                                    }
+                                                },
+                                                navTo = navigateTo
+                                            )
                                         }
                                         GotMindRoute.MemBlox -> {
                                             val viewModel: MemBloxViewModel = hiltViewModel()
@@ -170,11 +191,13 @@ class MainActivity : ComponentActivity() {
                                             val topScores by viewModel.topScores.collectAsState()
                                             val engineType by viewModel.engineType.collectAsState()
                                             MemBloxScreen(
-                                                uiState = state,
-                                                topScores = topScores,
-                                                engineType = engineType,
-                                                onNav = { if (it == "BACK") backStack.removeLastOrNull() },
-                                                onEvent = { event -> viewModel.handleEvent(event) }
+                                                uiState = com.zoewave.probase.gotmind.features.memblox.MemBloxUiState(
+                                                    game = state,
+                                                    topScores = topScores,
+                                                    engineType = engineType
+                                                ),
+                                                onEvent = { event -> viewModel.handleEvent(event) },
+                                                navTo = navigateTo
                                             )
                                         }
                                         GotMindRoute.SoundMind -> {
@@ -182,10 +205,11 @@ class MainActivity : ComponentActivity() {
                                             val state by viewModel.uiState.collectAsState()
                                             MindWaveScreen(
                                                 uiState = state,
-                                                onNav = { if (it == "BACK") backStack.removeLastOrNull() },
-                                                onEvent = { event -> viewModel.handleEvent(event) }
+                                                onEvent = { event -> viewModel.handleEvent(event) },
+                                                navTo = navigateTo
                                             )
                                         }
+                                        GotMindRoute.Back -> { /* Back is a signal, not a destination */ }
                                     }
                                 }
                             }

--- a/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/ui/components/GameScreen.kt
+++ b/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/ui/components/GameScreen.kt
@@ -13,17 +13,23 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.gotmind.mobile.R
-import com.zoewave.probase.gotmind.mobile.ui.GameViewModel
+import com.zoewave.probase.gotmind.model.GotMindRoute
 
 @Composable
-fun GameScreen(viewModel: GameViewModel) {
-    val gameState by viewModel.gameState.collectAsState()
-    val topScores by viewModel.topScores.collectAsState()
+fun GameScreen(
+    uiState: GotMindClassicUiState,
+    modifier: Modifier = Modifier,
+    onEvent: (GotMindClassicEvent) -> Unit,
+    navTo: (GotMindRoute) -> Unit
+) {
+    val gameState = uiState.game
+    val topScores = uiState.topScores
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -35,7 +41,7 @@ fun GameScreen(viewModel: GameViewModel) {
                 style = MaterialTheme.typography.headlineLarge
             )
             Text(text = stringResource(R.string.classic_score_label, gameState.currentScore))
-            Button(onClick = { viewModel.resetGame() }) {
+            Button(onClick = { onEvent(GotMindClassicEvent.ResetGame) }) {
                 Text(stringResource(R.string.classic_restart))
             }
         } else {
@@ -44,10 +50,10 @@ fun GameScreen(viewModel: GameViewModel) {
                 style = MaterialTheme.typography.headlineMedium
             )
             Text(text = stringResource(R.string.classic_current_score, gameState.currentScore))
-            Button(onClick = { viewModel.onScoreUpdate(10) }, modifier = Modifier.padding(top = 16.dp)) {
+            Button(onClick = { onEvent(GotMindClassicEvent.ScoreUpdate(10)) }, modifier = Modifier.padding(top = 16.dp)) {
                 Text(stringResource(R.string.classic_tap_to_score))
             }
-            Button(onClick = { viewModel.onGameOver() }, modifier = Modifier.padding(top = 8.dp)) {
+            Button(onClick = { onEvent(GotMindClassicEvent.GameOver) }, modifier = Modifier.padding(top = 8.dp)) {
                 Text(stringResource(R.string.classic_end_game))
             }
         }
@@ -60,5 +66,17 @@ fun GameScreen(viewModel: GameViewModel) {
         topScores.forEach { score ->
             Text(text = "${score.value}")
         }
+    }
+}
+
+@Preview
+@Composable
+private fun GameScreenPreview() {
+    MaterialTheme {
+        GameScreen(
+            uiState = GotMindClassicUiState(),
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/ui/components/GotMindClassicModels.kt
+++ b/applications/gotmind/apps/mobile/src/main/java/com/zoewave/probase/gotmind/mobile/ui/components/GotMindClassicModels.kt
@@ -1,0 +1,15 @@
+package com.zoewave.probase.gotmind.mobile.ui.components
+
+import com.zoewave.probase.gotmind.model.GameState
+import com.zoewave.probase.gotmind.model.Score
+
+data class GotMindClassicUiState(
+    val game: GameState = GameState(),
+    val topScores: List<Score> = emptyList()
+)
+
+sealed interface GotMindClassicEvent {
+    data object ResetGame : GotMindClassicEvent
+    data class ScoreUpdate(val delta: Int) : GotMindClassicEvent
+    data object GameOver : GotMindClassicEvent
+}

--- a/applications/gotmind/features/games/build.gradle.kts
+++ b/applications/gotmind/features/games/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:util"))
+    implementation(project(":applications:gotmind:model"))
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.navigation3.runtime)
 }

--- a/applications/gotmind/features/games/src/main/java/com/zoewave/probase/gotmind/features/games/GamesScreen.kt
+++ b/applications/gotmind/features/games/src/main/java/com/zoewave/probase/gotmind/features/games/GamesScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import com.zoewave.probase.gotmind.model.GotMindRoute
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -27,10 +29,13 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun GamesScreen(
-    onNav: (String) -> Unit
+    uiState: GamesUiState,
+    modifier: Modifier = Modifier,
+    onEvent: (GamesEvent) -> Unit,
+    navTo: (GotMindRoute) -> Unit
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
             .verticalScroll(rememberScrollState()),
@@ -55,7 +60,7 @@ fun GamesScreen(
 
         // --- MemBlox (Active) ---
         Button(
-            onClick = { onNav("MEMBLOX") },
+            onClick = { navTo(GotMindRoute.MemBlox) },
             modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
             shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
@@ -70,7 +75,7 @@ fun GamesScreen(
 
         // --- SoundMind (Active) ---
         Button(
-            onClick = { onNav("SOUNDMIND") },
+            onClick = { navTo(GotMindRoute.SoundMind) },
             modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
             shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
@@ -135,5 +140,17 @@ fun PlaceholderGameButton(title: String) {
                 fontWeight = FontWeight.Bold
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun GamesScreenPreview() {
+    MaterialTheme {
+        GamesScreen(
+            uiState = GamesUiState,
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/gotmind/features/games/src/main/java/com/zoewave/probase/gotmind/features/games/GamesUiState.kt
+++ b/applications/gotmind/features/games/src/main/java/com/zoewave/probase/gotmind/features/games/GamesUiState.kt
@@ -1,0 +1,5 @@
+package com.zoewave.probase.gotmind.features.games
+
+data object GamesUiState
+
+sealed interface GamesEvent

--- a/applications/gotmind/features/leaderboard/src/main/java/com/zoewave/probase/gotmind/features/leaderboard/ui/LeaderboardScreen.kt
+++ b/applications/gotmind/features/leaderboard/src/main/java/com/zoewave/probase/gotmind/features/leaderboard/ui/LeaderboardScreen.kt
@@ -48,10 +48,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.tooling.preview.Preview
 import com.zoewave.probase.gotmind.database.MemBloxScoreEntity
 import com.zoewave.probase.gotmind.database.MindWaveScoreEntity
 import com.zoewave.probase.gotmind.features.leaderboard.R
 import com.zoewave.probase.gotmind.model.memblox.MemBloxDifficulty
+import com.zoewave.probase.gotmind.model.GotMindRoute
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -59,17 +61,16 @@ import java.util.Locale
 @OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
 @Composable
 fun LeaderboardScreen(
-    membloxScores: List<MemBloxScoreEntity>,
-    mindwaveScores: List<MindWaveScoreEntity>,
-    onBack: () -> Unit = {},
-    onClearMemBlox: () -> Unit = {},
-    onClearMindWave: () -> Unit = {}
+    uiState: LeaderboardUiState,
+    modifier: Modifier = Modifier,
+    onEvent: (LeaderboardEvent) -> Unit,
+    navTo: (GotMindRoute) -> Unit
 ) {
     var selectedTab by remember { mutableStateOf(0) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(Color(0xFF0F0F0F))
             .statusBarsPadding()
@@ -77,7 +78,7 @@ fun LeaderboardScreen(
             .padding(top = 24.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-            IconButton(onClick = onBack) {
+            IconButton(onClick = { navTo(GotMindRoute.Back) }) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack, 
                     contentDescription = null, 
@@ -95,7 +96,7 @@ fun LeaderboardScreen(
                 modifier = Modifier.weight(1f)
             )
             
-            val currentScores = if (selectedTab == 0) membloxScores else mindwaveScores
+            val currentScores = if (selectedTab == 0) uiState.membloxScores else uiState.mindwaveScores
             if (currentScores.isNotEmpty()) {
                 IconButton(onClick = { showDeleteConfirm = true }) {
                     Icon(Icons.Default.DeleteSweep, contentDescription = null, tint = Color.Gray)
@@ -125,7 +126,7 @@ fun LeaderboardScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        val currentList = if (selectedTab == 0) membloxScores else mindwaveScores
+        val currentList = if (selectedTab == 0) uiState.membloxScores else uiState.mindwaveScores
         if (currentList.isEmpty()) {
             Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
                 Text(
@@ -157,7 +158,7 @@ fun LeaderboardScreen(
             text = { Text(stringResource(R.string.applications_gotmind_features_leaderboard_clear_confirm)) },
             confirmButton = {
                 TextButton(onClick = {
-                    if (selectedTab == 0) onClearMemBlox() else onClearMindWave()
+                    if (selectedTab == 0) onEvent(LeaderboardEvent.ClearMemBlox) else onEvent(LeaderboardEvent.ClearMindWave)
                     showDeleteConfirm = false
                 }) {
                     Text(stringResource(R.string.applications_gotmind_features_leaderboard_clear_all), color = Color.Red, fontWeight = FontWeight.Bold)
@@ -168,6 +169,18 @@ fun LeaderboardScreen(
                     Text(stringResource(R.string.applications_gotmind_features_leaderboard_cancel), color = Color.Gray)
                 }
             }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LeaderboardScreenPreview() {
+    MaterialTheme {
+        LeaderboardScreen(
+            uiState = LeaderboardUiState(),
+            onEvent = {},
+            navTo = {}
         )
     }
 }

--- a/applications/gotmind/features/leaderboard/src/main/java/com/zoewave/probase/gotmind/features/leaderboard/ui/LeaderboardUiState.kt
+++ b/applications/gotmind/features/leaderboard/src/main/java/com/zoewave/probase/gotmind/features/leaderboard/ui/LeaderboardUiState.kt
@@ -1,0 +1,14 @@
+package com.zoewave.probase.gotmind.features.leaderboard.ui
+
+import com.zoewave.probase.gotmind.database.MemBloxScoreEntity
+import com.zoewave.probase.gotmind.database.MindWaveScoreEntity
+
+data class LeaderboardUiState(
+    val membloxScores: List<MemBloxScoreEntity> = emptyList(),
+    val mindwaveScores: List<MindWaveScoreEntity> = emptyList()
+)
+
+sealed interface LeaderboardEvent {
+    data object ClearMemBlox : LeaderboardEvent
+    data object ClearMindWave : LeaderboardEvent
+}

--- a/applications/gotmind/features/memblox/src/main/java/com/zoewave/probase/gotmind/features/memblox/MemBloxState.kt
+++ b/applications/gotmind/features/memblox/src/main/java/com/zoewave/probase/gotmind/features/memblox/MemBloxState.kt
@@ -1,5 +1,7 @@
 package com.zoewave.probase.gotmind.features.memblox
 
+import com.zoewave.probase.gotmind.database.MemBloxScoreEntity
+import com.zoewave.probase.gotmind.model.MemBloxEngineType
 import com.zoewave.probase.gotmind.model.memblox.MemBloxBlock
 import com.zoewave.probase.gotmind.model.memblox.MemBloxDifficulty
 import java.util.UUID
@@ -119,4 +121,10 @@ data class MemBloxState(
     val dropDurationMillis: Int = 5000,
     val hapticsEnabled: Boolean = true,
     val soundEnabled: Boolean = true
+)
+
+data class MemBloxUiState(
+    val game: MemBloxState = MemBloxState(),
+    val topScores: List<MemBloxScoreEntity> = emptyList(),
+    val engineType: MemBloxEngineType = MemBloxEngineType.STATIC
 )

--- a/applications/gotmind/features/memblox/src/main/java/com/zoewave/probase/gotmind/features/memblox/ui/MemBloxScreen.kt
+++ b/applications/gotmind/features/memblox/src/main/java/com/zoewave/probase/gotmind/features/memblox/ui/MemBloxScreen.kt
@@ -86,15 +86,18 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.tooling.preview.Preview
 import com.zoewave.probase.gotmind.database.MemBloxScoreEntity
 import com.zoewave.probase.gotmind.features.memblox.HapticSignal
 import com.zoewave.probase.gotmind.features.memblox.MatchGhost
 import com.zoewave.probase.gotmind.features.memblox.MemBloxEvent
 import com.zoewave.probase.gotmind.features.memblox.MemBloxState
+import com.zoewave.probase.gotmind.features.memblox.MemBloxUiState
 import com.zoewave.probase.gotmind.features.memblox.PowerUpType
 import com.zoewave.probase.gotmind.features.memblox.R
 import com.zoewave.probase.gotmind.features.memblox.ScorePopup
 import com.zoewave.probase.gotmind.model.MemBloxEngineType
+import com.zoewave.probase.gotmind.model.GotMindRoute
 import com.zoewave.probase.gotmind.model.memblox.MemBloxBlock
 import com.zoewave.probase.gotmind.model.memblox.MemBloxDifficulty
 import kotlinx.coroutines.launch
@@ -106,19 +109,19 @@ import kotlin.random.Random
 
 @Composable
 fun MemBloxScreen(
-    uiState: MemBloxState,
-    topScores: List<MemBloxScoreEntity>,
-    engineType: MemBloxEngineType,
-    onNav: (String) -> Unit,
-    onEvent: (MemBloxEvent) -> Unit
+    uiState: MemBloxUiState,
+    modifier: Modifier = Modifier,
+    onEvent: (MemBloxEvent) -> Unit,
+    navTo: (GotMindRoute) -> Unit
 ) {
+    val game = uiState.game
     var showAnalytics by remember { mutableStateOf(false) }
 
     val haptic = LocalHapticFeedback.current
 
     // Haptic Feedback Observer
-    LaunchedEffect(uiState.lastHapticSignal) {
-        uiState.lastHapticSignal?.let { signal ->
+    LaunchedEffect(game.lastHapticSignal) {
+        game.lastHapticSignal?.let { signal ->
             when (signal) {
                 HapticSignal.LIGHT -> haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                 HapticSignal.MEDIUM -> haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -128,7 +131,7 @@ fun MemBloxScreen(
         }
     }
 
-    if (!uiState.isStarted) {
+    if (!game.isStarted) {
         DifficultySelectionScreen(
             onDifficultySelected = { onEvent(MemBloxEvent.StartGame(it)) }
         )
@@ -137,18 +140,18 @@ fun MemBloxScreen(
 
     // Screenshake Offset
     val shakeX by animateFloatAsState(
-        targetValue = if (uiState.shakeIntensity > 0 || uiState.isStressed) (Random.nextFloat() - 0.5f) * (uiState.shakeIntensity + 1f) * 10 else 0f,
+        targetValue = if (game.shakeIntensity > 0 || game.isStressed) (Random.nextFloat() - 0.5f) * (game.shakeIntensity + 1f) * 10 else 0f,
         animationSpec = spring(stiffness = Spring.StiffnessHigh),
         label = "ShakeX"
     )
     val shakeY by animateFloatAsState(
-        targetValue = if (uiState.shakeIntensity > 0 || uiState.isStressed) (Random.nextFloat() - 0.5f) * (uiState.shakeIntensity + 1f) * 10 else 0f,
+        targetValue = if (game.shakeIntensity > 0 || game.isStressed) (Random.nextFloat() - 0.5f) * (game.shakeIntensity + 1f) * 10 else 0f,
         animationSpec = spring(stiffness = Spring.StiffnessHigh),
         label = "ShakeY"
     )
 
-    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F0F0F))) {
-        ParticleBackground(speedFactor = if (uiState.isFrenzy) 3f else 1f)
+    Box(modifier = modifier.fillMaxSize().background(Color(0xFF0F0F0F))) {
+        ParticleBackground(speedFactor = if (game.isFrenzy) 3f else 1f)
 
         Column(modifier = Modifier.fillMaxSize()) {
             // 1. Ultra-Slim Header (Top Fixed HUD)
@@ -168,7 +171,7 @@ fun MemBloxScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     IconButton(
-                        onClick = { onNav("BACK") },
+                        onClick = { navTo(GotMindRoute.Back) },
                         modifier = Modifier.size(36.dp).background(Color.White.copy(alpha = 0.1f), CircleShape)
                     ) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.applications_gotmind_features_memblox_back), modifier = Modifier.size(20.dp), tint = Color.White)
@@ -176,12 +179,12 @@ fun MemBloxScreen(
 
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(text = uiState.score.toString(), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Black, color = if (uiState.isFrenzy) Color(0xFFE91E63) else MaterialTheme.colorScheme.primary)
+                            Text(text = game.score.toString(), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Black, color = if (game.isFrenzy) Color(0xFFE91E63) else MaterialTheme.colorScheme.primary)
                             Text(text = stringResource(R.string.applications_gotmind_features_memblox_score), style = MaterialTheme.typography.labelSmall, color = Color.Gray)
                         }
                         Spacer(modifier = Modifier.width(24.dp))
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(text = stringResource(R.string.applications_gotmind_features_memblox_pairs_format, uiState.pairsMatched, uiState.targetPairs), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = Color.White)
+                            Text(text = stringResource(R.string.applications_gotmind_features_memblox_pairs_format, game.pairsMatched, game.targetPairs), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = Color.White)
                             Text(text = stringResource(R.string.applications_gotmind_features_memblox_pairs), style = MaterialTheme.typography.labelSmall, color = Color.Gray)
                         }
                     }
@@ -205,12 +208,12 @@ fun MemBloxScreen(
                             .border(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f), RoundedCornerShape(12.dp))
                             .padding(16.dp)
                     ) {
-                        val loadPct = if (uiState.cols * uiState.rows > 0) (uiState.peakBoardBlocks * 100 / (uiState.cols * uiState.rows)) else 0
-                        AnalyticsRow(stringResource(R.string.applications_gotmind_features_memblox_hit_rate), stringResource(R.string.applications_gotmind_features_memblox_percent_format, (uiState.matchAccuracy * 100).toInt()))
-                        AnalyticsRow(stringResource(R.string.applications_gotmind_features_memblox_best_streak), "${uiState.bestMatchStreak}")
-                        AnalyticsRow(stringResource(R.string.applications_gotmind_features_memblox_avg_match_time), String.format(Locale.getDefault(), "%.1fs", uiState.avgMatchTimeMs / 1000f))
+                        val loadPct = if (game.cols * game.rows > 0) (game.peakBoardBlocks * 100 / (game.cols * game.rows)) else 0
+                        AnalyticsRow(stringResource(R.string.applications_gotmind_features_memblox_hit_rate), stringResource(R.string.applications_gotmind_features_memblox_percent_format, (game.matchAccuracy * 100).toInt()))
+                        AnalyticsRow(stringResource(R.string.applications_gotmind_features_memblox_best_streak), "${game.bestMatchStreak}")
+                        AnalyticsRow(stringResource(R.string.applications_gotmind_features_memblox_avg_match_time), String.format(Locale.getDefault(), "%.1fs", game.avgMatchTimeMs / 1000f))
                         AnalyticsRow(stringResource(R.string.applications_gotmind_features_memblox_peak_board_load), "$loadPct%")
-                        AnalyticsRow(stringResource(R.string.applications_gotmind_features_memblox_solubility), "${(uiState.successfulMatches * 100 / (uiState.totalClicks.coerceAtLeast(1)))}%")
+                        AnalyticsRow(stringResource(R.string.applications_gotmind_features_memblox_solubility), "${(game.successfulMatches * 100 / (game.totalClicks.coerceAtLeast(1)))}%")
 
                         Spacer(modifier = Modifier.height(16.dp))
                         Row(
@@ -220,7 +223,7 @@ fun MemBloxScreen(
                             Button(
                                 onClick = { 
                                     onEvent(MemBloxEvent.ResetToSelection)
-                                    onNav("BACK") 
+                                    navTo(GotMindRoute.Back) 
                                 },
                                 modifier = Modifier.weight(1f).height(40.dp),
                                 colors = ButtonDefaults.buttonColors(containerColor = Color.Red.copy(alpha = 0.2f), contentColor = Color.Red),
@@ -236,15 +239,15 @@ fun MemBloxScreen(
                                 onClick = { onEvent(MemBloxEvent.TogglePause) },
                                 modifier = Modifier.weight(1f).height(40.dp),
                                 colors = ButtonDefaults.buttonColors(
-                                    containerColor = if (uiState.isPaused) MaterialTheme.colorScheme.primary.copy(alpha = 0.2f) else Color.White.copy(alpha = 0.1f),
-                                    contentColor = if (uiState.isPaused) MaterialTheme.colorScheme.primary else Color.White
+                                    containerColor = if (game.isPaused) MaterialTheme.colorScheme.primary.copy(alpha = 0.2f) else Color.White.copy(alpha = 0.1f),
+                                    contentColor = if (game.isPaused) MaterialTheme.colorScheme.primary else Color.White
                                 ),
                                 shape = RoundedCornerShape(8.dp),
                                 contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp)
                             ) {
-                                Icon(if (uiState.isPaused) Icons.Default.PlayArrow else Icons.Default.Pause, contentDescription = null, modifier = Modifier.size(16.dp))
+                                Icon(if (game.isPaused) Icons.Default.PlayArrow else Icons.Default.Pause, contentDescription = null, modifier = Modifier.size(16.dp))
                                 Spacer(modifier = Modifier.width(4.dp))
-                                Text(if (uiState.isPaused) stringResource(R.string.applications_gotmind_features_memblox_resume) else stringResource(R.string.applications_gotmind_features_memblox_pause), style = MaterialTheme.typography.labelLarge)
+                                Text(if (game.isPaused) stringResource(R.string.applications_gotmind_features_memblox_resume) else stringResource(R.string.applications_gotmind_features_memblox_pause), style = MaterialTheme.typography.labelLarge)
                             }
                         }
                     }
@@ -252,13 +255,13 @@ fun MemBloxScreen(
             }
 
             // 2. Progress Line
-            val progress by animateFloatAsState(targetValue = uiState.pairsMatched.toFloat() / uiState.targetPairs, animationSpec = tween(500))
+            val progress by animateFloatAsState(targetValue = game.pairsMatched.toFloat() / game.targetPairs, animationSpec = tween(500))
             LinearProgressIndicator(
                 progress = { progress },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(2.dp),
-                color = if (uiState.isFrenzy) Color(0xFFE91E63) else MaterialTheme.colorScheme.primary,
+                color = if (game.isFrenzy) Color(0xFFE91E63) else MaterialTheme.colorScheme.primary,
                 trackColor = Color.Transparent,
                 strokeCap = StrokeCap.Butt
             )
@@ -270,71 +273,71 @@ fun MemBloxScreen(
                     .fillMaxWidth()
                     .offset { IntOffset(shakeX.roundToInt(), shakeY.roundToInt()) }
             ) {
-                val blockSize = maxWidth / uiState.cols
-                val blockHeight = maxHeight / uiState.rows
+                val blockSize = maxWidth / game.cols
+                val blockHeight = maxHeight / game.rows
 
-                uiState.grid.forEach { block ->
+                game.grid.forEach { block ->
                     key(block.id) {
-                        val nukingColor = uiState.nukingBlockIds[block.id]
-                        val isHinted = uiState.hintedBlockIds.contains(block.id)
+                        val nukingColor = game.nukingBlockIds[block.id]
+                        val isHinted = game.hintedBlockIds.contains(block.id)
                         MemBloxBlockRender(
                             block = block,
                             blockSize = blockSize,
                             blockHeight = blockHeight,
-                            isRevealed = uiState.isRevealed,
-                            isInitiallyRevealed = uiState.initiallyRevealedBlockIds.contains(block.id),
-                            isFallingMode = engineType == MemBloxEngineType.FALLING,
+                            isRevealed = game.isRevealed,
+                            isInitiallyRevealed = game.initiallyRevealedBlockIds.contains(block.id),
+                            isFallingMode = uiState.engineType == MemBloxEngineType.FALLING,
                             nukingColor = nukingColor?.let { Color(it) },
                             isHinted = isHinted,
-                            dropHeight = uiState.dropHeight,
-                            dropDurationMillis = uiState.dropDurationMillis,
+                            dropHeight = game.dropHeight,
+                            dropDurationMillis = game.dropDurationMillis,
                             onClick = { onEvent(MemBloxEvent.BlockClick(block)) }
                         )
                     }
                 }
 
-                if (uiState.isStressed) StressVignette()
-                if (uiState.frostAlpha > 0) FrostOverlay(alpha = uiState.frostAlpha)
-                if (uiState.isSlowed) Box(modifier = Modifier.fillMaxSize().background(Color(0xFFFFD54F).copy(alpha = 0.1f)))
+                if (game.isStressed) StressVignette()
+                if (game.frostAlpha > 0) FrostOverlay(alpha = game.frostAlpha)
+                if (game.isSlowed) Box(modifier = Modifier.fillMaxSize().background(Color(0xFFFFD54F).copy(alpha = 0.1f)))
 
-                uiState.activeShockwaves.forEach { shock ->
+                game.activeShockwaves.forEach { shock ->
                     key(shock.id) {
                         ShockwaveRenderer(centerX = blockSize * shock.col + (blockSize / 2), centerY = blockHeight * shock.row + (blockHeight / 2))
                     }
                 }
 
-                uiState.matchGhosts.forEach { ghost ->
+                game.matchGhosts.forEach { ghost ->
                     key(ghost.id) {
                         MatchGhostRenderer(ghost = ghost, blockSize = blockSize, blockHeight = blockHeight)
                     }
                 }
 
-                uiState.confettiBursts.forEach { burst ->
+                game.confettiBursts.forEach { burst ->
                     key(burst.id) {
                         ConfettiBurstRenderer(centerX = blockSize * burst.col + (blockSize / 2), centerY = blockHeight * burst.row + (blockHeight / 2))
                     }
                 }
 
-                uiState.floatingTexts.forEach { effect ->
+                game.floatingTexts.forEach { effect ->
                     key(effect.id) {
                         FloatingTextRenderer(effect = effect, blockSize = blockSize, blockHeight = blockHeight)
                     }
                 }
 
-                uiState.floatingScores.forEach { popup ->
+                game.floatingScores.forEach { popup ->
                     key(popup.id) {
                         ScorePopupRenderer(popup = popup, blockSize = blockSize, blockHeight = blockHeight)
                     }
                 }
 
                 // Combo & Frenzy Announcer
-                if (uiState.combo > 1) {
+                if (game.combo > 1) {
                     Box(modifier = Modifier.fillMaxSize().padding(top = 20.dp), contentAlignment = Alignment.TopCenter) {
                         Text(
-                            text = if (uiState.isFrenzy) stringResource(R.string.applications_gotmind_features_memblox_frenzy) else stringResource(R.string.applications_gotmind_features_memblox_combo, uiState.multiplier),
+                            text = if (game.isFrenzy) stringResource(R.string.applications_gotmind_features_memblox_frenzy) else stringResource(R.string.applications_gotmind_features_memblox_combo, game.multiplier),
                             style = MaterialTheme.typography.headlineMedium,
                             fontWeight = FontWeight.Black,
-                            color = if (uiState.isFrenzy) Color(0xFFE91E63) else Color(0xFFFF5722),
+                            color = if (game.isFrenzy) Color(0xFFE91E63) else Color(0xFFFF5722),
                             modifier = Modifier
                                 .background(Color.Black.copy(alpha = 0.4f), RoundedCornerShape(12.dp))
                                 .padding(horizontal = 16.dp, vertical = 4.dp)
@@ -342,10 +345,10 @@ fun MemBloxScreen(
                     }
                 }
 
-                if (uiState.isGameOver || uiState.isVictory) {
+                if (game.isGameOver || game.isVictory) {
                     EndGameOverlay(
-                        state = uiState, 
-                        onRetry = { onEvent(MemBloxEvent.StartGame(uiState.difficulty)) }, 
+                        state = game, 
+                        onRetry = { onEvent(MemBloxEvent.StartGame(game.difficulty)) }, 
                         onRetrySelection = { onEvent(MemBloxEvent.ResetToSelection) }
                     )
                 }
@@ -362,8 +365,8 @@ fun MemBloxScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 PowerUpType.entries.forEach { type ->
-                    val count = uiState.powerUps[type] ?: 0
-                    val isAvailable = count > 0 && !uiState.isGameOver && !uiState.isVictory && !uiState.isPaused
+                    val count = game.powerUps[type] ?: 0
+                    val isAvailable = count > 0 && !game.isGameOver && !game.isVictory && !game.isPaused
                     ElevatedAssistChip(
                         onClick = { onEvent(MemBloxEvent.UsePowerUp(type)) },
                         label = { Text("${stringResource(type.labelResId)} ($count)", style = MaterialTheme.typography.labelSmall, color = if (isAvailable) Color.White else Color.Gray) },
@@ -379,6 +382,18 @@ fun MemBloxScreen(
                 }
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun MemBloxScreenPreview() {
+    MaterialTheme {
+        MemBloxScreen(
+            uiState = MemBloxUiState(),
+            onEvent = {},
+            navTo = {}
+        )
     }
 }
 

--- a/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
+++ b/applications/gotmind/features/mindwave/src/main/java/com/zoewave/probase/gotmind/features/mindwave/ui/MindWaveScreen.kt
@@ -72,19 +72,22 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.tooling.preview.Preview
 import com.zoewave.probase.gotmind.features.mindwave.HapticSignal
 import com.zoewave.probase.gotmind.features.mindwave.MindWaveEvent
 import com.zoewave.probase.gotmind.features.mindwave.MindWaveState
 import com.zoewave.probase.gotmind.features.mindwave.Node
 import com.zoewave.probase.gotmind.features.mindwave.R
 import com.zoewave.probase.gotmind.model.MindWaveMode
+import com.zoewave.probase.gotmind.model.GotMindRoute
 import kotlin.random.Random
 
 @Composable
 fun MindWaveScreen(
     uiState: MindWaveState,
-    onNav: (String) -> Unit,
-    onEvent: (MindWaveEvent) -> Unit
+    modifier: Modifier = Modifier,
+    onEvent: (MindWaveEvent) -> Unit,
+    navTo: (GotMindRoute) -> Unit
 ) {
     var showControls by remember { mutableStateOf(false) }
     val haptic = LocalHapticFeedback.current
@@ -109,7 +112,7 @@ fun MindWaveScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F0F0F))) {
+    Box(modifier = modifier.fillMaxSize().background(Color(0xFF0F0F0F))) {
         MindWaveBackground()
         
         Column(
@@ -131,7 +134,7 @@ fun MindWaveScreen(
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 IconButton(
-                    onClick = { onNav("BACK") },
+                    onClick = { navTo(GotMindRoute.Back) },
                     modifier = Modifier.size(36.dp).background(Color.White.copy(alpha = 0.1f), CircleShape)
                 ) {
                     Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
@@ -174,7 +177,7 @@ fun MindWaveScreen(
                         Button(
                             onClick = { 
                                 onEvent(MindWaveEvent.ResetGame)
-                                onNav("BACK") 
+                                navTo(GotMindRoute.Back) 
                             },
                             modifier = Modifier.weight(1f).height(40.dp),
                             colors = ButtonDefaults.buttonColors(containerColor = Color.Red.copy(alpha = 0.2f), contentColor = Color.Red),
@@ -371,10 +374,22 @@ fun MindWaveScreen(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { onNav("BACK") }) {
+                TextButton(onClick = { navTo(GotMindRoute.Back) }) {
                     Text(stringResource(R.string.applications_gotmind_features_mindwave_back_hub), color = Color.Gray)
                 }
             }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun MindWaveScreenPreview() {
+    MaterialTheme {
+        MindWaveScreen(
+            uiState = MindWaveState(),
+            onEvent = {},
+            navTo = {}
         )
     }
 }

--- a/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsScreen.kt
+++ b/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsScreen.kt
@@ -60,8 +60,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.tooling.preview.Preview
 import com.zoewave.probase.gotmind.features.memblox.MemBloxEvent
-import com.zoewave.probase.gotmind.features.memblox.MemBloxState
 import com.zoewave.probase.gotmind.features.settings.R
 import com.zoewave.probase.gotmind.model.AppTheme
 import com.zoewave.probase.gotmind.model.ColorPalette
@@ -71,6 +71,7 @@ import com.zoewave.probase.gotmind.model.MindWaveMode
 import com.zoewave.probase.gotmind.model.NodeShape
 import com.zoewave.probase.gotmind.model.InstrumentType
 import com.zoewave.probase.gotmind.model.GameSettings
+import com.zoewave.probase.gotmind.model.GotMindRoute
 import java.util.Locale
 
 @Composable
@@ -238,15 +239,17 @@ fun SettingsSwitchField(
 
 @Composable
 fun SettingsScreen(
-    gameSettings: GameSettings = GameSettings(),
-    themeSettings: ThemeSettings = ThemeSettings(),
-    firebaseId: String = "",
-    onMemBloxEvent: (MemBloxEvent) -> Unit = {},
-    onSettingsEvent: (SettingsEvent) -> Unit = {},
-    onBack: () -> Unit = {}
+    uiState: SettingsUiState,
+    modifier: Modifier = Modifier,
+    onEvent: (SettingsScreenEvent) -> Unit,
+    navTo: (GotMindRoute) -> Unit
 ) {
+    val gameSettings = uiState.gameSettings
+    val themeSettings = uiState.themeSettings
+    val firebaseId = uiState.firebaseId
+
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(Color(0xFF0F0F0F))
             .statusBarsPadding()
@@ -260,7 +263,7 @@ fun SettingsScreen(
                 .padding(vertical = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            IconButton(onClick = onBack) {
+            IconButton(onClick = { navTo(GotMindRoute.Back) }) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null, tint = Color.White)
             }
             Spacer(modifier = Modifier.width(8.dp))
@@ -290,7 +293,7 @@ fun SettingsScreen(
                         AppTheme.LIGHT to stringResource(R.string.applications_gotmind_features_settings_theme_light),
                         AppTheme.DARK to stringResource(R.string.applications_gotmind_features_settings_theme_dark)
                     ),
-                    onSelected = { onSettingsEvent(SettingsEvent.SetTheme(it)) }
+                    onSelected = { onEvent(SettingsScreenEvent.Settings(SettingsEvent.SetTheme(it))) }
                 )
 
                 SettingsDropdownField(
@@ -304,7 +307,7 @@ fun SettingsScreen(
                         ColorPalette.OCEAN to stringResource(R.string.applications_gotmind_features_settings_palette_ocean),
                         ColorPalette.MATERIAL_EXPRESSIVE to stringResource(R.string.applications_gotmind_features_settings_palette_expressive)
                     ),
-                    onSelected = { onSettingsEvent(SettingsEvent.SetPalette(it)) }
+                    onSelected = { onEvent(SettingsScreenEvent.Settings(SettingsEvent.SetPalette(it))) }
                 )
             }
         }
@@ -321,14 +324,14 @@ fun SettingsScreen(
                     title = stringResource(R.string.applications_gotmind_features_settings_haptic_title),
                     subtitle = stringResource(R.string.applications_gotmind_features_settings_haptic_subtitle),
                     checked = gameSettings.hapticsEnabled,
-                    onCheckedChange = { onMemBloxEvent(MemBloxEvent.SetHapticsEnabled(it)) }
+                    onCheckedChange = { onEvent(SettingsScreenEvent.MemBlox(MemBloxEvent.SetHapticsEnabled(it))) }
                 )
                 HorizontalDivider(color = Color.White.copy(alpha = 0.05f))
                 SettingsSwitchField(
                     title = stringResource(R.string.applications_gotmind_features_settings_sound_title),
                     subtitle = stringResource(R.string.applications_gotmind_features_settings_sound_subtitle),
                     checked = gameSettings.soundEnabled,
-                    onCheckedChange = { onMemBloxEvent(MemBloxEvent.SetSoundEnabled(it)) }
+                    onCheckedChange = { onEvent(SettingsScreenEvent.MemBlox(MemBloxEvent.SetSoundEnabled(it))) }
                 )
             }
         }
@@ -350,7 +353,7 @@ fun SettingsScreen(
                     MindWaveMode.HARMONIC_ARC to stringResource(R.string.applications_gotmind_features_settings_mindwave_arc),
                     MindWaveMode.HARMONIC_RING to stringResource(R.string.applications_gotmind_features_settings_mindwave_ring)
                 ),
-                onSelected = { onSettingsEvent(SettingsEvent.SetMindWaveMode(it)) }
+                onSelected = { onEvent(SettingsScreenEvent.Settings(SettingsEvent.SetMindWaveMode(it))) }
             )
 
             SettingsDropdownField(
@@ -361,7 +364,7 @@ fun SettingsScreen(
                     NodeShape.CIRCLE to stringResource(R.string.applications_gotmind_features_settings_mw_node_shape_circle),
                     NodeShape.PIANO_KEY to stringResource(R.string.applications_gotmind_features_settings_mw_node_shape_piano)
                 ),
-                onSelected = { onSettingsEvent(SettingsEvent.SetMindWaveNodeShape(it)) }
+                onSelected = { onEvent(SettingsScreenEvent.Settings(SettingsEvent.SetMindWaveNodeShape(it))) }
             )
 
             SettingsDropdownField(
@@ -373,14 +376,14 @@ fun SettingsScreen(
                     InstrumentType.RETRO_8BIT to stringResource(R.string.applications_gotmind_features_settings_mw_instrument_retro),
                     InstrumentType.ZEN_TRIANGLE to stringResource(R.string.applications_gotmind_features_settings_mw_instrument_zen)
                 ),
-                onSelected = { onSettingsEvent(SettingsEvent.SetInstrument(it)) }
+                onSelected = { onEvent(SettingsScreenEvent.Settings(SettingsEvent.SetInstrument(it))) }
             )
 
             SettingsSwitchField(
                 title = stringResource(R.string.applications_gotmind_features_settings_mw_song_master),
                 subtitle = stringResource(R.string.applications_gotmind_features_settings_mw_song_master_desc),
                 checked = gameSettings.songMasterEnabled,
-                onCheckedChange = { onSettingsEvent(SettingsEvent.SetSongMaster(it)) }
+                onCheckedChange = { onEvent(SettingsScreenEvent.Settings(SettingsEvent.SetSongMaster(it))) }
             )
         }
 
@@ -393,7 +396,7 @@ fun SettingsScreen(
                 subtitle = stringResource(com.zoewave.probase.gotmind.features.memblox.R.string.applications_gotmind_features_memblox_engine_mode_desc),
                 checked = gameSettings.engineType == MemBloxEngineType.FALLING,
                 onCheckedChange = { isFalling: Boolean ->
-                    onMemBloxEvent(MemBloxEvent.SetEngineType(if (isFalling) MemBloxEngineType.FALLING else MemBloxEngineType.STATIC))
+                    onEvent(SettingsScreenEvent.MemBlox(MemBloxEvent.SetEngineType(if (isFalling) MemBloxEngineType.FALLING else MemBloxEngineType.STATIC)))
                 }
             )
 
@@ -402,7 +405,7 @@ fun SettingsScreen(
                 value = gameSettings.gameSpeed,
                 valueRange = 0.5f..2.0f,
                 steps = 15,
-                onValueChange = { onMemBloxEvent(MemBloxEvent.UpdateSpeed(it)) },
+                onValueChange = { onEvent(SettingsScreenEvent.MemBlox(MemBloxEvent.UpdateSpeed(it))) },
                 valueLabel = String.format(Locale.getDefault(), "%.1f", gameSettings.gameSpeed) + "x"
             )
 
@@ -412,7 +415,7 @@ fun SettingsScreen(
                     value = gameSettings.dropHeight.toFloat(),
                     valueRange = 1f..10f,
                     steps = 9,
-                    onValueChange = { onMemBloxEvent(MemBloxEvent.UpdateDropHeight(it.toInt())) },
+                    onValueChange = { onEvent(SettingsScreenEvent.MemBlox(MemBloxEvent.UpdateDropHeight(it.toInt()))) },
                     valueLabel = "${gameSettings.dropHeight}"
                 )
 
@@ -421,7 +424,7 @@ fun SettingsScreen(
                     value = gameSettings.dropDurationMillis.toFloat(),
                     valueRange = 1000f..10000f,
                     steps = 18,
-                    onValueChange = { onMemBloxEvent(MemBloxEvent.UpdateDropDuration(it.toInt())) },
+                    onValueChange = { onEvent(SettingsScreenEvent.MemBlox(MemBloxEvent.UpdateDropDuration(it.toInt()))) },
                     valueLabel = String.format(Locale.getDefault(), "%.1f", gameSettings.dropDurationMillis / 1000f) + "s"
                 )
             }
@@ -479,5 +482,17 @@ fun SettingsScreen(
         }
         
         Spacer(modifier = Modifier.height(48.dp))
+    }
+}
+
+@Preview
+@Composable
+private fun SettingsScreenPreview() {
+    MaterialTheme {
+        SettingsScreen(
+            uiState = SettingsUiState(),
+            onEvent = {},
+            navTo = {}
+        )
     }
 }

--- a/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsUiState.kt
+++ b/applications/gotmind/features/settings/src/main/java/com/zoewave/probase/gotmind/features/settings/ui/SettingsUiState.kt
@@ -1,0 +1,16 @@
+package com.zoewave.probase.gotmind.features.settings.ui
+
+import com.zoewave.probase.gotmind.features.memblox.MemBloxEvent
+import com.zoewave.probase.gotmind.model.GameSettings
+import com.zoewave.probase.gotmind.model.ThemeSettings
+
+data class SettingsUiState(
+    val gameSettings: GameSettings = GameSettings(),
+    val themeSettings: ThemeSettings = ThemeSettings(),
+    val firebaseId: String = ""
+)
+
+sealed interface SettingsScreenEvent {
+    data class Settings(val event: SettingsEvent) : SettingsScreenEvent
+    data class MemBlox(val event: MemBloxEvent) : SettingsScreenEvent
+}

--- a/applications/gotmind/model/src/main/java/com/zoewave/probase/gotmind/model/GotMindRoute.kt
+++ b/applications/gotmind/model/src/main/java/com/zoewave/probase/gotmind/model/GotMindRoute.kt
@@ -1,0 +1,25 @@
+package com.zoewave.probase.gotmind.model
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface GotMindRoute {
+    // Top Level Tabs
+    @Serializable data object Games : GotMindRoute
+    @Serializable data object Leaderboard : GotMindRoute
+    @Serializable data object Settings : GotMindRoute
+
+    // Fullscreen Game Screens
+    @Serializable data object GotMindClassic : GotMindRoute
+    @Serializable data object MemBlox : GotMindRoute
+    @Serializable data object SoundMind : GotMindRoute
+
+    @Serializable data object Back : GotMindRoute
+}
+
+data class TopLevelDestination(
+    val route: GotMindRoute,
+    val icon: ImageVector,
+    val labelResId: Int
+)


### PR DESCRIPTION
This commit refactors the UI layer of the GotMind application to follow a standardized Unidirectional Data Flow (UDF) pattern. It replaces direct ViewModel references in screens with dedicated UI state and event models and centralizes navigation logic.

- **UI Architecture Refactor**:
    - Standardized `GameScreen`, `GamesScreen`, `LeaderboardScreen`, `MemBloxScreen`, `MindWaveScreen`, and `SettingsScreen` to accept `uiState`, `onEvent`, and `navTo` parameters.
    - Created new UI state and event definitions: `GotMindClassicUiState`, `GamesUiState`, `LeaderboardUiState`, `MemBloxUiState`, and `SettingsUiState`.
    - Added `@Preview` composables to all major screens to facilitate UI development.
- **Navigation Modernization**:
    - Moved `GotMindRoute` and `TopLevelDestination` from `MainActivity.kt` to a dedicated `:applications:gotmind:model` module for better separation of concerns.
    - Introduced a unified `navigateTo` lambda in `MainActivity` to handle backstack management, top-level destination clearing, and a new `GotMindRoute.Back` signal.
    - Updated screen navigation from string-based constants (e.g., "CLASSIC", "BACK") to type-safe `GotMindRoute` objects.
- **Documentation**:
    - Added `applications/gotmind/Docs/PlayStore/Release/Release.md` to document solutions for common Google Play Console rollout errors regarding app bundles and version codes.
- **Dependency Management**:
    - Updated `applications/gotmind/features/games/build.gradle.kts` to include the model project dependency.