### PR TITLE
feat: introduce dedicated Nails tab and hand blueprint view in Style …

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -37,8 +37,8 @@
             <InsightsFilterSettings>
               <option name="connection">
                 <ConnectionSetting>
-                  <option name="appId" value="com.zoewave.probase.photodo" />
-                  <option name="mobileSdkAppId" value="1:786488326984:android:e00be2a9f5c50e8195517d" />
+                  <option name="appId" value="com.zoewave.probase.seaweed" />
+                  <option name="mobileSdkAppId" value="1:786488326984:android:85851adba3a7e76e95517d" />
                   <option name="projectId" value="android-zoewave" />
                   <option name="projectNumber" value="786488326984" />
                 </ConnectionSetting>

--- a/applications/ashbike/apps/mobile/build.gradle.kts
+++ b/applications/ashbike/apps/mobile/build.gradle.kts
@@ -142,6 +142,9 @@ dependencies {
 
     // The library containing the Adaptive APIs
     implementation(libs.androidx.material3.adaptive.navigation3)
+    implementation(libs.androidx.compose.material3.adaptive)
+    implementation(libs.androidx.compose.material3.adaptive.layout)
+    implementation(libs.androidx.compose.material3.adaptive.navigation)
 
     // Maps
     implementation(libs.google.maps.compose)

--- a/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/RidesScreen.kt
+++ b/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/RidesScreen.kt
@@ -23,7 +23,8 @@ fun RidesScreen(
     onDeleteClick: (String) -> Unit,
     onSyncClick: (String) -> Unit,
     onRetry: () -> Unit,
-    navTo: (String) -> Unit
+    navTo: (String) -> Unit,
+    selectedRideId: String? = null
 ) {
     Scaffold(
         modifier = modifier,
@@ -54,6 +55,7 @@ fun RidesScreen(
                     onDeleteClick = onDeleteClick,
                     onSyncClick = onSyncClick,
                     navTo = navTo,
+                    selectedRideId = selectedRideId,
                     bikeEvent = TODO(),
                     syncedIds = TODO(),
                     healthEvent = TODO(),

--- a/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/RidesUIRoute.kt
+++ b/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/RidesUIRoute.kt
@@ -33,6 +33,7 @@ fun RidesUIRoute(
     navTo: (String) -> Unit,
     ridesViewModel: RidesViewModel = hiltViewModel(),
     healthViewModel: HealthViewModel = hiltViewModel(),
+    selectedRideId: String? = null
 ) {
     // 1. Collect state from BOTH ViewModels
     val tripsUiState by ridesViewModel.uiState.collectAsState()
@@ -160,7 +161,8 @@ fun RidesUIRoute(
                     ridesViewModel.onEvent(RidesEvent.SyncRide(rideId))
                 },
                 healthUiState = healthUiState,
-                navTo = navTo
+                navTo = navTo,
+                selectedRideId = selectedRideId
             )
         }
     }

--- a/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/components/BikeRideCard.kt
+++ b/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/components/BikeRideCard.kt
@@ -35,15 +35,20 @@ fun BikeRideCard(
     ride: BikeRideUiModel,
     onDeleteClick: () -> Unit,
     onSyncClick: () -> Unit,
-    onNavigate: () -> Unit
+    onNavigate: () -> Unit,
+    selected: Boolean = false
 ) {
     Card(
         modifier = modifier
             .fillMaxWidth()
             .clickable(onClick = onNavigate),
         shape = RoundedCornerShape(8.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
-        elevation = CardDefaults.cardElevation(4.dp)
+        colors = CardDefaults.cardColors(
+            containerColor = if (selected) MaterialTheme.colorScheme.primaryContainer 
+                             else MaterialTheme.colorScheme.surfaceVariant
+        ),
+        border = if (selected) androidx.compose.foundation.BorderStroke(2.dp, MaterialTheme.colorScheme.primary) else null,
+        elevation = CardDefaults.cardElevation(if (selected) 8.dp else 4.dp)
     ) {
         Box {
             Box(

--- a/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/components/BikeTripsCompose.kt
+++ b/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/components/BikeTripsCompose.kt
@@ -31,7 +31,8 @@ fun BikeTripsCompose(
     onDeleteClick: (String) -> Unit,
     onSyncClick: (String) -> Unit,
     healthUiState: HealthUiState,
-    navTo: (String) -> Unit
+    navTo: (String) -> Unit,
+    selectedRideId: String? = null
 ) {
 
     // derive a simple “connected?” flag
@@ -77,6 +78,7 @@ fun BikeTripsCompose(
                         onDeleteClick = { onDeleteClick(rideModel.rideId) },
                         onSyncClick = { onSyncClick(rideModel.rideId) },
                         onNavigate = { navTo(rideModel.rideId) },
+                        selected = rideModel.rideId == selectedRideId
                     )
                 }
             }

--- a/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/components/details/RideDetailPlaceholder.kt
+++ b/applications/ashbike/apps/mobile/features/rides/src/main/java/com/zoewave/ashbike/mobile/rides/ui/components/details/RideDetailPlaceholder.kt
@@ -1,0 +1,27 @@
+package com.zoewave.ashbike.mobile.rides.ui.components.details
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RideDetailPlaceholder(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Select a ride to see details",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/applications/ashbike/apps/mobile/src/main/java/com/zoewave/probase/ashbike/mobile/ui/components/AshBikeMainScreen.kt
+++ b/applications/ashbike/apps/mobile/src/main/java/com/zoewave/probase/ashbike/mobile/ui/components/AshBikeMainScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -59,7 +61,7 @@ import com.zoewave.probase.ashbike.mobile.ui.MainUiEvent
 import com.zoewave.probase.ashbike.mobile.ui.MainViewModel
 import com.zoewave.probase.ashbike.mobile.ui.navigation.ashBikeNavEntryProvider
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 fun AshBikeMainScreen(
     viewModel: MainViewModel = hiltViewModel(),
@@ -80,6 +82,8 @@ fun AshBikeMainScreen(
     val backStack = remember {
         mutableStateListOf<AshBikeDestination>(AshBikeDestination.Home)
     }
+
+    val listDetailSceneStrategy = rememberListDetailSceneStrategy<AshBikeDestination>()
 
     // Helper to push a new screen
     fun navigateTo(destination: AshBikeDestination) {
@@ -119,6 +123,13 @@ fun AshBikeMainScreen(
     // ✅ FIX: Use derivedStateOf to strictly observe the list changes
     val currentDestination by remember {
         derivedStateOf { backStack.lastOrNull() ?: AshBikeDestination.Home }
+    }
+
+    val selectedRideId by remember {
+        derivedStateOf {
+            val detail = backStack.filterIsInstance<AshBikeDestination.RideDetail>().lastOrNull()
+            detail?.rideId
+        }
     }
 
     // 2. In your MainScreen
@@ -217,6 +228,7 @@ fun AshBikeMainScreen(
                 backStack = backStack,
                 modifier = Modifier.padding(innerPadding),
                 onBack = { backStack.removeLastOrNull() }, // Default back action
+                sceneStrategies = listOf(listDetailSceneStrategy),
                 entryDecorators = listOf(
                     rememberSaveableStateHolderNavEntryDecorator(),
                     rememberViewModelStoreNavEntryDecorator()
@@ -228,6 +240,7 @@ fun AshBikeMainScreen(
                         key = key,
                         navigateTo = { dest -> navigateTo(dest) },
                         homeViewModel = homeViewModel,
+                        selectedRideId = selectedRideId
                     )
                 }
             )

--- a/applications/ashbike/apps/mobile/src/main/java/com/zoewave/probase/ashbike/mobile/ui/navigation/ashBikeNavEntryProvider.kt
+++ b/applications/ashbike/apps/mobile/src/main/java/com/zoewave/probase/ashbike/mobile/ui/navigation/ashBikeNavEntryProvider.kt
@@ -11,10 +11,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.NavEntry
 import com.zoewave.ashbike.mobile.home.ui.HomeViewModel
 import com.zoewave.ashbike.mobile.rides.ui.RidesUIRoute
+import com.zoewave.ashbike.mobile.rides.ui.components.details.RideDetailPlaceholder
 import com.zoewave.ashbike.mobile.rides.ui.components.details.RideDetailScreen
 import com.zoewave.ashbike.mobile.rides.ui.components.details.RideDetailViewModel
 import com.zoewave.ashbike.mobile.rides.ui.components.unused.haversineMeters
@@ -27,11 +30,13 @@ import com.zoewave.probase.feature.places.ui.CoffeeShopViewModel
 import com.zoewave.probaseapplications.bike.features.main.ui.HomeUiRoute
 
 
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @SuppressLint("MissingPermission") // <--- ADD THIS
 fun ashBikeNavEntryProvider(
     key: AshBikeDestination,
     navigateTo: (AshBikeDestination) -> Unit,
-    homeViewModel: HomeViewModel
+    homeViewModel: HomeViewModel,
+    selectedRideId: String? = null
 ): NavEntry<AshBikeDestination> {
 
     // NavEntry wraps the content and provides the scope for Hilt ViewModels
@@ -52,75 +57,88 @@ fun ashBikeNavEntryProvider(
             // 2. TRIPS TAB (List)
             // -----------------------------------------------------------------
             is AshBikeDestination.Trips -> {
-                RidesUIRoute(
-                    modifier = Modifier.fillMaxSize(),
-                    // The Trips screen emits a string ID when a row is clicked.
-                    // We wrap that String into our Type-Safe 'RideDetail' object.
-                    navTo = { rideId ->
-                        navigateTo(AshBikeDestination.RideDetail(rideId))
-                    }
-                )
+                NavEntry(
+                    key = key,
+                    metadata = ListDetailSceneStrategy.listPane(
+                        detailPlaceholder = { RideDetailPlaceholder() }
+                    )
+                ) {
+                    RidesUIRoute(
+                        modifier = Modifier.fillMaxSize(),
+                        // The Trips screen emits a string ID when a row is clicked.
+                        // We wrap that String into our Type-Safe 'RideDetail' object.
+                        navTo = { rideId ->
+                            navigateTo(AshBikeDestination.RideDetail(rideId))
+                        },
+                        selectedRideId = selectedRideId
+                    )
+                }
             }
 
             // -----------------------------------------------------------------
             // 3. RIDE DETAIL (Detail Screen)
             // -----------------------------------------------------------------
             is AshBikeDestination.RideDetail -> {
-                // A. Get ViewModels
-                // Hilt scopes these to this specific NavEntry (Screen)
-                val rideViewModel: RideDetailViewModel = hiltViewModel()
-                val cafeViewModel: CoffeeShopViewModel = hiltViewModel()
+                NavEntry(
+                    key = key,
+                    metadata = ListDetailSceneStrategy.detailPane()
+                ) {
+                    // A. Get ViewModels
+                    // Hilt scopes these to this specific NavEntry (Screen)
+                    val rideViewModel: RideDetailViewModel = hiltViewModel()
+                    val cafeViewModel: CoffeeShopViewModel = hiltViewModel()
 
-                // B. CRITICAL: Bridge Nav3 Key -> ViewModel
-                // Since Nav3 doesn't populate SavedStateHandle automatically yet,
-                // we manually pass the ID from the Key to the ViewModel.
-                LaunchedEffect(key.rideId) {
-                    rideViewModel.loadRide(key.rideId)
-                }
-
-                // C. Collect State
-                val rideWithLocs by rideViewModel.rideWithLocations.collectAsState()
-                val cafeUiState by cafeViewModel.uiState.collectAsState()
-
-                // D. Define Cafe Logic (Ported from legacy NavGraph)
-                // This calculates the center of the ride and a dynamic radius to find coffee shops.
-                val findCafesAction = {
-                    val locations = rideWithLocs?.locations
-                    if (!locations.isNullOrEmpty()) {
-                        val centerLat = locations.map { it.lat }.average()
-                        val centerLng = locations.map { it.lng }.average()
-
-                        // Calculate dynamic radius based on ride size
-                        val routeRadius = locations.maxOfOrNull { loc ->
-                            haversineMeters(centerLat, centerLng, loc.lat, loc.lng)
-                        } ?: 0.0
-
-                        // Search slightly wider than the route (min 200m, max 1.5km)
-                        val searchRadius = (routeRadius + 100.0).coerceIn(200.0, 1500.0)
-
-                        cafeViewModel.onEvent(
-                            CoffeeShopEvent.FindCafesInArea(
-                                latitude = centerLat,
-                                longitude = centerLng,
-                                radius = searchRadius
-                            )
-                        )
-                    } else {
-                        Logging.w("Nav3", "User requested cafes, but ride location data is empty.")
+                    // B. CRITICAL: Bridge Nav3 Key -> ViewModel
+                    // Since Nav3 doesn't populate SavedStateHandle automatically yet,
+                    // we manually pass the ID from the Key to the ViewModel.
+                    LaunchedEffect(key.rideId) {
+                        rideViewModel.loadRide(key.rideId)
                     }
+
+                    // C. Collect State
+                    val rideWithLocs by rideViewModel.rideWithLocations.collectAsState()
+                    val cafeUiState by cafeViewModel.uiState.collectAsState()
+
+                    // D. Define Cafe Logic (Ported from legacy NavGraph)
+                    // This calculates the center of the ride and a dynamic radius to find coffee shops.
+                    val findCafesAction = {
+                        val locations = rideWithLocs?.locations
+                        if (!locations.isNullOrEmpty()) {
+                            val centerLat = locations.map { it.lat }.average()
+                            val centerLng = locations.map { it.lng }.average()
+
+                            // Calculate dynamic radius based on ride size
+                            val routeRadius = locations.maxOfOrNull { loc ->
+                                haversineMeters(centerLat, centerLng, loc.lat, loc.lng)
+                            } ?: 0.0
+
+                            // Search slightly wider than the route (min 200m, max 1.5km)
+                            val searchRadius = (routeRadius + 100.0).coerceIn(200.0, 1500.0)
+
+                            cafeViewModel.onEvent(
+                                CoffeeShopEvent.FindCafesInArea(
+                                    latitude = centerLat,
+                                    longitude = centerLng,
+                                    radius = searchRadius
+                                )
+                            )
+                        } else {
+                            Logging.w("Nav3", "User requested cafes, but ride location data is empty.")
+                        }
+                    }
+
+                    // E. Extract Shop List safely
+                    val coffeeShops = (cafeUiState as? CoffeeShopUIState.Success)?.coffeeShops ?: emptyList()
+
+                    // F. Render the Screen
+                    RideDetailScreen(
+                        modifier = Modifier.fillMaxSize(),
+                        rideWithLocs = rideWithLocs,
+                        coffeeShops = coffeeShops,
+                        onFindCafes = findCafesAction,
+                        onEvent = { event -> rideViewModel.onEvent(event) }
+                    )
                 }
-
-                // E. Extract Shop List safely
-                val coffeeShops = (cafeUiState as? CoffeeShopUIState.Success)?.coffeeShops ?: emptyList()
-
-                // F. Render the Screen
-                RideDetailScreen(
-                    modifier = Modifier.fillMaxSize(),
-                    rideWithLocs = rideWithLocs,
-                    coffeeShops = coffeeShops,
-                    onFindCafes = findCafesAction,
-                    onEvent = { event -> rideViewModel.onEvent(event) }
-                )
             }
 
             // -----------------------------------------------------------------

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/AnalysisStep.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/AnalysisStep.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.kocolor.features.analyzer.R
 import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.SimulationStep
@@ -98,6 +99,18 @@ fun AnalysisStep(
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
             modifier = Modifier.width(280.dp),
             textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AnalysisStepPreview() {
+    MaterialTheme {
+        AnalysisStep(
+            uiState = StyleSimulatorUiState(simulationStep = SimulationStep.BIO_MARKERS),
+            onEvent = {},
+            navTo = {}
         )
     }
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/BlueprintCallout.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/BlueprintCallout.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
@@ -126,4 +127,14 @@ fun BlueprintCallout(
             )
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun BlueprintCalloutPreview() {
+    BlueprintCallout(
+        label = "EYES",
+        productName = "Midnight Mascara",
+        colorHex = "#2C3E50"
+    )
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/ClothingBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/ClothingBlueprintView.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.kocolor.features.analyzer.R
@@ -98,4 +99,10 @@ fun ClothingBlueprintView(uiState: StyleSimulatorUiState) {
             modifier = Modifier.align(Alignment.BottomEnd).padding(bottom = 10.dp).offset(y = blueprintOffset)
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ClothingBlueprintViewPreview() {
+    ClothingBlueprintView(uiState = StyleSimulatorUiState())
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.core.model.ritual.MacroCategory
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
@@ -161,4 +162,10 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             modifier = Modifier.align(Alignment.BottomEnd).padding(bottom = 0.dp, end = 5.dp).offset(y = blueprintOffset - 10.dp)
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun FaceBlueprintViewPreview() {
+    FaceBlueprintView(uiState = StyleSimulatorUiState())
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/HandBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/HandBlueprintView.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.core.model.ritual.MacroCategory
@@ -102,4 +103,10 @@ fun HandBlueprintView(uiState: StyleSimulatorUiState) {
             modifier = Modifier.align(Alignment.TopEnd).padding(top = 80.dp).offset(y = (-40).dp)
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HandBlueprintViewPreview() {
+    HandBlueprintView(uiState = StyleSimulatorUiState())
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/MagicBackground.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/MagicBackground.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -32,4 +33,10 @@ fun MagicBackground() {
             )
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MagicBackgroundPreview() {
+    MagicBackground()
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/ResultTabToggle.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/ResultTabToggle.kt
@@ -12,11 +12,14 @@ import androidx.compose.material.icons.filled.PanTool
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.ResultTab
 
@@ -79,4 +82,14 @@ private fun ResultTabItem(
             modifier = Modifier.size(20.dp)
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ResultTabTogglePreview() {
+    val selectedTab = remember { mutableStateOf(ResultTab.FACE) }
+    ResultTabToggle(
+        selectedTab = selectedTab.value,
+        onTabSelected = { selectedTab.value = it }
+    )
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/AnchorSection.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/AnchorSection.kt
@@ -2,6 +2,9 @@ package com.zoewave.probase.kocolor.features.analyzer.simulator.ui.components.li
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Checkroom
+import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -14,6 +17,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.zoewave.probase.core.model.ritual.ColorFamily
@@ -96,4 +100,22 @@ fun <T> AnchorSection(
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AnchorSectionPreview() {
+    AnchorSection(
+        title = "CLOTHING ANCHORS",
+        categories = listOf(
+            Triple("Top", Icons.Default.Checkroom, "TOP"),
+            Triple("Bottom", Icons.Default.Layers, "BOTTOM")
+        ),
+        selectedCategory = "TOP",
+        onCategorySelect = {},
+        families = mapOf(ColorFamily.TRUE_RED to listOf("Red Item")),
+        anchoredFamily = ColorFamily.TRUE_RED,
+        onToggle = {},
+        emptyMessage = "No items found"
+    )
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/CategoryPill.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/CategoryPill.kt
@@ -2,6 +2,8 @@ package com.zoewave.probase.kocolor.features.analyzer.simulator.ui.components.li
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Checkroom
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -9,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -46,4 +49,15 @@ fun CategoryPill(
             )
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CategoryPillPreview() {
+    CategoryPill(
+        label = "Tops",
+        icon = Icons.Default.Checkroom,
+        isSelected = true,
+        onClick = {}
+    )
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/ColorFamilySwatch.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/ColorFamilySwatch.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.core.model.ritual.ColorFamily
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
@@ -55,4 +56,14 @@ fun ColorFamilySwatch(
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ColorFamilySwatchPreview() {
+    ColorFamilySwatch(
+        family = ColorFamily.TRUE_RED,
+        isSelected = true,
+        onClick = {}
+    )
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/MessagingStep.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/MessagingStep.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -183,4 +184,14 @@ fun MessagingStep(
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MessagingStepPreview() {
+    MessagingStep(
+        uiState = StyleSimulatorUiState(),
+        onEvent = {},
+        navTo = {}
+    )
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/PlaceholderResultCard.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/PlaceholderResultCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -37,4 +38,10 @@ fun PlaceholderResultCard(label: String) {
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PlaceholderResultCardPreview() {
+    PlaceholderResultCard(label = "Eyes")
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/ResultCard.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/list/ResultCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.zoewave.probase.core.model.ritual.ClothingItem
@@ -59,4 +60,13 @@ fun ResultCard(
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ResultCardPreview() {
+    ResultCard(
+        onEvent = {},
+        navTo = {}
+    )
 }


### PR DESCRIPTION
…Simulator

This commit expands the Style Simulator results interface by adding a third "Nails" category, separating nail polish recommendations from general cosmetics and providing a specialized hand-based visual blueprint.

- **UI & Navigation Enhancements**:
    - Updated `ResultTab` enum to include `NAILS`.
    - Redesigned the tab toggle from a horizontal row to a vertical column (64dp x 100dp) to accommodate the new tab.
    - Extracted tab button logic into a reusable `ResultTabIcon` component for consistency.
- **Nail-Specific Visualization**:
    - Introduced `HandBlueprintView` featuring a central hand anchor (`PanTool`) with decorative pigment overlays on fingertips mapping to recommended shades.
    - Implemented `BlueprintCallout` for nails at the top-right of the hand canvas.
    - Cleaned up `FaceBlueprintView` by removing the legacy nail callout line and anchor.
- **Atelier List Refactoring**:
    - Updated the result list logic to filter `recommendedCosmetics` based on `MacroCategory.NAILS`, ensuring nail products are isolated from face cosmetics (Eyes, Lips, Cheeks).
    - Added a "NAIL ATELIER" header and specific placeholder cards for the new tab.
    - Improved the main result loop using a `when` block for cleaner state-to-UI mapping across Face, Clothes, and Nails views.