### PR TITLE
feat: refine scanner ROI and relax OCR spatial filtering rules

### DIFF
--- a/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/ScannerOverlay.kt
+++ b/features/camera/productcapture/src/main/java/com/zoewave/probase/features/camera/productcapture/ui/ScannerOverlay.kt
@@ -4,22 +4,17 @@ import android.graphics.Rect
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect as ComposeRect
-import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.dp
 
 /**
  * A UI-driven targeting overlay for the "12-Megapixel Diet".
- * It darkens the background and punches out a clear ROI for the user to align the product.
+ * Displays only the targeting frame (bounding box) without any dimmed background.
  */
 @Composable
 fun ScannerOverlay(
@@ -30,9 +25,9 @@ fun ScannerOverlay(
         val canvasWidth = size.width
         val canvasHeight = size.height
 
-        // Define a tall ROI rectangle (ideal for bottles and boxes)
-        val rectWidth = canvasWidth * 0.75f
-        val rectHeight = canvasHeight * 0.55f 
+        // Define a "Full Height and Narrow" ROI rectangle
+        val rectWidth = canvasWidth * 0.62f // Narrow for better focus on product label
+        val rectHeight = canvasHeight * 0.96f // Maximum vertical coverage
         
         val left = (canvasWidth - rectWidth) / 2f
         val top = (canvasHeight - rectHeight) / 2f
@@ -41,32 +36,15 @@ fun ScannerOverlay(
 
         val androidRect = Rect(left.toInt(), top.toInt(), right.toInt(), bottom.toInt())
         
-        // Use a side effect to pass bounds back to the owner
+        // Pass the physical UI coordinates back for the "12-Megapixel Diet" cropping
         onBoundsCalculated(androidRect)
 
-        val overlayPath = Path().apply {
-            addRect(ComposeRect(0f, 0f, canvasWidth, canvasHeight))
-            addRoundRect(
-                RoundRect(
-                    left = left, top = top, right = right, bottom = bottom,
-                    cornerRadius = CornerRadius(24.dp.toPx())
-                )
-            )
-            fillType = PathFillType.EvenOdd
-        }
-
-        // 1. Draw the Dimmed Background
-        drawPath(
-            path = overlayPath,
-            color = Color.Black.copy(alpha = 0.7f)
-        )
-
-        // 2. Draw the targeting frame
+        // 2. Draw ONLY the targeting frame (No black background/mask)
         drawRoundRect(
-            color = Color.White.copy(alpha = 0.8f),
+            color = Color.White.copy(alpha = 0.9f),
             topLeft = Offset(left, top),
             size = Size(rectWidth, rectHeight),
-            cornerRadius = CornerRadius(24.dp.toPx()),
+            cornerRadius = CornerRadius(12.dp.toPx()), // Slimmer corners for narrow frame
             style = Stroke(width = 2.dp.toPx())
         )
     }

--- a/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/data/LocalOcrEngine.kt
+++ b/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/data/LocalOcrEngine.kt
@@ -82,43 +82,40 @@ class LocalOcrEngine @Inject constructor() {
             // Calculate relative vertical position (0.0 is top, 1.0 is bottom)
             val relativeTop = box.top.toFloat() / imageHeight.toFloat()
 
-            // --- RULE 1: The "Starburst" Filter (Top 15% of the bottle) ---
-            if (relativeTop < 0.15f) {
+            // --- RULE 1: Relaxed Starburst Filter (Top 10%) ---
+            if (relativeTop < 0.10f) {
                 val words = textLower.split("\\s+".toRegex())
                 val hasFluff = words.any { marketingFluff.contains(it) }
-                // If it's at the very top AND contains marketing words, destroy it.
-                if (hasFluff && block != heroBlock) {
+                // Only destroy if it's extreme marketing at the very peak
+                if (hasFluff && block != heroBlock && words.size < 3) {
                     continue 
                 }
             }
 
-            // --- RULE 2: Stop-Word Density Filter (Middle 65%) ---
-            if (relativeTop in 0.15f..0.80f) {
+            // --- RULE 2: Stop-Word Density Filter (Middle 80%) ---
+            if (relativeTop in 0.10f..0.90f) {
                 val words = textLower.split("\\s+".toRegex())
                 val fluffCount = words.count { marketingFluff.contains(it) }
                 
-                // If a block is densely packed with marketing buzzwords, drop it
-                // (Unless it's the Hero block, which we mathematically protect)
-                if (fluffCount >= 2 && block != heroBlock) {
+                // Loosened threshold: Drop only if it's almost entirely marketing speak
+                if (fluffCount >= 4 && block != heroBlock) {
                     continue
                 }
             }
 
-            // --- RULE 3: The Weight & Volume Filter (Bottom 20%) ---
-            if (relativeTop > 0.80f) {
+            // --- RULE 3: The Weight & Volume Filter (Bottom 10%) ---
+            if (relativeTop > 0.90f) {
                 // Check for standard cosmetic volume regex (e.g., "FL OZ", "mL", "Net Wt")
                 val volumeRegex = Regex("""(\d+(\.\d+)?\s*(fl\s*oz|ml|g|net\s*wt))""", RegexOption.IGNORE_CASE)
                 val match = volumeRegex.find(text)
                 
                 if (match != null) {
                     extractedVolume = match.value
-                    // We don't append this to the main builder; we isolate it.
                     continue 
                 }
                 
-                // The bottom 20% is usually company addresses and barcodes. 
-                // If it's not volume/weight, it's safe to drop to keep the payload pristine.
-                if (block != heroBlock) continue
+                // Allow some bottom text for now to avoid over-blocking
+                if (block != heroBlock && text.length < 5) continue
             }
 
             // If the block survived the spatial gauntlet, append it


### PR DESCRIPTION
This commit updates the camera scanner overlay for better product label alignment and adjusts the OCR engine to reduce aggressive text filtering, ensuring more relevant data is captured.

- **Scanner Overlay Improvements**:
    - Modified the ROI (Region of Interest) to be narrower (62% width) and taller (96% height) to better capture vertical product labels.
    - Removed the dimmed background mask to provide a clear view of the camera feed, leaving only the white targeting frame.
    - Updated the targeting frame's corner radius from 24dp to 12dp and increased its opacity.
- **OCR Filtering Refinement**:
    - **Top Zone**: Reduced the "Starburst" filter height from 15% to 10% and added a word count check to prevent discarding important headers.
    - **Middle Zone**: Expanded the middle zone (now 10%–90% height) and increased the marketing "fluff" threshold from 2 to 4 words to be less restrictive.
    - **Bottom Zone**: Reduced the volume and weight filter area to the bottom 10% and loosened restrictions on short text blocks to prevent over-blocking.