### PR TITLE
feat: integrate Nails category into Style Simulator recommendations

### DIFF
--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/data/StyleSimulatorEngine.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/data/StyleSimulatorEngine.kt
@@ -29,7 +29,7 @@ class StyleSimulatorEngine @Inject constructor(
           "rationale": "string",
           "selectedClothingIds": ["String", "String", "String"],
           "selectedCosmeticIds": ["String", "String", "String", ...],
-          "recommendedPalette": ["#HEX", "#HEX", "#HEX"]
+          "recommendedPalette": ["#HEX", "#HEX", "#HEX", "#HEX"]
         }
     """.trimIndent()
 
@@ -200,23 +200,21 @@ class StyleSimulatorEngine @Inject constructor(
             $minifiedManifest
             
             GOAL:
-            1. Select BEST 3 clothing items (Top, Bottom, Shoes) from the manifest.
-            2. Select exactly 3 PIGMENT makeup items (1 Eye, 1 Cheek, 1 Lip) from the manifest.
+            1. Select BEST 3 clothing items (Top, Bottom, Shoes) from the manifest. Prioritize user anchors.
+            2. Select exactly 4 PIGMENT makeup items (1 Eye, 1 Cheek, 1 Lip, 1 Nail) from the manifest. Prioritize user anchors.
             3. Select 1-2 DEFENSIVE items (Complexion/Skincare) from the manifest based strictly on the WEATHER/ATMOSPHERIC data. 
                - If UV is high, select an SPF product.
                - If humidity/heat is high, select a matte/long-wear foundation or primer.
-            4. Create a 3-color Palette (HEX codes) harmonizing the whole look.
-            5. Provide a brief rationale. Mention WHY you selected the specific DEFENSIVE items for the current weather.
+            4. Create a 4-color Palette (HEX codes) harmonizing the whole look. The 4th color MUST be the selected Nail color.
+            5. Provide a brief rationale. Mention WHY you selected the specific DEFENSIVE items for the current weather and why you chose the nail color.
                CRITICAL SYNTAX RULE: When referencing ANY selected item in your rationale, you MUST use the exact inline tag format <ITEM:id>. Do not attempt to guess or describe the item's brand in the text.
-               GOOD EXAMPLE: "I selected <ITEM:w_5> for its breathability, paired with <ITEM:c_14>."
-               BAD EXAMPLE: "I selected the Brunello top (#w_5)..."
             
             Respond ONLY with a valid JSON object matching this schema:
             {
               "rationale": "string",
               "selectedClothingIds": ["String", "String", "String"],
-              "selectedCosmeticIds": ["String", "String", "String", ...],
-              "recommendedPalette": ["#HEX", "#HEX", "#HEX"]
+              "selectedCosmeticIds": ["String", "String", "String", "String", ...],
+              "recommendedPalette": ["#HEX", "#HEX", "#HEX", "#HEX"]
             }
         """.trimIndent()
     }
