### PR TITLE
refactor: replace Card with ActionCard for actionable UI elements

### DIFF
--- a/features/xr/glass/samples/src/main/java/com/zoewave/probase/features/xr/glass/samples/CardSamples.kt
+++ b/features/xr/glass/samples/src/main/java/com/zoewave/probase/features/xr/glass/samples/CardSamples.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.xr.glimmer.ActionCard
 import androidx.xr.glimmer.Button
 import androidx.xr.glimmer.Card
 import androidx.xr.glimmer.GlimmerTheme
@@ -32,11 +33,11 @@ fun CardSamples() {
             Text("This card is interactive and provides visual feedback when focused/clicked.")
         }
 
-        Card(
+        ActionCard(
             title = { Text("Card with Action") },
             action = { Button(onClick = {}) { Text("Action") } }
         ) {
-            Text("This card has an explicit action button in the header.")
+            Text("This card has an explicit action button at the bottom.")
         }
     }
 }

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GoogleTestGlassesActivity.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GoogleTestGlassesActivity.kt
@@ -21,8 +21,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import androidx.xr.glimmer.ActionCard
 import androidx.xr.glimmer.Button
-import androidx.xr.glimmer.Card
 import androidx.xr.glimmer.GlimmerTheme
 import androidx.xr.glimmer.ListItem
 import androidx.xr.glimmer.Text
@@ -134,7 +134,7 @@ fun GoogleTestHomeScreen(
         contentAlignment = Alignment.Center
     ) {
         if (isVisualUiSupported) {
-            Card(
+            ActionCard(
                 title = { Text("Android XR Test") },
                 action = {
                     Button(onClick = onClose) {


### PR DESCRIPTION
This commit migrates UI components from the generic `Card` to the more specialized `ActionCard` in XR glass samples and test activities, aligning with updated Glimmer UI patterns for interactive elements.

- **Component Migration**:
    - Replaced `Card` with `ActionCard` in `GoogleTestGlassesActivity.kt` and `CardSamples.kt` where an explicit action button is present.
- **Documentation & Samples**:
    - Updated the descriptive text in `CardSamples.kt` to reflect that action buttons are positioned at the bottom of the `ActionCard` rather than in the header.
- **Code Cleanup**:
    - Updated imports in both modified files to include `ActionCard` and removed the unused `Card` import from `GoogleTestGlassesActivity.kt`.