### PR TITLE
refactor: migrate Room annotations to room3 and update datetime handling

### DIFF
--- a/applications/ashbike/database/build.gradle.kts
+++ b/applications/ashbike/database/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     // --- DataStore ---
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core)
+    implementation(libs.kotlinx.datetime)
 
     // --- Hilt & Room ---
     // Dependencies are AUTOMATICALLY added by the plugins above:

--- a/applications/ashbike/database/src/main/java/com/zoewave/probase/ashbike/database/BikeRideDB.kt
+++ b/applications/ashbike/database/src/main/java/com/zoewave/probase/ashbike/database/BikeRideDB.kt
@@ -2,7 +2,7 @@ package com.zoewave.probase.ashbike.database
 
 import androidx.room3.Database
 import androidx.room3.RoomDatabase
-import androidx.room3.TypeConverters
+import androidx.room3.ColumnTypeConverters
 import com.zoewave.probase.ashbike.database.converter.Converters
 
 @Database(
@@ -10,7 +10,7 @@ import com.zoewave.probase.ashbike.database.converter.Converters
     version = 1,
     exportSchema = false
 )
-@TypeConverters(Converters::class)
+@ColumnTypeConverters(Converters::class)
 @Suppress("ROOM_MISSING_CONSTRUCTED_BY")
 abstract class BikeRideDatabase : RoomDatabase() {
     abstract val bikeRideDao: BikeRideDao

--- a/applications/ashbike/database/src/main/java/com/zoewave/probase/ashbike/database/converter/Converters.kt
+++ b/applications/ashbike/database/src/main/java/com/zoewave/probase/ashbike/database/converter/Converters.kt
@@ -1,30 +1,22 @@
 package com.zoewave.probase.ashbike.database.converter
 
-import android.net.Uri
-import androidx.core.net.toUri
-import androidx.room3.TypeConverter
-
-//import kotlinx.datetime.LocalDateTime
+import androidx.room3.ColumnTypeConverter
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
 
 class Converters {
-
-    /*@TypeConverter
-    fun fromTimestrap(dateString: String?): LocalDateTime? {
-        return dateString?.let { LocalDateTime.parse(dateString) }
+    @ColumnTypeConverter
+    fun fromTimestamp(value: Long?): LocalDateTime? {
+        return value?.let {
+            Instant.fromEpochMilliseconds(it).toLocalDateTime(TimeZone.currentSystemDefault())
+        }
     }
 
-    @TypeConverter
-    fun toDateString(date: LocalDateTime?): String? {
-        return date?.toString()
-    }*/
-
-    @TypeConverter
-    fun fromString(value: String?): Uri? {
-        return if (value == null) null else value.toUri()
-    }
-
-    @TypeConverter
-    fun toString(uri: Uri?): String? {
-        return uri?.toString()
+    @ColumnTypeConverter
+    fun dateToTimestamp(date: LocalDateTime?): Long? {
+        return date?.toInstant(TimeZone.currentSystemDefault())?.toEpochMilliseconds()
     }
 }

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/KoColorDatabase.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/KoColorDatabase.kt
@@ -2,7 +2,7 @@ package com.zoewave.probase.kocolor.db
 
 import androidx.room3.Database
 import androidx.room3.RoomDatabase
-import androidx.room3.TypeConverters
+import androidx.room3.ColumnTypeConverters
 import com.zoewave.probase.kocolor.db.converter.FashionConverters
 import com.zoewave.probase.kocolor.db.dao.ClothingDao
 import com.zoewave.probase.kocolor.db.dao.CosmeticDao
@@ -29,7 +29,7 @@ import com.zoewave.probase.kocolor.db.entity.SavedSuggestionEntity
     version = 6,
     exportSchema = false
 )
-@TypeConverters(FashionConverters::class)
+@ColumnTypeConverters(FashionConverters::class)
 @Suppress("ROOM_MISSING_CONSTRUCTED_BY")
 abstract class KoColorDatabase : RoomDatabase() {
     abstract val fashionProfileDao: FashionProfileDao

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/converter/FashionConverters.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/converter/FashionConverters.kt
@@ -1,6 +1,6 @@
 package com.zoewave.probase.kocolor.db.converter
 
-import androidx.room3.TypeConverter
+import androidx.room3.ColumnTypeConverter
 import com.zoewave.probase.kocolor.db.entity.InventoryType
 import com.zoewave.probase.core.model.ritual.*
 import kotlinx.serialization.encodeToString
@@ -9,93 +9,93 @@ import kotlinx.serialization.json.Json
 class FashionConverters {
     private val json = Json { ignoreUnknownKeys = true }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromFashionAdvice(value: FashionAdvice): String = json.encodeToString(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toFashionAdvice(value: String): FashionAdvice = json.decodeFromString<FashionAdvice>(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromInventoryMetadata(value: InventoryMetadata?): String? = value?.let { json.encodeToString(it) }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toInventoryMetadata(value: String?): InventoryMetadata? = value?.let { json.decodeFromString<InventoryMetadata>(it) }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromSeasonalType(value: SeasonalType): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toSeasonalType(value: String): SeasonalType = try { SeasonalType.valueOf(value) } catch (e: Exception) { SeasonalType.UNKNOWN }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromUndertone(value: Undertone): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toUndertone(value: String): Undertone = try { Undertone.valueOf(value) } catch (e: Exception) { Undertone.UNKNOWN }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromInventoryType(value: InventoryType): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toInventoryType(value: String): InventoryType = try { InventoryType.valueOf(value) } catch (e: Exception) { InventoryType.CLOTHES }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromStringList(value: List<String>): String = json.encodeToString(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toStringList(value: String): List<String> = try { json.decodeFromString<List<String>>(value) } catch (e: Exception) { emptyList() }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromRoutineStepList(value: List<RoutineStep>): String = json.encodeToString(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toRoutineStepList(value: String): List<RoutineStep> = try { json.decodeFromString<List<RoutineStep>>(value) } catch (e: Exception) { emptyList() }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromRoutineTime(value: RoutineTime): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toRoutineTime(value: String): RoutineTime = try { RoutineTime.valueOf(value) } catch (e: Exception) { RoutineTime.OTHER }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromMacroCategory(value: MacroCategory): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toMacroCategory(value: String): MacroCategory = try { MacroCategory.valueOf(value) } catch (e: Exception) { MacroCategory.TOOLS }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromMicroCategory(value: MicroCategory): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toMicroCategory(value: String): MicroCategory = try { MicroCategory.valueOf(value) } catch (e: Exception) { MicroCategory.OTHER }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromFormulation(value: Formulation): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toFormulation(value: String): Formulation = try { Formulation.valueOf(value) } catch (e: Exception) { Formulation.UNKNOWN }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromChemistryBase(value: ChemistryBase): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toChemistryBase(value: String): ChemistryBase = try { ChemistryBase.valueOf(value) } catch (e: Exception) { ChemistryBase.UNKNOWN }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromFinish(value: Finish): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toFinish(value: String): Finish = try { Finish.valueOf(value) } catch (e: Exception) { Finish.UNKNOWN }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromCoverage(value: Coverage): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toCoverage(value: String): Coverage = try { Coverage.valueOf(value) } catch (e: Exception) { Coverage.NOT_APPLICABLE }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromClothingCategory(value: ClothingCategory): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toClothingCategory(value: String): ClothingCategory = try { ClothingCategory.valueOf(value) } catch (e: Exception) { ClothingCategory.OTHER }
 }

--- a/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/PhotoDoDatabase.kt
+++ b/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/PhotoDoDatabase.kt
@@ -3,7 +3,7 @@ package com.zoewave.probase.applications.photodo.db
 import androidx.room3.AutoMigration
 import androidx.room3.Database
 import androidx.room3.RoomDatabase
-import androidx.room3.TypeConverters
+import androidx.room3.ColumnTypeConverters
 import com.zoewave.probase.applications.photodo.db.converter.PhotoDoConverters
 import com.zoewave.probase.applications.photodo.db.entity.CategoryEntity
 import com.zoewave.probase.applications.photodo.db.entity.ExpenseEntity
@@ -29,7 +29,7 @@ import com.zoewave.probase.applications.photodo.db.entity.time.TimeLogEntity
         // We keep the version at 4 to maintain database compatibility.
     ]
 )
-@TypeConverters(PhotoDoConverters::class)
+@ColumnTypeConverters(PhotoDoConverters::class)
 @Suppress("ROOM_MISSING_CONSTRUCTED_BY")
 abstract class PhotoDoDB : RoomDatabase() {
     abstract fun photoDoDao(): PhotoDoDao

--- a/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/converter/Converters.kt
+++ b/applications/photodo/db/src/main/java/com/zoewave/probase/applications/photodo/db/converter/Converters.kt
@@ -2,7 +2,7 @@ package com.zoewave.probase.applications.photodo.db.converter
 
 import android.net.Uri
 import androidx.core.net.toUri
-import androidx.room3.TypeConverter
+import androidx.room3.ColumnTypeConverter
 import com.zoewave.probase.applications.photodo.db.entity.CategoryEntity
 import com.zoewave.probase.applications.photodo.db.model.Category
 import kotlin.time.Instant
@@ -11,34 +11,34 @@ import kotlin.time.Instant
 class PhotoDoConverters {
 
     // --- Date/Time ---
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromTimestamp(value: Long?): Instant? {
         return value?.let { Instant.fromEpochMilliseconds(it) }
     }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun dateToTimestamp(date: Instant?): Long? {
         return date?.toEpochMilliseconds()
     }
 
     // --- URIs ---
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromUri(uri: Uri?): String? {
         return uri?.toString()
     }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toUri(uriString: String?): Uri? {
         return uriString?.toUri()
     }
 
     // --- String Lists ---
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromStringList(list: List<String>?): String? {
         return list?.joinToString(separator = ",")
     }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toStringList(data: String?): List<String>? {
         return data?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
     }

--- a/applications/rxlogic/db/src/main/java/com/zoewave/probase/rxlogic/db/RxLogicConverters.kt
+++ b/applications/rxlogic/db/src/main/java/com/zoewave/probase/rxlogic/db/RxLogicConverters.kt
@@ -1,6 +1,6 @@
 package com.zoewave.probase.rxlogic.db
 
-import androidx.room3.TypeConverter
+import androidx.room3.ColumnTypeConverter
 import com.zoewave.probase.rxlogic.model.Frequency
 import com.zoewave.probase.rxlogic.model.LogStatus
 import kotlinx.datetime.Instant
@@ -9,33 +9,33 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 class RxLogicConverters {
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromFrequency(value: Frequency): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toFrequency(value: String): Frequency = Frequency.valueOf(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromLogStatus(value: LogStatus): String = value.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toLogStatus(value: String): LogStatus = LogStatus.valueOf(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromInstant(value: Instant): Long = value.toEpochMilliseconds()
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toInstant(value: Long): Instant = Instant.fromEpochMilliseconds(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromLocalTime(value: LocalTime): String = value.toString()
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toLocalTime(value: String): LocalTime = LocalTime.parse(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromLocalTimeList(value: List<LocalTime>): String = Json.encodeToString(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toLocalTimeList(value: String): List<LocalTime> = Json.decodeFromString(value)
 }

--- a/applications/rxlogic/db/src/main/java/com/zoewave/probase/rxlogic/db/RxLogicDatabase.kt
+++ b/applications/rxlogic/db/src/main/java/com/zoewave/probase/rxlogic/db/RxLogicDatabase.kt
@@ -2,14 +2,14 @@ package com.zoewave.probase.rxlogic.db
 
 import androidx.room3.Database
 import androidx.room3.RoomDatabase
-import androidx.room3.TypeConverters
+import androidx.room3.ColumnTypeConverters
 
 @Database(
     entities = [MedicationEntity::class, MedicationLogEntity::class],
     version = 1,
     exportSchema = false
 )
-@TypeConverters(RxLogicConverters::class)
+@ColumnTypeConverters(RxLogicConverters::class)
 abstract class RxLogicDatabase : RoomDatabase() {
     abstract fun medicationDao(): MedicationDao
 }

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/SeaweedDatabase.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/SeaweedDatabase.kt
@@ -2,7 +2,7 @@ package com.zoewave.probase.seaweed.database
 
 import androidx.room3.Database
 import androidx.room3.RoomDatabase
-import androidx.room3.TypeConverters
+import androidx.room3.ColumnTypeConverters
 import com.zoewave.probase.seaweed.database.converter.ExpenseConverters
 
 @Database(
@@ -18,7 +18,7 @@ import com.zoewave.probase.seaweed.database.converter.ExpenseConverters
     version = 1,
     exportSchema = false
 )
-@TypeConverters(ExpenseConverters::class)
+@ColumnTypeConverters(ExpenseConverters::class)
 @Suppress("ROOM_MISSING_CONSTRUCTED_BY")
 abstract class SeaweedDatabase : RoomDatabase() {
     abstract val transactionDao: TransactionDao

--- a/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/converter/ExpenseConverters.kt
+++ b/applications/seaweed/database/src/main/java/com/zoewave/probase/seaweed/database/converter/ExpenseConverters.kt
@@ -1,6 +1,6 @@
 package com.zoewave.probase.seaweed.database.converter
 
-import androidx.room3.TypeConverter
+import androidx.room3.ColumnTypeConverter
 import com.zoewave.probase.seaweed.model.ExpenseCategory
 import com.zoewave.probase.seaweed.model.ExpenseFrequency
 import com.zoewave.probase.seaweed.model.SeaweedThemeConfig
@@ -8,33 +8,33 @@ import com.zoewave.probase.seaweed.model.SpendingType
 import com.zoewave.probase.seaweed.model.ThemeMode
 
 class ExpenseConverters {
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromFrequency(frequency: ExpenseFrequency): String = frequency.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toFrequency(value: String): ExpenseFrequency = ExpenseFrequency.valueOf(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromCategory(category: ExpenseCategory): String = category.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toCategory(value: String): ExpenseCategory = ExpenseCategory.valueOf(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromThemeConfig(config: SeaweedThemeConfig): String = config.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toThemeConfig(value: String): SeaweedThemeConfig = SeaweedThemeConfig.valueOf(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromThemeMode(mode: ThemeMode): String = mode.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toThemeMode(value: String): ThemeMode = ThemeMode.valueOf(value)
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromImportance(type: SpendingType): String = type.name
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toImportance(value: String): SpendingType = SpendingType.valueOf(value)
 }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -27,13 +27,15 @@ dependencies {
 
     // --- Core Android ---
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.room.common)
+    implementation(libs.kotlinx.coroutines.core)
+    // implementation(libs.androidx.room.common)
     // Note: 'appcompat' and 'material.legacy' are usually not needed in a pure data module
     // unless you are using specific Android resource classes.
     // implementation(libs.androidx.appcompat)
     // implementation(libs.material.legacy)
 
     // --- Hilt & Room ---
+    ksp(libs.androidx.room.common)
     // Dependencies are AUTOMATICALLY added by:
     // - id("composetemplate.android.hilt")
     // - id("composetemplate.android.room")

--- a/core/database/src/main/java/com/zoewave/probase/core/database/BaseProEntity.kt
+++ b/core/database/src/main/java/com/zoewave/probase/core/database/BaseProEntity.kt
@@ -1,31 +1,16 @@
 package com.zoewave.probase.core.database
 
 import androidx.room3.ColumnInfo
+import androidx.room3.ColumnTypeConverters
 import androidx.room3.Entity
 import androidx.room3.PrimaryKey
-import androidx.room3.TypeConverters
 import com.zoewave.probase.core.database.converter.Converters
 
 @Entity(tableName = "basepro_table")
-@TypeConverters(Converters::class)
+@ColumnTypeConverters(Converters::class)
 data class BaseProEntity(
     @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "id") val todoId: Int = 0,
     @ColumnInfo(name = "title") val title: String = "",
     @ColumnInfo(name = "description") val description: String = "",
-    @ColumnInfo(name = "image_path") val imgPath: String? = null // Store image path as a String
-    // @ColumnInfo(name = "timestamp") val timestamp : ZonedDateTime = ZonedDateTime.now(),
-    // @ColumnInfo(name = "date") val timestamp: kotlinx.datetime.LocalDateTime? = null,
-    // kotlinx.datetime.Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()),
-    /*@ColumnInfo(name = "lat") val lat: Double = 0.0,
-    @ColumnInfo(name = "lon") val lon: Double = 0.0,
-    @ColumnInfo(name = "alarmOn") val alarmOn: Boolean = false,
-    @ColumnInfo(name = "completed") val isCompleted: Boolean = false,
-    @ColumnInfo(name = "image_path") val imgPath: Uri? = null,
-    @ColumnInfo(name = "audio_path") val audioPath: Uri? = null*/
-
-)
-
-data class BaseProUpdate(
-    val id: Int,
-    //val alarmOn: Boolean
+    @ColumnInfo(name = "image_path") val imgPath: String? = null
 )

--- a/core/database/src/main/java/com/zoewave/probase/core/database/BaseProUpdate.kt
+++ b/core/database/src/main/java/com/zoewave/probase/core/database/BaseProUpdate.kt
@@ -1,0 +1,7 @@
+package com.zoewave.probase.core.database
+
+import androidx.room3.ColumnInfo
+
+data class BaseProUpdate(
+    @ColumnInfo(name = "id") val todoId: Int,
+)

--- a/core/database/src/main/java/com/zoewave/probase/core/database/converter/Converters.kt
+++ b/core/database/src/main/java/com/zoewave/probase/core/database/converter/Converters.kt
@@ -1,28 +1,16 @@
 package com.zoewave.probase.core.database.converter
 
 import android.net.Uri
-import androidx.room3.TypeConverter
-
-//import kotlinx.datetime.LocalDateTime
+import androidx.room3.ColumnTypeConverter
 
 class Converters {
 
-    /*@TypeConverter
-    fun fromTimestrap(dateString: String?): LocalDateTime? {
-        return dateString?.let { LocalDateTime.parse(dateString) }
-    }
-
-    @TypeConverter
-    fun toDateString(date: LocalDateTime?): String? {
-        return date?.toString()
-    }*/
-
-    @TypeConverter
+    @ColumnTypeConverter
     fun fromString(value: String?): Uri? {
         return if (value == null) null else Uri.parse(value)
     }
 
-    @TypeConverter
+    @ColumnTypeConverter
     fun toString(uri: Uri?): String? {
         return uri?.toString()
     }


### PR DESCRIPTION
This commit refactors the database layer across multiple modules to support `androidx.room3` APIs, replacing legacy type converter annotations and standardizing datetime conversions.

- **Room Annotation Migration**:
    - Replaced `@TypeConverter` with `@ColumnTypeConverter` in all converter classes across `ashbike`, `kocolor`, `photodo`, `rxlogic`, `seaweed`, and `core` modules.
    - Updated database definitions to use `@ColumnTypeConverters` instead of `@TypeConverters`.
- **Datetime Implementation**:
    - Refactored `ashbike` database converters to use `kotlinx.datetime` (`Instant`, `LocalDateTime`) instead of legacy string or Uri-based conversion.
    - Added `kotlinx-datetime` dependency to the `ashbike` database module.
- **Core Database Cleanup**:
    - Extracted `BaseProUpdate` into its own file from `BaseProEntity.kt` and added explicit `@ColumnInfo` mapping for the ID field.
    - Cleaned up `BaseProEntity.kt` and `Converters.kt` in the core module by removing obsolete commented-out code and unused imports.
- **Dependency Updates**:
    - Added `ksp(libs.androidx.room.common)` and `kotlinx.coroutines.core` to `core/database/build.gradle.kts` to support the updated Room processing.