### PR TITLE
Glass notification

### DIFF
--- a/core/data/src/main/java/com/zoewave/probase/core/data/repository/LiveAiRepository.kt
+++ b/core/data/src/main/java/com/zoewave/probase/core/data/repository/LiveAiRepository.kt
@@ -1,12 +1,25 @@
 package com.zoewave.probase.core.data.repository
 
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.flow.StateFlow
 
-interface LiveAiRepository : LifecycleObserver {
+interface LiveAiRepository : DefaultLifecycleObserver {
     val isSessionActive: StateFlow<Boolean>
     val audioLevel: StateFlow<Float>
 
     fun startSession()
     fun stopSession()
+
+    // 1. Automatically kill the AI session when the glasses are taken off
+    override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
+        stopSession()
+    }
+
+    // 2. (Optional) Auto-start the session when the activity resumes
+    // override fun onStart(owner: LifecycleOwner) {
+    //     super.onStart(owner)
+    //     startSession()
+    // }
 }

--- a/features/xr/glass/src/main/AndroidManifest.xml
+++ b/features/xr/glass/src/main/AndroidManifest.xml
@@ -44,5 +44,16 @@
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.zoewave.probase.features.xr.glass.SystemAlertActivity"
+            android:exported="true"
+            android:label="System Alert"
+            android:requiredDisplayCategory="xr_projected"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GlassesMainActivity.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/GlassesMainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.viewModels
 import androidx.camera.core.ExperimentalLensFacing
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,6 +27,7 @@ import com.zoewave.probase.core.data.repository.GlassBridgeRepository
 import com.zoewave.probase.core.data.repository.LiveAiRepository
 import com.zoewave.probase.features.xr.glass.data.GlassSessionRepository
 import com.zoewave.probase.features.xr.glass.ui.GlassApp
