### PR TITLE
feat: expand sample data generation and document XR design principles

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-07-05T21:39:44.877924Z">
+        <DropdownSelection timestamp="2026-07-06T19:57:04.002785Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_10_Pro.avd" />
@@ -103,7 +103,7 @@
       </SelectionState>
       <SelectionState runConfigName="applications.kocolor.apps.mobile">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-06-29T23:57:35.531777Z">
+        <DropdownSelection timestamp="2026-07-06T19:48:17.541459Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/developer/.android/avd/Pixel_10_Pro.avd" />

--- a/applications/kocolor/apps/mobile/features/settings/src/main/java/com/zoewave/probase/kocolor/mobile/features/settings/ui/SettingsViewModel.kt
+++ b/applications/kocolor/apps/mobile/features/settings/src/main/java/com/zoewave/probase/kocolor/mobile/features/settings/ui/SettingsViewModel.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.kocolor.db.KoColorSettings
 import com.zoewave.probase.kocolor.db.dao.CosmeticDao
+import com.zoewave.probase.kocolor.db.dao.ClothingDao
 import com.zoewave.probase.kocolor.db.entity.CosmeticItemEntity
+import com.zoewave.probase.kocolor.db.entity.ClothingItemEntity
 import com.zoewave.probase.core.data.service.health.HealthSessionManager
 import com.zoewave.probase.core.model.ritual.*
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -43,7 +45,7 @@ sealed class SettingsEvent {
     data class OnTempUnitChanged(val unit: String) : SettingsEvent()
     data class OnHydrationGoalChanged(val goal: Double) : SettingsEvent()
     data object OnResetHydrationProgress : SettingsEvent()
-    data object OnGenerateSampleCosmetics : SettingsEvent()
+    data object OnGenerateSampleData : SettingsEvent()
     data class InitializeWithSection(val section: String) : SettingsEvent()
 }
 
