### PR TITLE
feat: add Glimmer vs Material 3 comparison samples and custom spatial…

### DIFF
--- a/features/xr/glass/samples/src/main/java/com/zoewave/probase/features/xr/glass/samples/GlimmerComparisonSamples.kt
+++ b/features/xr/glass/samples/src/main/java/com/zoewave/probase/features/xr/glass/samples/GlimmerComparisonSamples.kt
@@ -1,0 +1,165 @@
+package com.zoewave.probase.features.xr.glass.samples
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.xr.glimmer.Button
+import androidx.xr.glimmer.Card
+import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.glimmer.Icon
+import androidx.xr.glimmer.IconButton
+import androidx.xr.glimmer.Text
+import androidx.xr.glimmer.ToggleButton
+
+/**
+ * Glimmer equivalent of the Material 3 samples.
+ * Used for one-to-one comparison in the DroidCon talk.
+ */
+@Composable
+fun GlimmerComparisonSamples() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Text(
+            text = "Glimmer (Spatial Optimized)",
+            style = GlimmerTheme.typography.titleLarge,
+            color = GlimmerTheme.colors.primary
+        )
+
+        // Buttons
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Buttons", style = GlimmerTheme.typography.titleSmall)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = { }) { Text("Filled") }
+                // Glimmer encourages using standard buttons for spatial clarity 
+                // rather than purely aesthetic variants like 'Outlined'
+                Button(onClick = { }) { Text("Elevated") }
+                Button(onClick = { }) { Text("Outlined") }
+            }
+        }
+
+        // Icon Buttons
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Icon Buttons", style = GlimmerTheme.typography.titleSmall)
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                IconButton(onClick = { }) {
+                    Icon(Icons.Default.Favorite, contentDescription = "Favorite")
+                }
+                IconButton(onClick = { }) {
+                    Icon(Icons.Default.Share, contentDescription = "Share")
+                }
+                IconButton(onClick = { }) {
+                    Icon(Icons.Default.Settings, contentDescription = "Settings")
+                }
+            }
+        }
+
+        // Cards
+        Card(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text("Glimmer Card", style = GlimmerTheme.typography.titleMedium)
+                Text(
+                    "This is an optimized Glimmer Card. Notice the spatial focus effects, automatic depth, and high-contrast styling for additive light displays.",
+                    style = GlimmerTheme.typography.bodyMedium
+                )
+            }
+        }
+
+        // Selection Controls
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text("Selection Controls", style = GlimmerTheme.typography.titleSmall)
+            
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                var checked1 by remember { mutableStateOf(true) }
+                ToggleButton(checked = checked1, onCheckedChange = { checked1 = it }) {
+                    Text("Checkbox Equivalent")
+                }
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                var checked2 by remember { mutableStateOf(false) }
+                ToggleButton(checked = checked2, onCheckedChange = { checked2 = it }) {
+                    Text("Switch Equivalent")
+                }
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                var checked3 by remember { mutableStateOf(true) }
+                ToggleButton(checked = checked3, onCheckedChange = { checked3 = it }) {
+                    Text("Radio Equivalent")
+                }
+            }
+        }
+
+        // Slider Equivalent
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Range Input (Glimmer)", style = GlimmerTheme.typography.titleSmall)
+            Text(
+                "Glimmer avoids traditional sliders for precision. Use ToggleButtons or distinct steps for spatial interaction.",
+                style = GlimmerTheme.typography.bodySmall
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                repeat(5) { i ->
+                    var checked by remember { mutableStateOf(i == 2) }
+                    ToggleButton(checked = checked, onCheckedChange = { checked = it }) {
+                        Text("${i + 1}")
+                    }
+                }
+            }
+        }
+
+        // Color Palette
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text("Glimmer Color Palette (Optimized)", style = GlimmerTheme.typography.titleSmall)
+            Text(
+                "Glimmer colors are 'electric' and high-vibrancy. They leverage additive light physics to remain solid and legible over real-world backgrounds.",
+                style = GlimmerTheme.typography.bodySmall,
+                color = androidx.compose.ui.graphics.Color.White.copy(alpha = 0.7f)
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                GlimmerColorSwatch(GlimmerTheme.colors.primary, "Primary")
+                GlimmerColorSwatch(GlimmerTheme.colors.secondary, "Secondary")
+                GlimmerColorSwatch(GlimmerTheme.colors.positive, "Positive")
+            }
+        }
+    }
+}
+
+@Composable
+private fun GlimmerColorSwatch(color: androidx.compose.ui.graphics.Color, label: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .background(color, CircleShape)
+        )
+        Text(label, style = GlimmerTheme.typography.bodySmall)
+    }
+}

