### PR TITLE
feat: implement hardware permission handling and reactive camera life…

### DIFF
--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GlassesMainActivity.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GlassesMainActivity.kt
@@ -1,14 +1,18 @@
 package com.zoewave.probase.features.xr.glass
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.ActivityResultLauncher
 import androidx.camera.core.ExperimentalLensFacing
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -16,6 +20,8 @@ import androidx.xr.glimmer.GlimmerTheme
 import androidx.xr.projected.ProjectedDeviceController
 import androidx.xr.projected.ProjectedDisplayController
 import androidx.xr.projected.experimental.ExperimentalProjectedApi
+import androidx.xr.projected.permissions.ProjectedPermissionsRequestParams
+import androidx.xr.projected.permissions.ProjectedPermissionsResultContract
 import com.zoewave.probase.core.data.repository.GlassBridgeRepository
 import com.zoewave.probase.core.data.repository.LiveAiRepository
 import com.zoewave.probase.features.xr.glass.data.GlassSessionRepository
@@ -37,6 +43,13 @@ class GlassesMainActivity : ComponentActivity() {
     private var displayController: ProjectedDisplayController? = null
     private var isVisualUiSupported by mutableStateOf(false)
     private var areVisualsOn by mutableStateOf(true)
+
+    private val requestPermissionLauncher: ActivityResultLauncher<List<ProjectedPermissionsRequestParams>> =
+        registerForActivityResult(ProjectedPermissionsResultContract()) { results ->
+            if (results[Manifest.permission.CAMERA] == true) {
+                android.util.Log.d("GlassesMain", "Camera permission granted")
+            }
+        }
 
     private var initialSample: GlimmerSample? = null
 
@@ -69,6 +82,9 @@ class GlassesMainActivity : ComponentActivity() {
 
         // Initialize features. Phone app is responsible for pre-requesting permissions.
         initializeGlassesFeatures()
+
+        // Request hardware permissions for AI glasses features (e.g. Vision, Object Recognition)
+        requestHardwarePermissions()
 
         lifecycleScope.launch {
             glassBridgeRepository.glassCommands.collect { command ->
@@ -134,6 +150,23 @@ class GlassesMainActivity : ComponentActivity() {
                     glassSessionRepository.updateConnection(false)
                 }
             }
+        }
+    }
+
+    private fun requestHardwarePermissions() {
+        val permissions = listOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
+        val missingPermissions = permissions.filter {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+        }
+
+        if (missingPermissions.isNotEmpty()) {
+            val params = ProjectedPermissionsRequestParams(
+                permissions = missingPermissions,
+                rationale = "Camera and Microphone access are required to provide an immersive experience on your glasses."
+            )
+            // Best Practice: Speak the rationale since instructions aren't audible by default on glasses
+            params.rationale?.let { audioInterface.speak(it) }
+            requestPermissionLauncher.launch(listOf(params))
         }
     }
 

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/UnifiedVisionScreen.kt
@@ -109,14 +109,25 @@ fun UnifiedVisionRoute(
         viewModel.initializeAsHostCommander()
     }
 
-    // 2. Bulletproof Initialization: Key on both Permission and Activity presence
+    // 2. Reactive Lifecycle: Initialize on Connect + Permission, Teardown on Disconnect
     LaunchedEffect(isGranted, activity) {
+        if (activity == null) return@LaunchedEffect
+        
         viewModel.onEvent(VisionUiEvent.CheckPermissions(context))
-        if (isGranted && activity != null) {
-            Log.d("VisionUI", "Permission is GRANTED and Activity is ready. FIRING INITIALIZE!")
-            viewModel.cameraManager.initialize(activity)
+
+        if (android.os.Build.VERSION.SDK_INT >= 36) {
+            ProjectedContext.isProjectedDeviceConnected(context, Dispatchers.Main).collect { connected ->
+                if (connected && isGranted) {
+                    Log.d("VisionUI", "Bridge CONNECTED and Permission GRANTED. Initializing hardware...")
+                    viewModel.cameraManager.initialize(activity)
+                } else if (!connected) {
+                    Log.w("VisionUI", "Bridge DISCONNECTED. Tearing down hardware...")
+                    viewModel.cameraManager.teardown()
+                }
+            }
         } else {
-            Log.d("VisionUI", "Initialization pending: isGranted=$isGranted, activity=${activity?.let { "Ready" } ?: "Null"}")
+            // Fallback for older API levels where we assume connection if the activity is running
+            if (isGranted) viewModel.cameraManager.initialize(activity)
         }
     }
 

--- a/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
+++ b/features/xr/glass/vision/src/main/java/com/zoewave/probase/features/glass/vision/ui/manager/SimpleGlassesCameraManager.kt
@@ -77,9 +77,15 @@ class SimpleGlassesCameraManager @Inject constructor(
                 val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
 
                 if (!cameraProvider.hasCamera(cameraSelector)) {
-                    val msg = "ERROR: Hardware camera not found on projected device."
+                    val isEmulator = android.os.Build.PRODUCT.contains("sdk") || android.os.Build.MODEL.contains("Emulator")
+                    val msg = if (isEmulator) {
+                        "EMULATOR LIMIT: Virtual camera not supported on projected bridge."
+                    } else {
+                        "ERROR: Hardware camera not found on glasses."
+                    }
                     addLog(msg)
                     Log.w(tag, msg)
+                    _cameraSource.value = if (isEmulator) "Emulator (No Camera)" else "Hardware Missing"
                     return@launch
                 }
                 


### PR DESCRIPTION
…cycle for XR glasses

This commit introduces a robust permission request flow and a reactive camera management system tailored for XR projected environments, ensuring hardware is only initialized when the device is connected and permissions are granted.

- **Permission Management**:
    - Integrated `ProjectedPermissionsResultContract` in `GlassesMainActivity` to handle XR-specific permission requests.
    - Implemented `requestHardwarePermissions` to check for `CAMERA` and `RECORD_AUDIO` access.
    - Added an audio-based rationale playback using `audioInterface.speak` to guide users through permission requests on the glass interface.
- **Reactive Camera Lifecycle**:
    - Refactored `UnifiedVisionScreen` to use `ProjectedContext.isProjectedDeviceConnected` for reactive initialization and teardown of camera resources (API 36+).
    - Implemented a fallback initialization strategy for older API levels.
    - Added explicit `teardown()` calls to release hardware resources when the projected bridge disconnects.
- **Hardware Detection & Debugging**:
    - Updated `SimpleGlassesCameraManager` to provide specific feedback for emulator environments, distinguishing between missing hardware and virtualization limits.
    - Refined camera source state reporting to track "Hardware Missing" or "Emulator" status.
- **Infrastructure**:
    - Added support for `ProjectedPermissionsRequestParams` to handle multi-permission prompts within the projected display context.