@@ -51,6 +53,7 @@ sealed class SettingsEvent {
 class SettingsViewModel @Inject constructor(
     private val koSettings: KoColorSettings,
     private val cosmeticDao: CosmeticDao,
+    private val clothingDao: ClothingDao,
     private val healthSessionManager: HealthSessionManager
 ) : ViewModel() {
 
@@ -132,8 +135,8 @@ class SettingsViewModel @Inject constructor(
                     healthSessionManager.deleteTodayHydration()
                 }
             }
-            SettingsEvent.OnGenerateSampleCosmetics -> {
-                generateSampleItems()
+            SettingsEvent.OnGenerateSampleData -> {
+                generateSampleData()
             }
             is SettingsEvent.InitializeWithSection -> {
                 if (event.section == "Hydration") {
@@ -143,16 +146,16 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    private fun generateSampleItems() {
+    private fun generateSampleData() {
         viewModelScope.launch {
-            val brands = listOf("L'Oreal", "MAC", "Maybelline", "Chanel", "Dior", "Fenty Beauty", "Rare Beauty")
-            val productSuffixes = listOf("Glow", "Matte", "Gloss", "Cream", "Stick", "Powder", "Ink")
-            val colors = listOf("#FF0000", "#FFC0CB", "#800020", "#C71585", "#DB7093", "#FFA07A", "#FF7F50")
+            // 1. Generate 10 High-Fidelity Cosmetics
+            val cosmeticBrands = listOf("Chanel", "Dior", "Fenty Beauty", "Rare Beauty", "MAC", "Estée Lauder", "YSL", "NARS", "Guerlain", "Charlotte Tilbury")
+            val cosmeticColors = listOf("#8B0000", "#FFC0CB", "#D4AF37", "#2C2420", "#FDEEF4", "#E8F1FD", "#FEECEB", "#800020", "#C71585", "#DB7093")
             
-            repeat(50) { i ->
+            repeat(10) { i ->
                 val micro = MicroCategory.entries.toTypedArray().random()
-                val brand = brands.random()
-                val name = "${brand} ${productSuffixes.random()} ${i + 1}"
+                val brand = cosmeticBrands[i % cosmeticBrands.size]
+                val name = "$brand ${micro.displayName} Elite"
                 
                 cosmeticDao.insertCosmetic(
                     CosmeticItemEntity(
@@ -160,9 +163,33 @@ class SettingsViewModel @Inject constructor(
                         brand = brand,
                         macroCategory = micro.macro,
                         microCategory = micro,
-                        colorHex = colors.random(),
-                        shadeName = "Shade ${i + 1}",
-                        timestamp = System.currentTimeMillis() - (i * 1000 * 60 * 60) // Different times
+                        colorHex = cosmeticColors[i % cosmeticColors.size],
+                        shadeName = "Signature ${i + 1}",
+                        timestamp = System.currentTimeMillis() - (i * 3600000)
+                    )
+                )
+            }
+
+            // 2. Generate 10 High-Fidelity Clothing Items
+            val clothingBrands = listOf("Atelier", "Saint Laurent", "Celine", "Brunello Cucinelli", "Loro Piana", "Hermès", "The Row", "Prada", "Gucci", "Loewe")
+            val clothingColors = listOf("#222222", "#FFFFFF", "#F5F5DC", "#000080", "#355E3B", "#4A2C2A", "#708090", "#800000", "#FFD700", "#E1C16E")
+
+            repeat(10) { i ->
+                val category = ClothingCategory.entries.toTypedArray().random()
+                val brand = clothingBrands[i % clothingBrands.size]
+                val formality = if (i % 3 == 0) Formality.PROFESSIONAL else if (i % 5 == 0) Formality.FORMAL else Formality.CASUAL
+                
+                clothingDao.insertClothing(
+                    ClothingItemEntity(
+                        name = "$brand ${category.displayName} Piece",
+                        brand = brand,
+                        category = category,
+                        formality = formality,
+                        colorHex = clothingColors[i % clothingColors.size],
+                        dominantHex = clothingColors[i % clothingColors.size],
+                        material = "Premium Silk/Cashmere Blend",
+                        price = (200..2000).random().toDouble(),
+                        timestamp = System.currentTimeMillis() - (i * 7200000)
                     )
                 )
             }

--- a/applications/kocolor/apps/mobile/features/settings/src/main/java/com/zoewave/probase/kocolor/mobile/features/settings/ui/components/SettingsScreen.kt
+++ b/applications/kocolor/apps/mobile/features/settings/src/main/java/com/zoewave/probase/kocolor/mobile/features/settings/ui/components/SettingsScreen.kt
@@ -174,11 +174,11 @@ fun SettingsScreen(
                     Text("Developer Options", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.error)
                     Spacer(modifier = Modifier.height(8.dp))
                     Button(
-                        onClick = { onEvent(SettingsEvent.OnGenerateSampleCosmetics) },
+                        onClick = { onEvent(SettingsEvent.OnGenerateSampleData) },
                         modifier = Modifier.fillMaxWidth(),
                         colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
                     ) {
-                        Text("Add 50 Sample Cosmetics")
+                        Text("Add Sample Portfolio Items")
                     }
                 }
             }

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ProjectedCapabilities.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ProjectedCapabilities.kt
@@ -1,22 +1,31 @@
 package com.zoewave.probase.features.xr.glass
 
 import androidx.xr.projected.ProjectedDeviceController
-import androidx.xr.projected.ProjectedDeviceController.Capability.Companion.CAPABILITY_VISUAL_UI
 import androidx.xr.projected.experimental.ExperimentalProjectedApi
 
 /**
- * Helper object to check for Android XR device capabilities.
- * Matches the terminology used in documentation and DroidCon materials.
+ * DESIGN PRINCIPLE: Why we use this abstraction for Android XR Capabilities
+ *
+ * 1. INITIALIZATION: Capabilities are intrinsic to the hardware. We query once 
+ *    at startup (GlassesMainActivity) for efficiency.
+ *
+ * 2. STATE HOISTING: We hoist 'isVisualUiSupported' to the top-level GlassApp.
+ *    This keeps sub-composables (RitualLayout) reactive and decoupled from hardware.
+ *
+ * 3. GRACEFUL FALLBACK: If CAPABILITY_VISUAL_UI is missing, we pivot to 
+ *    Audio Guidance Mode rather than showing a broken or empty UI.
  */
 @OptIn(ExperimentalProjectedApi::class)
 object ProjectedCapabilities {
     /**
      * Constant representing the ability to show a visual UI (display).
+     * Usage: controller.capabilities.contains(CAPABILITY_VISUAL_UI)
      */
     val CAPABILITY_VISUAL_UI = ProjectedDeviceController.Capability.CAPABILITY_VISUAL_UI
 
     /**
-     * Checks if the connected device supports visual UI.
+     * Helper to check if the connected device supports visual UI.
+     * Recommended for cleaner call sites: ProjectedCapabilities.hasDisplay(controller)
      */
     fun hasDisplay(controller: ProjectedDeviceController): Boolean {
         return controller.capabilities.contains(CAPABILITY_VISUAL_UI)


### PR DESCRIPTION
This commit updates the developer options to generate a more diverse set of sample data, including both cosmetics and clothing items, and adds architectural documentation for Android XR capability handling.

- **Sample Data Generation**:
    - Renamed `OnGenerateSampleCosmetics` to `OnGenerateSampleData` across the settings feature to reflect a broader scope.
    - Updated `SettingsViewModel` to inject `ClothingDao` for generating portfolio items.
    - Refined cosmetic generation logic: reduced count to 10 "high-fidelity" items with curated brands and color hex codes.
    - Implemented sample clothing generation: adds 10 items with randomized categories, formality levels (Professional, Formal, Casual), and premium material descriptions.
    - Updated `SettingsScreen` UI text to "Add Sample Portfolio Items."

- **Android XR Documentation**:
    - Added comprehensive KDoc to `ProjectedCapabilities` outlining design principles for XR hardware abstraction.
    - Documented strategies for **State Hoisting** (lifting capability checks to top-level composables) and **Graceful Fallback** (pivoting to Audio Guidance Mode when visual UI is unsupported).
    - Refined the `CAPABILITY_VISUAL_UI` constant reference to simplify hardware capability checks.

- **Infrastructure**:
    - Updated IDE deployment target selector states for the Pixel 10 Pro emulator.