--- a/features/xr/glass/samples/src/main/java/com/zoewave/probase/features/xr/glass/samples/GlimmerSliderSamples.kt
+++ b/features/xr/glass/samples/src/main/java/com/zoewave/probase/features/xr/glass/samples/GlimmerSliderSamples.kt
@@ -1,0 +1,165 @@
+package com.zoewave.probase.features.xr.glass.samples
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.SignalCellularAlt
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.xr.glimmer.Card
+import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.glimmer.Icon
+import androidx.xr.glimmer.Text
+import androidx.xr.glimmer.surface
+
+/**
+ * Custom Glimmer Slider implementation.
+ * Since the official Slider is not yet in the SDK, we build it using Surface 
+ * following the design principles for AI glasses.
+ */
+@Composable
+fun GlimmerSliderSamples() {
+    var volume by remember { mutableStateOf(0.4f) }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Custom Glimmer Slider", style = GlimmerTheme.typography.titleMedium)
+
+        // The "Chroma" card from the documentation screenshot
+        Card(
+            modifier = Modifier.fillMaxWidth(0.9f)
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Column {
+                        Text(
+                            text = "Transparent",
+                            style = GlimmerTheme.typography.titleSmall,
+                            color = Color.White
+                        )
+                        Text(
+                            text = "Chroma",
+                            style = GlimmerTheme.typography.bodySmall,
+                            color = Color.White.copy(alpha = 0.7f)
+                        )
+                    }
+                    Icon(
+                        Icons.Default.SignalCellularAlt,
+                        contentDescription = null,
+                        tint = Color.White.copy(alpha = 0.7f)
+                    )
+                }
+
+                Spacer(Modifier.height(24.dp))
+
+                // Our Custom Glimmer Slider
+                GlimmerSlider(
+                    value = volume,
+                    onValueChange = { volume = it },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun GlimmerSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    BoxWithConstraints(
+        modifier = modifier
+            .height(48.dp)
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        val widthPx = constraints.maxWidth.toFloat()
+        val width = maxWidth
+        val thumbWidth = 64.dp
+        
+        // Track background
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+                .background(Color.White.copy(alpha = 0.3f), CircleShape)
+                .pointerInput(Unit) {
+                    detectDragGestures { change, _ ->
+                        val progress = (change.position.x / widthPx).coerceIn(0f, 1f)
+                        onValueChange(progress)
+                    }
+                }
+        )
+
+        // Active Track
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(value)
+                .height(2.dp)
+                .background(Color.White, CircleShape)
+        )
+
+        // Thumb - Following Glimmer "Pill" design
+        Box(
+            modifier = Modifier
+                .offset { 
+                    IntOffset(
+                        ((value * (width.toPx() - thumbWidth.toPx()))).toInt(), 
+                        0
+                    ) 
+                }
+                .size(width = thumbWidth, height = 32.dp)
+                .surface(shape = RoundedCornerShape(16.dp)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.MusicNote,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF000000)
+@Composable
+private fun GlimmerSliderSamplesPreview() {
+    GlimmerTheme {
+        GlimmerSliderSamples()
+    }
+}

--- a/features/xr/glass/samples/src/main/java/com/zoewave/probase/features/xr/glass/samples/Material3Samples.kt
+++ b/features/xr/glass/samples/src/main/java/com/zoewave/probase/features/xr/glass/samples/Material3Samples.kt
@@ -1,0 +1,164 @@
+package com.zoewave.probase.features.xr.glass.samples
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Standard Material 3 components using the default M3 Dark Theme.
+ * This is used to demonstrate how "traditional" mobile UI renders on Glass 
+ * compared to the optimized Glimmer toolkit.
+ */
+@Composable
+fun Material3Samples() {
+    MaterialTheme(colorScheme = darkColorScheme()) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
+                Text(
+                    text = "Standard Material 3",
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+
+                // Buttons
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Buttons", style = MaterialTheme.typography.titleSmall)
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(onClick = { }) { Text("Filled") }
+                        ElevatedButton(onClick = { }) { Text("Elevated") }
+                        OutlinedButton(onClick = { }) { Text("Outlined") }
+                    }
+                }
+
+                // Icon Buttons
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Icon Buttons", style = MaterialTheme.typography.titleSmall)
+                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        IconButton(onClick = { }) {
+                            Icon(Icons.Default.Favorite, contentDescription = "Favorite")
+                        }
+                        IconButton(onClick = { }) {
+                            Icon(Icons.Default.Share, contentDescription = "Share")
+                        }
+                        IconButton(onClick = { }) {
+                            Icon(Icons.Default.Settings, contentDescription = "Settings")
+                        }
+                    }
+                }
+
+                // Cards
+                Card(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text("Material 3 Card", style = MaterialTheme.typography.titleMedium)
+                        Text(
+                            "This is a standard M3 Card component. Notice the lack of spatial depth effects compared to Glimmer.",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+
+                // Selection Controls
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("Selection Controls", style = MaterialTheme.typography.titleSmall)
+                    
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        var checked by remember { mutableStateOf(true) }
+                        Checkbox(checked = checked, onCheckedChange = { checked = it })
+                        Text("Checkbox")
+                    }
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        var switched by remember { mutableStateOf(false) }
+                        Switch(checked = switched, onCheckedChange = { switched = it })
+                        Text("Switch", modifier = Modifier.padding(start = 8.dp))
+                    }
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        RadioButton(selected = true, onClick = { })
+                        Text("Radio Button")
+                    }
+                }
+
+                // Slider
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Slider", style = MaterialTheme.typography.titleSmall)
+                    var sliderPosition by remember { mutableStateOf(0.5f) }
+                    Slider(value = sliderPosition, onValueChange = { sliderPosition = it })
+                }
+
+                // Color Palette
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("M3 Color Palette (Mobile)", style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        "Standard M3 colors use tonal palettes designed for reflective screens. On see-through glass, these can appear 'muddy' or transparent.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        ColorSwatch(MaterialTheme.colorScheme.primary, "Primary")
+                        ColorSwatch(MaterialTheme.colorScheme.secondary, "Secondary")
+                        ColorSwatch(MaterialTheme.colorScheme.tertiary, "Tertiary")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColorSwatch(color: androidx.compose.ui.graphics.Color, label: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .background(color, CircleShape)
+        )
+        Text(label, style = MaterialTheme.typography.labelSmall)
+    }
+}

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassApp.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassApp.kt
@@ -37,13 +37,16 @@ import com.zoewave.probase.features.xr.glass.samples.ButtonsSamples
 import com.zoewave.probase.features.xr.glass.samples.CardSamples
 import com.zoewave.probase.features.xr.glass.samples.ColorsSamples
 import com.zoewave.probase.features.xr.glass.samples.DepthEffectLevelsSample