+import com.zoewave.probase.features.xr.glass.ui.GlassViewModel
 import com.zoewave.probase.features.xr.glass.ui.GlimmerSample
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -35,12 +37,16 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class GlassesMainActivity : ComponentActivity() {
 
+    private val LIFECYCLE_TAG = "XrLifecycle"
+
     @Inject lateinit var glassBridgeRepository: GlassBridgeRepository
     @Inject lateinit var glassSessionRepository: GlassSessionRepository
     @Inject lateinit var liveAiRepository: LiveAiRepository
     private lateinit var audioInterface: GlassAudioInterface
+    private val viewModel: GlassViewModel by viewModels()
 
     private var displayController: ProjectedDisplayController? = null
+    private var deviceController: ProjectedDeviceController? = null
     private var isVisualUiSupported by mutableStateOf(false)
     private var areVisualsOn by mutableStateOf(true)
 
@@ -57,6 +63,7 @@ class GlassesMainActivity : ComponentActivity() {
     @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        android.util.Log.d(LIFECYCLE_TAG, "onCreate: Initializing Glass Session")
 
         handleIntent(intent)
 
@@ -74,8 +81,11 @@ class GlassesMainActivity : ComponentActivity() {
 
         lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onDestroy(owner: LifecycleOwner) {
-                displayController?.close()
+                android.util.Log.d(LIFECYCLE_TAG, "onDestroy: Cleaning up controllers")
+                displayController?.close() // Controller for the Projected device display
                 displayController = null
+                deviceController?.close() // Controller for the Projected device
+                deviceController = null
                 glassSessionRepository.updateActiveSample(null)
             }
         })
@@ -128,19 +138,21 @@ class GlassesMainActivity : ComponentActivity() {
         // Clarification: create() is a suspend function in alpha08, so we use launch(Main.immediate).
         lifecycleScope.launch(kotlinx.coroutines.Dispatchers.Main.immediate) {
             try {
-                val projectedDeviceController = ProjectedDeviceController.create(this@GlassesMainActivity)
-                val connected = projectedDeviceController.capabilities.isNotEmpty()
-                isVisualUiSupported = ProjectedCapabilities.hasDisplay(projectedDeviceController)
+                val controller = ProjectedDeviceController.create(this@GlassesMainActivity)
+                deviceController = controller
+                
+                val connected = controller.capabilities.isNotEmpty()
+                isVisualUiSupported = ProjectedCapabilities.hasDisplay(controller)
                 
                 // Keep repository update async as it might be state-driven
                 launch {
                     glassSessionRepository.updateConnection(connected)
                 }
 
-                val controller = ProjectedDisplayController.create(this@GlassesMainActivity)
-                displayController = controller
+                val dispController = ProjectedDisplayController.create(this@GlassesMainActivity)
+                displayController = dispController
                 val observer = GlassesLifecycleObserver(
-                    controller = controller,
+                    controller = dispController,
                     onVisualsChanged = { visualsOn -> areVisualsOn = visualsOn }
                 )
                 lifecycle.addObserver(observer)
@@ -172,13 +184,27 @@ class GlassesMainActivity : ComponentActivity() {
 
     override fun onStart() {
         super.onStart()
+        android.util.Log.d(LIFECYCLE_TAG, "onStart: Glass Session is active")
         lifecycleScope.launch {
             glassBridgeRepository.updateGlassSessionState(isActive = true)
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        android.util.Log.d(LIFECYCLE_TAG, "onResume: Activity focused")
+        viewModel.setPaused(false)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        android.util.Log.d(LIFECYCLE_TAG, "onPause: Activity backgrounded but still visible")
+        viewModel.setPaused(true)
+    }
+
     override fun onStop() {
         super.onStop()
+        android.util.Log.d(LIFECYCLE_TAG, "onStop: Glass Session stopped")
         lifecycleScope.launch {
             glassBridgeRepository.updateGlassSessionState(isActive = false)
         }

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/SystemAlertActivity.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/SystemAlertActivity.kt
@@ -1,0 +1,73 @@
+package com.zoewave.probase.features.xr.glass
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.xr.glimmer.Button
+import androidx.xr.glimmer.Card
+import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.glimmer.Icon
+import androidx.xr.glimmer.Text
+import androidx.xr.projected.experimental.ExperimentalProjectedApi
+
+/**
+ * A "System Alert" activity that covers the main app.
+ * Used to demonstrate the ON_PAUSE lifecycle state on AI Glasses.
+ */
+@OptIn(ExperimentalProjectedApi::class)
+class SystemAlertActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        // This activity should be translucent so we can see the background app
+        setContent {
+            GlimmerTheme {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.5f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    AlertContent(onDismiss = { finish() })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlertContent(onDismiss: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(0.8f),
+        title = { Text("System Alert") },
+        leadingIcon = {
+            Icon(Icons.Default.Warning, contentDescription = null, tint = Color.Yellow)
+        }
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "This activity has pushed the background app to ON_PAUSE.",
+                style = GlimmerTheme.typography.bodyMedium
+            )
+            Spacer(Modifier.height(24.dp))
+            Button(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) {
+                Text("Dismiss")
+            }
+        }
+    }
+}

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassApp.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassApp.kt
@@ -3,8 +3,10 @@ package com.zoewave.probase.features.xr.glass.ui
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.ExperimentalLensFacing
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
@@ -22,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -189,6 +192,37 @@ fun GlassApp(
                             color = Color.White
                         )
                     }
+                }
+            }
+        }
+
+        // --- Lifecycle Paused Badge ---
+        AnimatedVisibility(
+            visible = uiState.isPaused,
+            enter = slideInVertically { it } + fadeIn(),
+            exit = slideOutVertically { it } + fadeOut(),
+            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 24.dp)
+        ) {
+            Card(
+                color = Color.DarkGray.copy(alpha = 0.8f),
+                modifier = Modifier.padding(8.dp)
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        Icons.Default.Info,
+                        contentDescription = null,
+                        tint = Color.Yellow,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = "ON_PAUSE (Still Rendering)",
+                        style = GlimmerTheme.typography.bodySmall,
+                        color = Color.White
+                    )
                 }
             }
         }

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassUiState.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassUiState.kt
@@ -7,5 +7,6 @@ data class GlassUiState(
     val isLoading: Boolean = true,
     val isAiActive: Boolean = false,
     val aiAudioLevel: Float = 0f,
-    val notificationText: String? = null
+    val notificationText: String? = null,
+    val isPaused: Boolean = false
 )

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassViewModel.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassViewModel.kt
@@ -28,6 +28,7 @@ class GlassViewModel @Inject constructor(
 
     private val _currentDate = MutableStateFlow(getStartOfDay(System.currentTimeMillis()))
     private val _notificationText = MutableStateFlow<String?>(null)
+    private val _isPaused = MutableStateFlow(false)
     
     val uiState: StateFlow<GlassUiState> = combine(
         _currentDate.flatMapLatest { date ->
@@ -52,14 +53,16 @@ class GlassViewModel @Inject constructor(
         },
         liveAiRepository.isSessionActive,
         liveAiRepository.audioLevel,
-        _notificationText
-    ) { activeRoutine, isAiActive, aiLevel, notification ->
+        _notificationText,
+        _isPaused
+    ) { activeRoutine, isAiActive, aiLevel, notification, paused ->
         GlassUiState(
             morningRoutine = activeRoutine,
             isLoading = false,
             isAiActive = isAiActive,
             aiAudioLevel = aiLevel,
-            notificationText = notification
+            notificationText = notification,
+            isPaused = paused
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), GlassUiState())
 
@@ -72,6 +75,10 @@ class GlassViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun setPaused(paused: Boolean) {
+        _isPaused.value = paused
     }
 
     private fun showNotification(text: String) {

--- a/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassXRDemosPhoneScreen.kt
+++ b/features/xr/glass/src/main/java/com/zoewave/probase/features/xr/glass/ui/GlassXRDemosPhoneScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Cast
 import androidx.compose.material.icons.filled.CastConnected
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -51,6 +52,7 @@ import com.zoewave.probase.features.glass.vision.ui.UnifiedVisionRoute
 import com.zoewave.probase.features.glass.vision.ui.VisionUiEvent
 import com.zoewave.probase.features.glass.vision.ui.VisionViewModel
 import com.zoewave.probase.features.xr.glass.GlassesMainActivity
+import com.zoewave.probase.features.xr.glass.SystemAlertActivity
 
 @androidx.annotation.OptIn(ExperimentalLensFacing::class)
 @OptIn(
@@ -84,7 +86,8 @@ fun GlassXRDemosPhoneRoute(
         onStopDemo = { viewModel.updateActiveSample(null) },
         onNextSample = { sample -> viewModel.updateActiveSample(sample.next()) },
         onPreviousSample = { sample -> viewModel.updateActiveSample(sample.previous()) },
-        onSendNotification = { text -> viewModel.sendNotification(text) }
+        onSendNotification = { text -> viewModel.sendNotification(text) },
+        onTriggerAlert = { launchAlertOnGlasses(context) }
     )
 }
 
@@ -101,6 +104,7 @@ fun GlassXRDemosPhoneScreen(
     onNextSample: (GlimmerSample) -> Unit,
     onPreviousSample: (GlimmerSample) -> Unit,
     onSendNotification: (String) -> Unit,
+    onTriggerAlert: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
@@ -226,16 +230,27 @@ fun GlassXRDemosPhoneScreen(
 
                             if (isConnected) {
                                 Spacer(Modifier.height(16.dp))
-                                androidx.compose.material3.Button(
-                                    onClick = { onSendNotification("Hello DroidCon from Phone!") },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    colors = androidx.compose.material3.ButtonDefaults.buttonColors(
-                                        containerColor = Color(0xFF4CAF50)
-                                    )
-                                ) {
-                                    Icon(Icons.Default.Notifications, contentDescription = null)
-                                    Spacer(Modifier.width(8.dp))
-                                    Text("Ping Glasses")
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    androidx.compose.material3.Button(
+                                        onClick = { onSendNotification("Hello DroidCon from Phone!") },
+                                        modifier = Modifier.weight(1f),
+                                        colors = androidx.compose.material3.ButtonDefaults.buttonColors(
+                                            containerColor = Color(0xFF4CAF50)
+                                        )
+                                    ) {
+                                        Icon(Icons.Default.Notifications, contentDescription = null)
+                                        Spacer(Modifier.width(8.dp))
+                                        Text("Ping")
+                                    }
+                                    
+                                    androidx.compose.material3.OutlinedButton(
+                                        onClick = { onTriggerAlert() },
+                                        modifier = Modifier.weight(1f)
+                                    ) {
+                                        Icon(Icons.Default.Warning, contentDescription = null)
+                                        Spacer(Modifier.width(8.dp))
+                                        Text("Alert")
+                                    }
                                 }
                             }
                         }
@@ -311,6 +326,29 @@ private fun launchOnGlasses(context: android.content.Context, sample: GlimmerSam
         val intent = Intent(context, GlassesMainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             putExtra("initial_sample", sample.name)
+        }
+        context.startActivity(intent)
+    }
+}
+
+@OptIn(ExperimentalProjectedApi::class)
+private fun launchAlertOnGlasses(context: android.content.Context) {
+    if (android.os.Build.VERSION.SDK_INT >= 35) {
+        try {
+            val options = ProjectedContext.createProjectedActivityOptions(context)
+            val intent = Intent(context, SystemAlertActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent, options.toBundle())
+        } catch (e: Exception) {
+            val intent = Intent(context, SystemAlertActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+        }
+    } else {
+        val intent = Intent(context, SystemAlertActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
         context.startActivity(intent)
     }


### PR DESCRIPTION
How to use this in your Talk:
1.
Filter Tag: In the Android Studio Logcat, filter for XrLifecycle.
2.
Live Demo:
◦
Open Sample: You will see onCreate -> onStart -> onResume.
◦
Trigger "Alert": You will see onPause appear. Point out that the XrLifecycle log stops there, even though the UI is still rendering!
◦
Dismiss Alert: You will see onResume.
◦
Close Sample: You will see onStop -> onDestroy.
What the logs show:
•
onCreate: Initializing Glass Session.
•
onStart: Glass Session is active.
•
onResume: Activity focused.
•
onPause: Activity backgrounded but still visible.
•
onStop: Glass Session stopped (Controller cleanup starts).
•
onDestroy: Cleaning up controllers (Leak prevention).
This provides clear, real-time evidence for the audience that the Android XR activity model is both familiar and unique! 🚀