@@ -258,22 +256,28 @@ class StyleSimulatorEngine @Inject constructor(
         bottoms.smartPick({it.name}, {it.notes})?.let { selectedItems.add(it) }
         shoes.smartPick({it.name}, {it.notes})?.let { selectedItems.add(it) }
         
-        // 2. Pick Cosmetics (Trinity: Eyes, Cheeks, Lips)
+        // 2. Pick Cosmetics (Trinity: Eyes, Cheeks, Lips, Nails)
         val eyes = availableCosmetics.filter { it.macroCategory == MacroCategory.EYES }
         val cheeks = availableCosmetics.filter { it.macroCategory == MacroCategory.DIMENSION }
         val lips = availableCosmetics.filter { it.macroCategory == MacroCategory.LIPS }
+        val nails = availableCosmetics.filter { it.macroCategory == MacroCategory.NAILS }
 
         eyes.smartPick({it.name}, {it.notes})?.let { selectedCosmetics.add(it) }
         cheeks.smartPick({it.name}, {it.notes})?.let { selectedCosmetics.add(it) }
         lips.smartPick({it.name}, {it.notes})?.let { selectedCosmetics.add(it) }
+        nails.smartPick({it.name}, {it.notes})?.let { selectedCosmetics.add(it) }
 
         val palette = selectedItems.mapNotNull { it.dominantHex }.distinct().toMutableList()
         if (palette.isEmpty()) palette.add("#FFFFFF")
         
-        while (palette.size < 3) {
-            palette.add(listOf("#000000", "#808080", "#E0E0E0", "#333333").random())
+        selectedCosmetics.forEach { item ->
+            item.colorHex?.let { palette.add(it) }
         }
-        val finalPalette = palette.take(3)
+
+        while (palette.size < 4) {
+            palette.add(listOf("#000000", "#808080", "#E0E0E0", "#333333", "#8B0000").random())
+        }
+        val finalPalette = palette.take(4)
 
         return StyleBlueprint(
             rationale = "Local Architect: Selected from your vault based on intent.",

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/SimulatorComponents.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/SimulatorComponents.kt
@@ -184,7 +184,8 @@ fun MessagingStep(
                 categories = listOf(
                     Triple("Eyes", Icons.Default.Visibility, MacroCategory.EYES),
                     Triple("Cheeks", Icons.Default.FaceRetouchingNatural, MacroCategory.DIMENSION),
-                    Triple("Lips", Icons.Default.Face, MacroCategory.LIPS)
+                    Triple("Lips", Icons.Default.Face, MacroCategory.LIPS),
+                    Triple("Nails", Icons.Default.PanTool, MacroCategory.NAILS)
                 ),
                 selectedCategory = uiState.selectedCosmeticCategory,
                 onCategorySelect = { onEvent(SimulatorEvent.SelectCosmeticCategory(it as MacroCategory)) },
@@ -873,11 +874,20 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                 end = Offset(center.x + 100.dp.toPx(), center.y + 160.dp.toPx()),
                 pathEffect = dashEffect, strokeWidth = 1.dp.toPx()
             )
+
+            // Nails (Bottom Right - Lower)
+            drawLine(
+                color = Color.LightGray,
+                start = Offset(center.x + 40.dp.toPx(), center.y + 80.dp.toPx()),
+                end = Offset(center.x + 120.dp.toPx(), center.y + 180.dp.toPx()),
+                pathEffect = dashEffect, strokeWidth = 1.dp.toPx()
+            )
         }
 
         val eyesItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.EYES }
         val cheeksItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
         val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
+        val nailsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.NAILS }
 
         BlueprintCallout(
             label = "EYES",
@@ -897,6 +907,13 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             label = "LIPS",
             productName = lipsItem?.name ?: "Pending...",
             colorHex = lipsItem?.colorHex,
+            modifier = Modifier.align(Alignment.BottomEnd).padding(bottom = 0.dp).offset(x = (-30).dp, y = blueprintOffset - 50.dp)
+        )
+
+        BlueprintCallout(
+            label = "NAILS",
+            productName = nailsItem?.name ?: "Pending...",
+            colorHex = nailsItem?.colorHex,
             modifier = Modifier.align(Alignment.BottomEnd).padding(bottom = 0.dp).offset(y = blueprintOffset - 10.dp)
         )
     }

--- a/core/model/src/main/java/com/zoewave/probase/core/model/ritual/CosmeticItem.kt
+++ b/core/model/src/main/java/com/zoewave/probase/core/model/ritual/CosmeticItem.kt
@@ -9,6 +9,7 @@ enum class MacroCategory(val displayName: String, val description: String) {
     DIMENSION("Color & Dimension", "Products that bring life, shadow, and light."),
     EYES("Eyes & Brows", "All definition for the upper face."),
     LIPS("Lips", "All color and care for the mouth."),
+    NAILS("Nails", "Polish, care, and enhancements."),
     HAIR("Haircare", "Cleanse, treat, and style."),
     HYGIENE("Hygiene & Bath", "Daily body care and sanitization."),
     ORAL("Oral Care", "Smile preservation and hygiene."),
@@ -103,7 +104,7 @@ enum class MicroCategory(val macro: MacroCategory) {
     
     // Hands & Nails
     HAND_CREAM(MacroCategory.HYGIENE),
-    NAIL_POLISH(MacroCategory.TOOLS),
+    NAIL_POLISH(MacroCategory.NAILS),
     
     // Tools
     BRUSHES(MacroCategory.TOOLS),


### PR DESCRIPTION
This commit expands the Style Simulator's recommendation engine and UI to include a "Nails" category. It updates the LLM orchestration logic to include nail pigments, increases the recommended palette size, and adds visual callouts to the blueprint view.

- **Data Modeling & Categories**:
    - Introduced `NAILS` as a distinct `MacroCategory`.
    - Reclassified `NAIL_POLISH` from `TOOLS` to the new `NAILS` macro category for better organizational alignment.
- **Engine & LLM Logic**:
    - Updated `StyleSimulatorEngine` prompt to select 4 pigment items (Eye, Cheek, Lip, Nail) instead of 3.
    - Expanded the `recommendedPalette` requirement to 4 HEX codes, explicitly mandating that the 4th color matches the selected nail color.
    - Updated the "Local Architect" fallback logic to include nail category filtering and expanded palette generation.
    - Refined the AI rationale instructions to include justifications for nail color selection.
- **UI & Component Enhancements**:
    - Added a "Nails" tab to the cosmetic category selector using the `PanTool` icon.
    - Updated `FaceBlueprintView` to include a dedicated `BlueprintCallout` and dashed anchor line for nail recommendations.
    - Adjusted blueprint layout offsets to accommodate the additional nail metadata callout.