### PR TITLE
feat: implement hardware bypass for local AI and handle unsupported s…

### DIFF
--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -307,28 +307,36 @@ class BoxCaptureViewModel @Inject constructor(
                 sessionRepository.updateServiceStatus("obf", ServiceStatus.FAILED, "Barcode not in OBF.")
             }
 
-            // 2. Local AI Cleanup (Always run or only on OBF failure/incomplete?)
-            // Let's run it if OBF failed or data is thin
+            // 2. Local AI Cleanup
             if (brand.isNullOrBlank() || name.isNullOrBlank()) {
                 sessionRepository.updateServiceStatus("localai", ServiceStatus.ACCESSING, "Synthesizing OCR text...")
                 val ocrData = performDeepOcr()
                 val localAiResult = localAi.standardizeOcrText(ocrData.ingredientsOcr + "\n" + ocrData.instructionsOcr)
                 
-                if (!localAiResult.brand.isNullOrBlank()) {
-                    sessionRepository.updateServiceStatus("localai", ServiceStatus.SUCCESS, "Found: ${localAiResult.brand}")
-                    brand = localAiResult.brand
-                    name = localAiResult.productName
-                    topIngredient = localAiResult.ingredients.firstOrNull() ?: topIngredient
-                } else {
-                    sessionRepository.updateServiceStatus("localai", ServiceStatus.FAILED, "No brand identified.")
+                localAiResult.onSuccess { data ->
+                    if (!data.brand.isNullOrBlank()) {
+                        sessionRepository.updateServiceStatus("localai", ServiceStatus.SUCCESS, "Found: ${data.brand}")
+                        brand = data.brand
+                        name = data.productName
+                        topIngredient = data.ingredients.firstOrNull() ?: topIngredient
+                    } else {
+                        sessionRepository.updateServiceStatus("localai", ServiceStatus.FAILED, "No brand identified.")
+                    }
+                }.onFailure {
+                    // Hardware Bypass
+                    sessionRepository.updateServiceStatus("localai", ServiceStatus.UNSUPPORTED, "Hardware bypass active.")
+                    // Fallback to simple brand extraction if Nano is unsupported
+                    val fallbackBrand = extractBrandFromText(ocrData.ingredientsOcr + " " + ocrData.instructionsOcr)
+                    brand = fallbackBrand
                 }
             } else {
                 sessionRepository.updateServiceStatus("localai", ServiceStatus.SUCCESS, "Using OBF context.")
             }
 
             // 3. Parallel Server Enrichment
-            if (!brand.isNullOrBlank()) {
-                startBackgroundEnrichment(brand, name ?: "", code, topIngredient)
+            val finalBrand = brand
+            if (!finalBrand.isNullOrBlank()) {
+                startBackgroundEnrichment(finalBrand, name ?: "", code, topIngredient)
             } else {
                 // Final hard fail for others
                 sessionRepository.updateServiceStatus("fda", ServiceStatus.FAILED, "No product context.")
@@ -402,6 +410,10 @@ class BoxCaptureViewModel @Inject constructor(
     }
 
     private data class OcrResults(val ingredientsOcr: String, val instructionsOcr: String)
+
+    private fun extractBrandFromText(text: String): String? {
+        return if (text.isNotBlank()) text.split(" ").firstOrNull { it.length > 2 && it[0].isUpperCase() } else null
+    }
 
     private fun prepareReview(mode: CaptureMode) {
         viewModelScope.launch {

--- a/applications/kocolor/features/clothingcapture/src/main/java/com/zoewave/probase/kocolor/features/clothingcapture/ui/ClothingCaptureViewModel.kt
+++ b/applications/kocolor/features/clothingcapture/src/main/java/com/zoewave/probase/kocolor/features/clothingcapture/ui/ClothingCaptureViewModel.kt
@@ -202,11 +202,16 @@ class ClothingCaptureViewModel @Inject constructor(
 
             if (localLabelsOcr.isNotBlank()) {
                 sessionRepository.updateServiceStatus("localai", ServiceStatus.ACCESSING, "Synthesizing label text...")
-                val result = localAi.standardizeOcrText(localLabelsOcr)
-                if (!result.brand.isNullOrBlank()) {
-                    sessionRepository.updateServiceStatus("localai", ServiceStatus.SUCCESS, "Found: ${result.brand}")
-                } else {
-                    sessionRepository.updateServiceStatus("localai", ServiceStatus.FAILED, "No label data extracted.")
+                val localAiResult = localAi.standardizeOcrText(localLabelsOcr)
+                
+                localAiResult.onSuccess { data ->
+                    if (!data.brand.isNullOrBlank()) {
+                        sessionRepository.updateServiceStatus("localai", ServiceStatus.SUCCESS, "Found: ${data.brand}")
+                    } else {
+                        sessionRepository.updateServiceStatus("localai", ServiceStatus.FAILED, "No label data extracted.")
+                    }
+                }.onFailure {
+                    sessionRepository.updateServiceStatus("localai", ServiceStatus.UNSUPPORTED, "Hardware bypass active.")
                 }
             } else {
                 sessionRepository.updateServiceStatus("localai", ServiceStatus.FAILED, "No label photo.")

--- a/core/model/src/main/java/com/zoewave/probase/core/model/network/DiscoveryStatus.kt
+++ b/core/model/src/main/java/com/zoewave/probase/core/model/network/DiscoveryStatus.kt
@@ -1,7 +1,7 @@
 package com.zoewave.probase.core.model.network
 
 enum class ServiceStatus {
-    IDLE, ACCESSING, SUCCESS, FAILED
+    IDLE, ACCESSING, SUCCESS, FAILED, UNSUPPORTED
 }
 
 data class ServiceHealth(

--- a/features/ai/local/src/main/java/com/zoewave/probase/features/ai/local/data/LocalAiEngine.kt
+++ b/features/ai/local/src/main/java/com/zoewave/probase/features/ai/local/data/LocalAiEngine.kt
@@ -29,10 +29,10 @@ class LocalAiEngine @Inject constructor() {
 
     /**
      * Uses on-device LLM (Gemini Nano) to clean up and standardize raw OCR text.
-     * This is crucial for making reliable server lookups in the next step.
+     * Returns Result.failure(UnsupportedOperationException) if hardware bypass is needed.
      */
-    suspend fun standardizeOcrText(rawText: String): LocalStandardizedData = withContext(Dispatchers.Default) {
-        if (rawText.isBlank()) return@withContext LocalStandardizedData()
+    suspend fun standardizeOcrText(rawText: String): Result<LocalStandardizedData> = withContext(Dispatchers.Default) {
+        if (rawText.isBlank()) return@withContext Result.success(LocalStandardizedData())
 
         try {
             val prompt = """
@@ -47,27 +47,16 @@ class LocalAiEngine @Inject constructor() {
             """.trimIndent()
 
             val response = localModel.generateContent(prompt)
-            val jsonText = response.text ?: return@withContext LocalStandardizedData()
+            val jsonText = response.text ?: return@withContext Result.success(LocalStandardizedData())
 
             // Handle potential LLM markdown artifacts
             val cleanedJson = jsonText.substringAfter("{").substringBeforeLast("}")
             val fullJson = "{$cleanedJson}"
 
-            json.decodeFromString<LocalStandardizedData>(fullJson)
+            Result.success(json.decodeFromString<LocalStandardizedData>(fullJson))
         } catch (e: Exception) {
-            android.util.Log.w("LocalAiEngine", "Local AI failed or unsupported: ${e.message}")
-            // Fallback to simple heuristic if local LLM is unavailable
-            heuristicFallback(rawText)
+            android.util.Log.w("LocalAiEngine", "Local AI hardware bypass triggered: ${e.message}")
+            Result.failure(e)
         }
-    }
-
-    private fun heuristicFallback(text: String): LocalStandardizedData {
-        val lines = text.lines().filter { it.isNotBlank() }
-        val brand = lines.firstOrNull { it.all { c -> c.isUpperCase() || c.isWhitespace() } }
-        val name = lines.find { it.length > 5 && it != brand }
-        return LocalStandardizedData(
-            brand = brand,
-            productName = name
-        )
     }
 }

--- a/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/DiscoveryStatusScreen.kt
+++ b/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/DiscoveryStatusScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -70,9 +71,11 @@ fun DiscoveryStatusScreen(
         )
     }
 
-    // Check if all services in current mode have finished (Success or Failed)
+    // Check if all services in current mode have finished (Success, Failed, or Unsupported)
     val allFinished = services.all { 
-        it.health.status == ServiceStatus.SUCCESS || it.health.status == ServiceStatus.FAILED 
+        it.health.status == ServiceStatus.SUCCESS || 
+        it.health.status == ServiceStatus.FAILED ||
+        it.health.status == ServiceStatus.UNSUPPORTED
     }
 
     Box(
@@ -184,6 +187,7 @@ private fun ServiceStatusRow(service: ServiceInfo) {
         when (service.health.status) {
             ServiceStatus.SUCCESS -> Color(0xFF065f46)
             ServiceStatus.FAILED -> Color(0xFF7f1d1d)
+            ServiceStatus.UNSUPPORTED -> Color(0xFF1e293b).copy(alpha = 0.3f)
             ServiceStatus.ACCESSING -> Color(0xFF1e293b)
             ServiceStatus.IDLE -> Color(0xFF1e293b).copy(alpha = 0.5f)
         },
@@ -193,6 +197,7 @@ private fun ServiceStatusRow(service: ServiceInfo) {
     val iconColor = when (service.health.status) {
         ServiceStatus.SUCCESS -> Color(0xFF34d399)
         ServiceStatus.FAILED -> Color(0xFFf87171)
+        ServiceStatus.UNSUPPORTED -> Color.Gray.copy(alpha = 0.5f)
         ServiceStatus.ACCESSING -> Color(0xFF60a5fa)
         ServiceStatus.IDLE -> Color.Gray
     }
@@ -233,6 +238,14 @@ private fun ServiceStatusRow(service: ServiceInfo) {
                             Icon(Icons.Default.Close, null, tint = iconColor, modifier = Modifier.padding(4.dp))
                         }
                     }
+                    ServiceStatus.UNSUPPORTED -> {
+                        Icon(
+                            androidx.compose.material.icons.Icons.Default.Info, 
+                            null, 
+                            tint = iconColor, 
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
                     ServiceStatus.ACCESSING -> {
                         CircularProgressIndicator(
                             modifier = Modifier.size(24.dp),
@@ -250,13 +263,13 @@ private fun ServiceStatusRow(service: ServiceInfo) {
                 Text(
                     service.name,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = Color.White,
+                    color = if (service.health.status == ServiceStatus.UNSUPPORTED) Color.Gray else Color.White,
                     fontWeight = FontWeight.Bold
                 )
                 Text(
                     service.health.note ?: service.description,
                     style = MaterialTheme.typography.labelSmall,
-                    color = Color.White.copy(alpha = 0.8f)
+                    color = if (service.health.status == ServiceStatus.UNSUPPORTED) Color.Gray.copy(alpha = 0.6f) else Color.White.copy(alpha = 0.8f)
                 )
             }
         }


### PR DESCRIPTION
…tates in UI

This commit refactors the local AI OCR standardization to handle hardware limitations gracefully. It introduces a `Result`-based API for the AI engine and adds an `UNSUPPORTED` service status to provide better feedback when on-device LLMs (like Gemini Nano) cannot run.

- **Local AI Engine**:
    - Updated `standardizeOcrText` in `LocalAiEngine` to return `Result<LocalStandardizedData>`, allowing callers to handle failures and hardware bypasses.
    - Removed internal heuristic fallbacks from the engine to ensure cleaner separation of concerns.
- **ViewModel Updates**:
    - Integrated `onSuccess` and `onFailure` handling for local AI results in `BoxCaptureViewModel` and `ClothingCaptureViewModel`.
    - Implemented a simple heuristic fallback in `BoxCaptureViewModel` to extract brand names from raw text when local AI is unavailable.
- **Discovery Status & UI**:
    - Added `UNSUPPORTED` to the `ServiceStatus` enum to represent services skipped due to hardware constraints.
    - Updated `DiscoveryStatusScreen` to visualize the unsupported state using a new `Info` icon and dimmed styling.
    - Modified completion logic to treat the `UNSUPPORTED` state as a finished service status during product discovery.
- **Models**:
    - Expanded `DiscoveryStatus.kt` to include the `UNSUPPORTED` status in the `ServiceStatus` enum.