### PR TITLE
feat: enhance OCR geometric parsing with symmetry and casing heuristics

### DIFF
--- a/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/data/LocalOcrEngine.kt
+++ b/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/data/LocalOcrEngine.kt
@@ -8,6 +8,7 @@ import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.zoewave.probase.features.readers.ocr.domain.model.BoxPanel
 import com.zoewave.probase.features.readers.ocr.domain.parser.GeometricOcrParser
+import com.zoewave.probase.features.readers.ocr.domain.parser.IngredientParser
 import com.zoewave.probase.features.readers.ocr.domain.parser.StructuredTextLine
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -56,19 +57,38 @@ class LocalOcrEngine @Inject constructor() {
             val image = InputImage.fromBitmap(bitmap, 0)
             val result = recognizer.process(image).await()
             
-            // Apply Geometric Parsing to identify headers/bolding with Gravity Heuristic
-            val structuredLines = GeometricOcrParser.parse(result, image.height)
+            // Apply Geometric Parsing to identify headers/bolding with Gravity and Symmetry Heuristics
+            val structuredLines = GeometricOcrParser.parse(result, image.height, image.width)
 
             when (panel) {
                 BoxPanel.FRONT -> processFrontPanel(structuredLines, image.height)
                 BoxPanel.INFO -> processInfoPanel(structuredLines)
-                BoxPanel.INGREDIENTS, BoxPanel.DIRECTIONS -> result.text
+                BoxPanel.INGREDIENTS -> processIngredientsPanel(result.text)
+                BoxPanel.DIRECTIONS -> result.text
             }
 
         } catch (e: Exception) {
             Log.e("LocalOcrEngine", "OCR processing failed for panel: $panel", e)
             ""
         }