+import com.zoewave.probase.features.xr.glass.samples.GlimmerComparisonSamples
 import com.zoewave.probase.features.xr.glass.samples.GlimmerLazyListSamples
+import com.zoewave.probase.features.xr.glass.samples.GlimmerSliderSamples
 import com.zoewave.probase.features.xr.glass.samples.GlimmerPagerSamples
 import com.zoewave.probase.features.xr.glass.samples.IconButtonSamples
 import com.zoewave.probase.features.xr.glass.samples.IconSamples
 import com.zoewave.probase.features.xr.glass.samples.IconToggleButtonsSamples
 import com.zoewave.probase.features.xr.glass.samples.IndirectPointerGestureSamples
 import com.zoewave.probase.features.xr.glass.samples.ListItemSamples
+import com.zoewave.probase.features.xr.glass.samples.Material3Samples
 import com.zoewave.probase.features.xr.glass.samples.ObjectRecognitionScreen
 import com.zoewave.probase.features.xr.glass.samples.ShapesSamples
 import com.zoewave.probase.features.xr.glass.samples.SpatialNoteOverlay
@@ -139,6 +142,9 @@ fun GlassApp(
                         GlimmerSample.Vision -> VisionRoute()
                         GlimmerSample.ObjectRecognition -> ObjectRecognitionScreen()
                         GlimmerSample.SpatialNote -> SpatialNoteOverlay()
+                        GlimmerSample.Material3 -> Material3Samples()
+                        GlimmerSample.GlimmerComparison -> GlimmerComparisonSamples()
+                        GlimmerSample.Slider -> GlimmerSliderSamples()
                     }
                 }
             }

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/SamplesMenu.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/SamplesMenu.kt
@@ -38,6 +38,9 @@ enum class GlimmerSample(val title: String) {
     Vision("Vision AI"),
     ObjectRecognition("Object Recognition"),
     SpatialNote("Spatial Note"),
+    Material3("Standard Material 3"),
+    GlimmerComparison("Glimmer Comparison"),
+    Slider("Glimmer Slider (Custom)"),
     Ritual("Morning Ritual Layout");
 
     fun next(): GlimmerSample {


### PR DESCRIPTION
… slider

This commit introduces a set of comparison samples to demonstrate the differences between standard Material 3 components and the spatially-optimized Glimmer toolkit. It also implements a custom slider component tailored for XR environments.

- **Comparison Framework**:
    - Added `Material3Samples.kt` to showcase standard mobile UI components (Buttons, Cards, Selection Controls) using the default M3 Dark Theme.
    - Added `GlimmerComparisonSamples.kt` to provide a one-to-one comparison of Glimmer equivalents, highlighting spatial optimization, depth effects, and high-vibrancy "electric" color palettes designed for additive light displays.
- **Custom Spatial Components**:
    - Implemented `GlimmerSlider` in `GlimmerSliderSamples.kt`, a custom pill-style range input built using `Surface` and `pointerInput` to fill a gap in the current SDK.
    - Included a "Chroma" card example to demonstrate the slider's integration within a high-contrast spatial container.
- **UI & Navigation**:
    - Expanded `GlimmerSample` enum and `SamplesMenu.kt` to include entries for "Standard Material 3", "Glimmer Comparison", and "Glimmer Slider (Custom)".
    - Updated `GlassApp.kt` with new navigation routes to handle the added sample screens.
- **Design Logic**:
    - Integrated specific spatial design principles into the samples, such as replacing traditional sliders with discrete steps/ToggleButtons and using high-vibrancy colors to maintain legibility over real-world backgrounds.