### PR TITLE
feat: implement geometric OCR parsing and enable full-frame debugging

### DIFF
--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureScreen.kt
@@ -145,9 +145,11 @@ internal fun BoxCaptureScreen(
                                             .clip(CircleShape)
                                     )
                                 } else if (step != CaptureStep.BARCODE && step != CaptureStep.PRICE) {
+                                    /* Bypassing ScannerOverlay for full-frame debugging
                                     ScannerOverlay(onBoundsCalculated = { bounds ->
                                         onEvent(BoxCaptureEvent.ScannerBoundsCalculated(bounds))
                                     })
+                                    */
                                 }
                             }
                         )

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -387,22 +387,23 @@ class BoxCaptureViewModel @Inject constructor(
                     else -> null
                 }
 
+                /* Bypassing Surgical ROI Crop for full-frame debugging
                 val processedBitmap = if (panel != null && scannerBounds != null) {
                     Log.d(TAG, "Executing ROI Crop for $panel...")
-                    // We'll need the preview dimensions. For now, assuming standard full screen
-                    // In a production app, these would be passed via Event
                     SurgicalCropper.cropToROI(
                         rawBitmap = rawBitmap,
                         uiRect = scannerBounds!!,
                         previewWidth = context.resources.displayMetrics.widthPixels,
                         previewHeight = context.resources.displayMetrics.heightPixels,
-                        rotationDegrees = 90 // Standard CameraX rotation
+                        rotationDegrees = 90
                     )
                 } else rawBitmap
+                */
+                val processedBitmap = rawBitmap
 
                 // --- Background OCR Trigger ---
                 if (panel != null) {
-                    Log.d(TAG, "Triggering background OCR for panel: $panel")
+                    Log.d(TAG, "Triggering background OCR (FULL FRAME) for panel: $panel")
                     val text = ocrEngine.processSinglePanel(panel, processedBitmap)
                     panelOcrResults[panel] = text
                     Log.d(TAG, "Background OCR Complete for $panel. Output:\n$text")

--- a/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/data/LocalOcrEngine.kt
+++ b/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/data/LocalOcrEngine.kt
@@ -4,10 +4,11 @@ import android.graphics.Bitmap
 import android.graphics.Rect
 import android.util.Log
 import com.google.mlkit.vision.common.InputImage
-import com.google.mlkit.vision.text.Text
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.zoewave.probase.features.readers.ocr.domain.model.BoxPanel
+import com.zoewave.probase.features.readers.ocr.domain.parser.GeometricOcrParser
+import com.zoewave.probase.features.readers.ocr.domain.parser.StructuredTextLine
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -55,9 +56,12 @@ class LocalOcrEngine @Inject constructor() {
             val image = InputImage.fromBitmap(bitmap, 0)
             val result = recognizer.process(image).await()
             
+            // Apply Geometric Parsing to identify headers/bolding with Gravity Heuristic
+            val structuredLines = GeometricOcrParser.parse(result, image.height)
+
             when (panel) {
-                BoxPanel.FRONT -> processFrontPanel(result, image.height)
-                BoxPanel.INFO -> processInfoPanel(result)
+                BoxPanel.FRONT -> processFrontPanel(structuredLines, image.height)
+                BoxPanel.INFO -> processInfoPanel(structuredLines)
                 BoxPanel.INGREDIENTS, BoxPanel.DIRECTIONS -> result.text
             }
 
@@ -67,27 +71,29 @@ class LocalOcrEngine @Inject constructor() {
         }
     }
 
-    private fun processFrontPanel(visionText: Text, imageHeight: Int): String {
+    private fun processFrontPanel(lines: List<StructuredTextLine>, imageHeight: Int): String {
         val cleanedTextBuilder = StringBuilder()
         var extractedVolume: String? = null
 
-        // 1. Identify the Hero Text (The block with the largest physical height)
-        val heroBlock = visionText.textBlocks.maxByOrNull { it.boundingBox?.height() ?: 0 }
+        // Calculate avg height again locally for the tag, or I can pass it from Parser.
+        // Let's just use the Line metadata for now.
+        val avgHeight = lines.mapNotNull { it.boundingBox?.height() }.average()
 
-        for (block in visionText.textBlocks) {
-            val box: Rect = block.boundingBox ?: continue
-            val text = block.text
+        for (line in lines) {
+            val box: Rect = line.boundingBox ?: continue
+            val text = line.text
             val textLower = text.lowercase()
+            val height = box.height()
 
             // Calculate relative vertical position (0.0 is top, 1.0 is bottom)
             val relativeTop = box.top.toFloat() / imageHeight.toFloat()
 
-            // --- RULE 1: Relaxed Starburst Filter (Top 10%) ---
+            // --- RULE 1: The "Starburst" Filter (Top 10% of the bottle) ---
             if (relativeTop < 0.10f) {
                 val words = textLower.split("\\s+".toRegex())
                 val hasFluff = words.any { marketingFluff.contains(it) }
-                // Only destroy if it's extreme marketing at the very peak
-                if (hasFluff && block != heroBlock && words.size < 3) {
+                // Only destroy if it's fluff AND NOT a geometric header
+                if (hasFluff && !line.isHeader && words.size < 3) {
                     continue 
                 }
             }
@@ -97,15 +103,14 @@ class LocalOcrEngine @Inject constructor() {
                 val words = textLower.split("\\s+".toRegex())
                 val fluffCount = words.count { marketingFluff.contains(it) }
                 
-                // Loosened threshold: Drop only if it's almost entirely marketing speak
-                if (fluffCount >= 4 && block != heroBlock) {
+                // Drop only if it's marketing speak AND not a header
+                if (fluffCount >= 4 && !line.isHeader) {
                     continue
                 }
             }
 
             // --- RULE 3: The Weight & Volume Filter (Bottom 10%) ---
             if (relativeTop > 0.90f) {
-                // Check for standard cosmetic volume regex (e.g., "FL OZ", "mL", "Net Wt")
                 val volumeRegex = Regex("""(\d+(\.\d+)?\s*(fl\s*oz|ml|g|net\s*wt))""", RegexOption.IGNORE_CASE)
                 val match = volumeRegex.find(text)
                 
@@ -114,15 +119,19 @@ class LocalOcrEngine @Inject constructor() {
                     continue 
                 }
                 
-                // Allow some bottom text for now to avoid over-blocking
-                if (block != heroBlock && text.length < 5) continue
+                if (!line.isHeader && text.length < 5) continue
             }
 
-            // If the block survived the spatial gauntlet, append it
-            cleanedTextBuilder.append(text).append("\n")
+            // High-fidelity Logging for Debugging
+            val ratio = if (avgHeight > 0) height / avgHeight else 1.0
+            val pScore = line.prominenceScore
+            val boostTag = if (line.hasTrademark) "[BOOSTED] " else ""
+            val typeTag = if (line.isHeader) "HEADER" else "NORMAL"
+            
+            val tag = "[$boostTag$typeTag(h=$height, r=${"%.1f".format(ratio)}, p=${"%.0f".format(pScore)})] "
+            cleanedTextBuilder.append(tag).append(text).append("\n")
         }
 
-        // Append the perfectly extracted volume to the very end for consistent LLM parsing
         extractedVolume?.let {
             cleanedTextBuilder.append("\n[VOLUME: $it]")
         }
@@ -130,20 +139,22 @@ class LocalOcrEngine @Inject constructor() {
         return cleanedTextBuilder.toString().trim()
     }
 
-    private fun processInfoPanel(visionText: Text): String {
+    private fun processInfoPanel(lines: List<StructuredTextLine>): String {
         val cleanedTextBuilder = StringBuilder()
 
-        for (block in visionText.textBlocks) {
-            val textLower = block.text.lowercase()
+        for (line in lines) {
+            val textLower = line.text.lowercase()
             val words = textLower.split("\\s+".toRegex())
             val fluffCount = words.count { marketingFluff.contains(it) }
 
-            // Lighter filter for Info panel: only drop extremely high density fluff
-            if (fluffCount > 3) {
+            // Protect headers and bold terms in info panels
+            val hasBoldTerms = line.elements.any { it.isBold }
+            
+            if (fluffCount > 3 && !line.isHeader && !hasBoldTerms) {
                 continue
             }
 
-            cleanedTextBuilder.append(block.text).append("\n")
+            cleanedTextBuilder.append(line.text).append("\n")
         }
 
         return cleanedTextBuilder.toString().trim()

--- a/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/domain/parser/GeometricOcrParser.kt
+++ b/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/domain/parser/GeometricOcrParser.kt
@@ -1,0 +1,148 @@
+package com.zoewave.probase.features.readers.ocr.domain.parser
+
+import android.graphics.Rect
+import com.google.mlkit.vision.text.Text
+
+data class StructuredElement(
+    val text: String,
+    val isBold: Boolean,
+    val isColumnStart: Boolean,
+    val boundingBox: Rect?
+)
+
+data class StructuredTextLine(
+    val text: String,
+    val isHeader: Boolean,
+    val relativeTop: Float,
+    val elements: List<StructuredElement>,
+    val boundingBox: Rect?
+) {
+    /**
+     * The "Trademark Booster": Rank legal identities higher.
+     * Brands legally mark their identity with registered trademark (®) or trademark (™) symbols.
+     */
+    val hasTrademark: Boolean
+        get() = text.contains("®") || 
+                text.contains("™") || 
+                text.contains("(R)", ignoreCase = true) || 
+                text.contains("(TM)", ignoreCase = true)
+
+    /**
+     * The "Gravity" Heuristic: Rank visual prominence by height and vertical placement.
+     * Important text (Brand, Name) is typically large and at the top.
+     * Marketing fluff is penalized the further down the package it appears.
+     */
+    val prominenceScore: Float
+        get() {
+            val height = boundingBox?.height() ?: 0
+            val baseScore = height.toFloat() * (1.0f - relativeTop)
+            
+            // If it has a trademark, apply a 1.5x multiplier to guarantee it wins
+            return if (hasTrademark) baseScore * 1.5f else baseScore
+        }
+}
+
+/**
+ * GeometricOcrParser: Infers typographical hierarchy using bounding box geometry.
+ * Uses O(N) single-pass extraction + O(1) mathematical flagging.
+ */
+object GeometricOcrParser {
+
+    private const val HEADER_RATIO = 1.5f
+    private const val BOLD_RATIO = 1.3f
+    private const val COLUMN_GAP_RATIO = 2.0f
+
+    /**
+     * Converts raw ML Kit text into structured lines with geometric metadata.
+     * @param visionText The raw result from ML Kit
+     * @param imageHeight The height of the original bitmap to calculate relative vertical placement.
+     */
+    fun parse(visionText: Text, imageHeight: Int): List<StructuredTextLine> {
+        val allLines = visionText.textBlocks.flatMap { it.lines }
+        if (allLines.isEmpty()) return emptyList()
+
+        // 1. Pre-calculate Averages for the panel context
+        val lineHeights = allLines.mapNotNull { it.boundingBox?.height() }
+        val averageLineHeight = lineHeights.average().toFloat()
+        
+        android.util.Log.d("GeometricOcrParser", "Panel Stats: Avg Height: ${"%.2f".format(averageLineHeight)}, Total Lines: ${allLines.size}")
+
+        val allElements = allLines.flatMap { it.elements }
+        val averageWordRatio = allElements.mapNotNull { element ->
+            val box = element.boundingBox ?: return@mapNotNull null
+            box.width().toFloat() / box.height().toFloat()
+        }.average().toFloat()
+
+        // Calculate average gap between words on the same line
+        val allGaps = mutableListOf<Int>()
+        allLines.forEach { line ->
+            for (i in 0 until line.elements.size - 1) {
+                val currentRight = line.elements[i].boundingBox?.right ?: continue
+                val nextLeft = line.elements[i + 1].boundingBox?.left ?: continue
+                val gap = nextLeft - currentRight
+                if (gap > 0) allGaps.add(gap)
+            }
+        }
+        val averageGap = if (allGaps.isNotEmpty()) allGaps.average().toFloat() else 0f
+
+        // 2. Build structured output with mathematical flagging
+        return allLines.map { line ->
+            val lineBox = line.boundingBox
+            val isHeader = (lineBox?.height() ?: 0) > (averageLineHeight * HEADER_RATIO)
+            
+            // Calculate relative vertical position (Gravity calculation)
+            val relativeTop = if (lineBox != null && imageHeight > 0) {
+                lineBox.top.toFloat() / imageHeight.toFloat()
+            } else 0f
+
+            val structuredElements = line.elements.mapIndexed { index, element ->
+                val box = element.boundingBox
+                
+                // Infer Bolding: Is this word unusually wide for its height?
+                val ratio = if (box != null && box.height() > 0) {
+                    box.width().toFloat() / box.height().toFloat()
+                } else 0f
+                val isBold = ratio > (averageWordRatio * BOLD_RATIO)
+
+                // Infer Columns: Is there an unusually large gap before this word?
+                var isColumnStart = false
+                if (index > 0) {
+                    val prevRight = line.elements[index - 1].boundingBox?.right ?: 0
+                    val currentLeft = box?.left ?: 0
+                    val gap = currentLeft - prevRight
+                    if (gap > (averageGap * COLUMN_GAP_RATIO)) {
+                        isColumnStart = true
+                    }
+                }
+
+                StructuredElement(
+                    text = element.text,
+                    isBold = isBold,
+                    isColumnStart = isColumnStart,
+                    boundingBox = box
+                )
+            }
+
+            StructuredTextLine(
+                text = line.text,
+                isHeader = isHeader,
+                relativeTop = relativeTop,
+                elements = structuredElements,
+                boundingBox = lineBox
+            )
+        }
+    }
+
+    /**
+     * Identifies the top two identity candidates (Brand and Product Name)
+     * using the Gravity-weighted Prominence Score.
+     */
+    fun extractIdentityCandidates(lines: List<StructuredTextLine>): Pair<String, String> {
+        val sortedByProminence = lines.sortedByDescending { it.prominenceScore }
+        
+        val brand = sortedByProminence.getOrNull(0)?.text ?: "Detected Brand"
+        val productName = sortedByProminence.getOrNull(1)?.text ?: "Captured Product"
+        
+        return brand to productName
+    }
+}


### PR DESCRIPTION
This commit introduces a geometric parsing layer to the OCR engine to improve brand and product identification by analyzing typographical hierarchy. It also temporarily bypasses ROI cropping to facilitate full-frame debugging.

- **Geometric OCR Parsing**:
    - Created `GeometricOcrParser` to infer typography hierarchy (headers, bolding, and columns) based on ML Kit bounding box geometry.
    - Defined `StructuredTextLine` and `StructuredElement` to store geometric metadata and calculated prominence scores.
    - Implemented a "Gravity" heuristic to rank text based on height and vertical placement, and a "Trademark Booster" to prioritize brand identifiers.
- **LocalOcrEngine Enhancements**:
    - Integrated `GeometricOcrParser` into the OCR workflow for front and info panels.
    - Refined text filtering rules (e.g., "Starburst" and volume filters) to use header metadata and prominence scores instead of simple height checks.
    - Added high-fidelity logging tags to OCR output to track height ratios and prominence scores during debugging.
- **BoxCapture Debugging**:
    - Bypassed `SurgicalCropper` in `BoxCaptureViewModel` to trigger background OCR on the full-frame `rawBitmap`.
    - Commented out `ScannerOverlay` in `BoxCaptureScreen` for unobstructed full-frame visual debugging.
    - Updated logging to indicate when full-frame OCR is being triggered.