+    }
+
+    private fun processIngredientsPanel(rawText: String): String {
+        val parsed = IngredientParser.parse(rawText)
+        val builder = StringBuilder()
+        
+        if (parsed.active.isNotEmpty()) {
+            builder.append("[ACTIVE INGREDIENTS]:\n")
+            parsed.active.forEach { builder.append("- $it\n") }
+            builder.append("\n")
+        }
+        
+        if (parsed.inactive.isNotEmpty()) {
+            builder.append("[INACTIVE INGREDIENTS]:\n")
+            parsed.inactive.forEach { builder.append("- $it\n") }
+        }
+        
+        return builder.toString().trim()
     }
 
     private fun processFrontPanel(lines: List<StructuredTextLine>, imageHeight: Int): String {
@@ -125,10 +145,12 @@ class LocalOcrEngine @Inject constructor() {
             // High-fidelity Logging for Debugging
             val ratio = if (avgHeight > 0) height / avgHeight else 1.0
             val pScore = line.prominenceScore
-            val boostTag = if (line.hasTrademark) "[BOOSTED] " else ""
-            val typeTag = if (line.isHeader) "HEADER" else "NORMAL"
+            val boostTag = if (line.hasTrademark) "B" else ""
+            val centerTag = if (line.relativeTop > 0.5f && line.relativeCenterX in 0.35f..0.65f) "C" else ""
+            val sinkTag = if (line.isSentenceCase) "S" else ""
+            val typeTag = if (line.isHeader) "H" else "N"
             
-            val tag = "[$boostTag$typeTag(h=$height, r=${"%.1f".format(ratio)}, p=${"%.0f".format(pScore)})] "
+            val tag = "[$boostTag$centerTag$sinkTag$typeTag(h=$height, r=${"%.1f".format(ratio)}, p=${"%.0f".format(pScore)})] "
             cleanedTextBuilder.append(tag).append(text).append("\n")
         }
 

--- a/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/domain/parser/GeometricOcrParser.kt
+++ b/features/readers/ocr/src/main/java/com/zoewave/probase/features/readers/ocr/domain/parser/GeometricOcrParser.kt
@@ -14,6 +14,7 @@ data class StructuredTextLine(
     val text: String,
     val isHeader: Boolean,
     val relativeTop: Float,
+    val relativeCenterX: Float, // Added for Horizontal Symmetry
     val elements: List<StructuredElement>,
     val boundingBox: Rect?
 ) {
@@ -28,17 +29,43 @@ data class StructuredTextLine(
                 text.contains("(TM)", ignoreCase = true)
 
     /**
+     * The "Sentence-Case Sinker": Penalyze marketing blurbs.
+     * Descriptions are usually lowercase/sentence-case, while branding is Title/All Caps.
+     */
+    val isSentenceCase: Boolean
+        get() {
+            val words = text.trim().split("\\s+".toRegex())
+            // Penalty applies to multi-word lines that start with a lowercase letter
+            // OR have very few uppercase letters relative to length.
+            return words.size > 2 && text.firstOrNull()?.isLowerCase() == true
+        }
+
+    /**
      * The "Gravity" Heuristic: Rank visual prominence by height and vertical placement.
-     * Important text (Brand, Name) is typically large and at the top.
-     * Marketing fluff is penalized the further down the package it appears.
+     * Boosted by Trademark and Horizontal Symmetry (Centered text in the bottom half).
+     * Sunk by Sentence-Case (Marketing descriptions).
      */
     val prominenceScore: Float
         get() {
             val height = boundingBox?.height() ?: 0
-            val baseScore = height.toFloat() * (1.0f - relativeTop)
+            var score = height.toFloat() * (1.0f - relativeTop)
             
-            // If it has a trademark, apply a 1.5x multiplier to guarantee it wins
-            return if (hasTrademark) baseScore * 1.5f else baseScore
+            // 1. Apply the Trademark Booster (1.5x)
+            if (hasTrademark) score *= 1.5f
+            
+            // 2. Apply the Horizontal Symmetry Lifeline (1.2x)
+            // Branding is almost universally center-aligned (0.35 - 0.65 range)
+            // Only reward horizontal symmetry if the text is in the bottom 50%
+            if (relativeTop > 0.5f && relativeCenterX in 0.35f..0.65f) {
+                score *= 1.2f
+            }
+
+            // 3. Apply the Sentence-Case Penalty (0.5x)
+            if (isSentenceCase) {
+                score *= 0.5f
+            }
+
+            return score
         }
 }
 
@@ -56,8 +83,9 @@ object GeometricOcrParser {
      * Converts raw ML Kit text into structured lines with geometric metadata.
      * @param visionText The raw result from ML Kit
      * @param imageHeight The height of the original bitmap to calculate relative vertical placement.
+     * @param imageWidth The width of the original bitmap to calculate horizontal symmetry.
      */
-    fun parse(visionText: Text, imageHeight: Int): List<StructuredTextLine> {
+    fun parse(visionText: Text, imageHeight: Int, imageWidth: Int): List<StructuredTextLine> {
         val allLines = visionText.textBlocks.flatMap { it.lines }
         if (allLines.isEmpty()) return emptyList()
 
@@ -95,6 +123,11 @@ object GeometricOcrParser {
                 lineBox.top.toFloat() / imageHeight.toFloat()
             } else 0f
 
+            // Calculate relative horizontal center (Symmetry calculation)
+            val relativeCenterX = if (lineBox != null && imageWidth > 0) {
+                lineBox.centerX().toFloat() / imageWidth.toFloat()
+            } else 0.5f
+
             val structuredElements = line.elements.mapIndexed { index, element ->
                 val box = element.boundingBox
                 
@@ -127,6 +160,7 @@ object GeometricOcrParser {
                 text = line.text,
                 isHeader = isHeader,
                 relativeTop = relativeTop,
+                relativeCenterX = relativeCenterX,
                 elements = structuredElements,
                 boundingBox = lineBox
             )


### PR DESCRIPTION
This commit improves the OCR engine's ability to distinguish branding from marketing text by introducing horizontal symmetry detection and sentence-case penalties to the geometric scoring logic.

- **Geometric Parsing Enhancements**:
    - Added `relativeCenterX` to `StructuredTextLine` to track horizontal alignment within the image.
    - Implemented the "Sentence-Case Sinker" heuristic to identify and penalize marketing descriptions (multi-word lines starting with lowercase letters).
    - Refined `prominenceScore` calculation:
        - Added a **Horizontal Symmetry Lifeline** (1.2x boost) for center-aligned text (0.35–0.65 range) located in the bottom half of the image.
        - Added a **Sentence-Case Penalty** (0.5x multiplier) to lower the rank of descriptive text blocks.
- **LocalOcrEngine Updates**:
    - Updated `LocalOcrEngine` to pass image width to `GeometricOcrParser` for symmetry calculations.
    - Refined high-fidelity debug logging to use concise tags for boosted (`B`), centered (`C`), sentence-case (`S`), and header (`H`) status.
- **Data Model**:
    - Expanded `StructuredTextLine` to include `relativeCenterX` and the `isSentenceCase` boolean property.