### PR TITLE
Kocolor working

### DIFF
--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/BlueprintCallout.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/BlueprintCallout.kt
@@ -43,24 +43,27 @@ fun BlueprintCallout(
     label: String,
     productName: String,
     colorHex: String?,
+    isExpanded: Boolean,
+    onExpandToggle: () -> Unit,
     modifier: Modifier = Modifier,
     anchorAlignment: Alignment = Alignment.TopEnd
 ) {
-    var isExpanded by remember { mutableStateOf(false) }
-
     Box(
         modifier = modifier
             .offset {
-                IntOffset(
-                    x = if (isExpanded && anchorAlignment == Alignment.TopEnd) (-40).dp.roundToPx() else 0,
-                    y = 0
-                )
+                // Shift toward center logic: 
+                // TopEnd anchor (Left-side box) shifts RIGHT (Positive X)
+                // TopStart anchor (Right-side box) shifts LEFT (Negative X)
+                val shift = if (isExpanded) {
+                    if (anchorAlignment == Alignment.TopEnd) 40.dp.roundToPx() else (-40).dp.roundToPx()
+                } else 0
+                IntOffset(x = shift, y = 0)
             }
     ) {
         Card(
             modifier = Modifier
                 .width(if (isExpanded) 160.dp else 120.dp)
-                .clickable { isExpanded = !isExpanded },
+                .clickable { onExpandToggle() },
             shape = RoundedCornerShape(12.dp),
             colors = CardDefaults.cardColors(containerColor = Color.White),
             elevation = CardDefaults.cardElevation(defaultElevation = if (isExpanded) 12.dp else 4.dp)
@@ -145,9 +148,12 @@ fun BlueprintCallout(
 @Preview(showBackground = true)
 @Composable
 fun BlueprintCalloutPreview() {
+    var expanded by remember { mutableStateOf(false) }
     BlueprintCallout(
         label = "EYES",
         productName = "Midnight Mascara",
-        colorHex = "#2C3E50"
+        colorHex = "#2C3E50",
+        isExpanded = expanded,
+        onExpandToggle = { expanded = !expanded }
     )
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/ClothingBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/ClothingBlueprintView.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -20,12 +20,16 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.kocolor.features.analyzer.R
 import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulatorUiState
 
 @Composable
 fun ClothingBlueprintView(uiState: StyleSimulatorUiState) {
+    // SINGLE SOURCE OF TRUTH: Tracks the currently expanded card
+    var expandedCategory by remember { mutableStateOf<String?>(null) }
+
     val blueprintOffset = 10.dp
     val horizontalShift = 0.dp
     
@@ -98,10 +102,13 @@ fun ClothingBlueprintView(uiState: StyleSimulatorUiState) {
             label = "TOP",
             productName = topItem?.name ?: "Pending...",
             colorHex = topItem?.colorHex,
+            isExpanded = expandedCategory == "TOP",
+            onExpandToggle = { expandedCategory = if (expandedCategory == "TOP") null else "TOP" },
             modifier = Modifier
+                .zIndex(if (expandedCategory == "TOP") 10f else 1f)
                 .offset(
-                    x = horizontalShift + topCallout.x.dp + 6.dp,
-                    y = blueprintOffset + topCallout.y.dp + 6.dp
+                    x = horizontalShift + topCallout.x.dp,
+                    y = blueprintOffset + topCallout.y.dp
                 ),
             anchorAlignment = Alignment.TopStart
         )
@@ -110,10 +117,13 @@ fun ClothingBlueprintView(uiState: StyleSimulatorUiState) {
             label = "BOTTOM",
             productName = bottomItem?.name ?: "Pending...",
             colorHex = bottomItem?.colorHex,
+            isExpanded = expandedCategory == "BOTTOM",
+            onExpandToggle = { expandedCategory = if (expandedCategory == "BOTTOM") null else "BOTTOM" },
             modifier = Modifier
+                .zIndex(if (expandedCategory == "BOTTOM") 10f else 1f)
                 .offset(
-                    x = horizontalShift + bottomCallout.x.dp - 120.dp - 6.dp,
-                    y = blueprintOffset + bottomCallout.y.dp + 6.dp
+                    x = horizontalShift + bottomCallout.x.dp,
+                    y = blueprintOffset + bottomCallout.y.dp
                 ),
             anchorAlignment = Alignment.TopEnd
         )
@@ -122,10 +132,13 @@ fun ClothingBlueprintView(uiState: StyleSimulatorUiState) {
             label = "SHOES",
             productName = shoeItem?.name ?: "Pending...",
             colorHex = shoeItem?.colorHex,
+            isExpanded = expandedCategory == "SHOES",
+            onExpandToggle = { expandedCategory = if (expandedCategory == "SHOES") null else "SHOES" },
             modifier = Modifier
+                .zIndex(if (expandedCategory == "SHOES") 10f else 1f)
                 .offset(
-                    x = horizontalShift + shoesCallout.x.dp + 6.dp,
-                    y = blueprintOffset + shoesCallout.y.dp + 6.dp
+                    x = horizontalShift + shoesCallout.x.dp,
+                    y = blueprintOffset + shoesCallout.y.dp
                 ),
             anchorAlignment = Alignment.TopStart
         )

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
@@ -3,6 +3,7 @@ package com.zoewave.probase.kocolor.features.analyzer.simulator.ui.components.gr
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
@@ -11,6 +12,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -22,6 +27,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.zoewave.probase.core.model.ritual.MacroCategory
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.kocolor.features.analyzer.R
@@ -29,18 +35,19 @@ import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulator
 
 @Composable
 fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
+    // SINGLE SOURCE OF TRUTH: Tracks the currently expanded card (null = all closed)
+    var expandedCategory by remember { mutableStateOf<String?>(null) }
 
-
-    // 1. Slight shift right to balance the new layout
+    // 1. Layout Shifts
     val blueprintOffset = 10.dp
     val horizontalShift = 15.dp
 
     // 2. Define Rebalanced Line Targets
-    // EYES: Flipped to Upper Right (Positive X)
-    val eyesAnchor = Offset(35.dp.value, -45.dp.value) // Anchored to the right eye
+    // EYES: Upper Right
+    val eyesAnchor = Offset(35.dp.value, -45.dp.value)
     val eyesCallout = Offset(100.dp.value, -90.dp.value)
 
-    // CHEEKS: Pushed to Lower Left (Safely below the color palette)
+    // CHEEKS: Lower Left (Below palette)
     val cheeksAnchor = Offset(-45.dp.value, 25.dp.value)
     val cheeksCallout = Offset(-90.dp.value, 120.dp.value)
 
@@ -48,14 +55,13 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
     val lipsAnchor = Offset(0.dp.value, 75.dp.value)
     val lipsCallout = Offset(90.dp.value, 150.dp.value)
 
-
     Box(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp),
         contentAlignment = Alignment.Center
     ) {
-        // Central Face Anchor (Always use Line-Art for Blueprint feel)
+        // Central Face Anchor
         Box(
             modifier = Modifier
                 .size(280.dp)
@@ -73,51 +79,33 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
 
         // Callout Lines & Shades
         Canvas(modifier = Modifier.fillMaxSize()) {
-            val center = Offset(
-                size.width / 2 + horizontalShift.toPx(),
-                size.height / 2 + blueprintOffset.toPx()
-            )
+            val center = Offset(size.width / 2 + horizontalShift.toPx(), size.height / 2 + blueprintOffset.toPx())
 
             // 1. Draw "Shades" (Soft Glows on the face)
-            val eyesItem =
-                uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.EYES }
-            val cheeksItem =
-                uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
-            val lipsItem =
-                uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
+            val eyesItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.EYES }
+            val cheeksItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
+            val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
             // Eyes Shade
             eyesItem?.colorHex?.let { hex ->
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.35f), Color.Transparent),
-                        center = Offset(
-                            center.x + eyesAnchor.x.dp.toPx(),
-                            center.y + eyesAnchor.y.dp.toPx()
-                        ),
+                        center = Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx()),
                         radius = 20.dp.toPx()
                     ),
                     radius = 20.dp.toPx(),
-                    center = Offset(
-                        center.x + eyesAnchor.x.dp.toPx(),
-                        center.y + eyesAnchor.y.dp.toPx()
-                    )
+                    center = Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
                 )
-                // Right Eye
+                // Left Eye (Mirrored for the shade effect)
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.35f), Color.Transparent),
-                        center = Offset(
-                            center.x - eyesAnchor.x.dp.toPx(),
-                            center.y + eyesAnchor.y.dp.toPx()
-                        ),
+                        center = Offset(center.x - eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx()),
                         radius = 20.dp.toPx()
                     ),
                     radius = 20.dp.toPx(),
-                    center = Offset(
-                        center.x - eyesAnchor.x.dp.toPx(),
-                        center.y + eyesAnchor.y.dp.toPx()
-                    )
+                    center = Offset(center.x - eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
                 )
             }
 
@@ -126,32 +114,21 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.3f), Color.Transparent),
-                        center = Offset(
-                            center.x + cheeksAnchor.x.dp.toPx(),
-                            center.y + cheeksAnchor.y.dp.toPx()
-                        ),
+                        center = Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx()),
                         radius = 35.dp.toPx()
                     ),
                     radius = 35.dp.toPx(),
-                    center = Offset(
-                        center.x + cheeksAnchor.x.dp.toPx(),
-                        center.y + cheeksAnchor.y.dp.toPx()
-                    )
+                    center = Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
                 )
+                // Right Cheek (Mirrored)
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.3f), Color.Transparent),
-                        center = Offset(
-                            center.x - cheeksAnchor.x.dp.toPx(),
-                            center.y + cheeksAnchor.y.dp.toPx()
-                        ),
+                        center = Offset(center.x - cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx()),
                         radius = 35.dp.toPx()
                     ),
                     radius = 35.dp.toPx(),
-                    center = Offset(
-                        center.x - cheeksAnchor.x.dp.toPx(),
-                        center.y + cheeksAnchor.y.dp.toPx()
-                    )
+                    center = Offset(center.x - cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
                 )
             }
 
@@ -160,53 +137,43 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.4f), Color.Transparent),
-                        center = Offset(
-                            center.x + lipsAnchor.x.dp.toPx(),
-                            center.y + lipsAnchor.y.dp.toPx()
-                        ),
+                        center = Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx()),
                         radius = 25.dp.toPx()
                     ),
                     radius = 25.dp.toPx(),
-                    center = Offset(
-                        center.x + lipsAnchor.x.dp.toPx(),
-                        center.y + lipsAnchor.y.dp.toPx()
-                    )
+                    center = Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx())
                 )
             }
 
-            // 2. Draw Callout Lines (Solid with anchor dots)
+            // 2. Draw Callout Lines (Only if NOT expanded)
             val lineStroke = 0.8.dp.toPx()
             val anchorRadius = 2.dp.toPx()
             val lineColor = Color.DarkGray.copy(alpha = 0.4f)
 
-            // Eyes (Top Left)
-            val eyesStart =
-                Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
-            val eyesEnd =
-                Offset(center.x + eyesCallout.x.dp.toPx(), center.y + eyesCallout.y.dp.toPx())
-            drawLine(lineColor, eyesStart, eyesEnd, lineStroke)
-            drawCircle(lineColor, anchorRadius, eyesStart)
+            if (expandedCategory != "EYES") {
+                val eyesStart = Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
+                val eyesEnd = Offset(center.x + eyesCallout.x.dp.toPx(), center.y + eyesCallout.y.dp.toPx())
+                drawLine(lineColor, eyesStart, eyesEnd, lineStroke)
+                drawCircle(lineColor, anchorRadius, eyesStart)
+            }
 
-            // Cheeks (Mid Left)
-            val cheeksStart =
-                Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
-            val cheeksEnd =
-                Offset(center.x + cheeksCallout.x.dp.toPx(), center.y + cheeksCallout.y.dp.toPx())
-            drawLine(lineColor, cheeksStart, cheeksEnd, lineStroke)
-            drawCircle(lineColor, anchorRadius, cheeksStart)
+            if (expandedCategory != "CHEEKS") {
+                val cheeksStart = Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
+                val cheeksEnd = Offset(center.x + cheeksCallout.x.dp.toPx(), center.y + cheeksCallout.y.dp.toPx())
+                drawLine(lineColor, cheeksStart, cheeksEnd, lineStroke)
+                drawCircle(lineColor, anchorRadius, cheeksStart)
+            }
 
-            // Lips (Bottom Right)
-            val lipsStart =
-                Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx())
-            val lipsEnd =
-                Offset(center.x + lipsCallout.x.dp.toPx(), center.y + lipsCallout.y.dp.toPx())
-            drawLine(lineColor, lipsStart, lipsEnd, lineStroke)
-            drawCircle(lineColor, anchorRadius, lipsStart)
+            if (expandedCategory != "LIPS") {
+                val lipsStart = Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx())
+                val lipsEnd = Offset(center.x + lipsCallout.x.dp.toPx(), center.y + lipsCallout.y.dp.toPx())
+                drawLine(lineColor, lipsStart, lipsEnd, lineStroke)
+                drawCircle(lineColor, anchorRadius, lipsStart)
+            }
         }
 
         val eyesItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.EYES }
-        val cheeksItem =
-            uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
+        val cheeksItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
         val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
         // 3. Deterministic Alignment Math for Collapsed State
@@ -214,48 +181,62 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
         val calloutHalfWidth = calloutWidth / 2
         val calloutHalfHeight = 28.dp
 
-        // EYES is now on the RIGHT -> Add half-width, Anchor at TopStart
+        // --- EYES CALLOUT ---
+        val isEyesExpanded = expandedCategory == "EYES"
         BlueprintCallout(
             label = "EYES",
             productName = eyesItem?.name ?: "Pending...",
             colorHex = eyesItem?.colorHex,
             modifier = Modifier
-                .width(calloutWidth)
-                .offset(
-                    x = horizontalShift + eyesCallout.x.dp + calloutHalfWidth,
-                    y = blueprintOffset + eyesCallout.y.dp + calloutHalfHeight
+                .clickable { expandedCategory = if (isEyesExpanded) null else "EYES" }
+                .zIndex(if (isEyesExpanded) 10f else 1f)
+                .then(
+                    if (isEyesExpanded) Modifier
+                    else Modifier.width(calloutWidth).offset(
+                        x = horizontalShift + eyesCallout.x.dp + calloutHalfWidth,
+                        y = blueprintOffset + eyesCallout.y.dp + calloutHalfHeight
+                    )
                 ),
-            anchorAlignment = Alignment.TopStart
+            anchorAlignment = if (isEyesExpanded) Alignment.Center else Alignment.TopStart
         )
 
-        // CHEEKS is on the LEFT -> Subtract half-width, Anchor at TopEnd
+        // --- CHEEKS CALLOUT ---
+        val isCheeksExpanded = expandedCategory == "CHEEKS"
         BlueprintCallout(
             label = "CHEEKS",
             productName = cheeksItem?.name ?: "Pending...",
             colorHex = cheeksItem?.colorHex,
             modifier = Modifier
-                .width(calloutWidth)
-                .offset(
-                    x = horizontalShift + cheeksCallout.x.dp - calloutHalfWidth,
-                    y = blueprintOffset + cheeksCallout.y.dp + calloutHalfHeight
+                .clickable { expandedCategory = if (isCheeksExpanded) null else "CHEEKS" }
+                .zIndex(if (isCheeksExpanded) 10f else 1f)
+                .then(
+                    if (isCheeksExpanded) Modifier
+                    else Modifier.width(calloutWidth).offset(
+                        x = horizontalShift + cheeksCallout.x.dp - calloutHalfWidth,
+                        y = blueprintOffset + cheeksCallout.y.dp + calloutHalfHeight
+                    )
                 ),
-            anchorAlignment = Alignment.TopEnd
+            anchorAlignment = if (isCheeksExpanded) Alignment.Center else Alignment.TopEnd
         )
 
-        // LIPS is on the RIGHT -> Add half-width, Anchor at TopStart
+        // --- LIPS CALLOUT ---
+        val isLipsExpanded = expandedCategory == "LIPS"
         BlueprintCallout(
             label = "LIPS",
             productName = lipsItem?.name ?: "Pending...",
             colorHex = lipsItem?.colorHex,
             modifier = Modifier
-                .width(calloutWidth)
-                .offset(
-                    x = horizontalShift + lipsCallout.x.dp + calloutHalfWidth,
-                    y = blueprintOffset + lipsCallout.y.dp + calloutHalfHeight
+                .clickable { expandedCategory = if (isLipsExpanded) null else "LIPS" }
+                .zIndex(if (isLipsExpanded) 10f else 1f)
+                .then(
+                    if (isLipsExpanded) Modifier
+                    else Modifier.width(calloutWidth).offset(
+                        x = horizontalShift + lipsCallout.x.dp + calloutHalfWidth,
+                        y = blueprintOffset + lipsCallout.y.dp + calloutHalfHeight
+                    )
                 ),
-            anchorAlignment = Alignment.TopStart
+            anchorAlignment = if (isLipsExpanded) Alignment.Center else Alignment.TopStart
         )
-
     }
 }
 

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
@@ -31,19 +31,19 @@ import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulator
 fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
 
 
-// 1. Shift the entire face significantly right to clear the color palette
+    // 1. Center the face to protect the right margin
     val blueprintOffset = 10.dp
-    val horizontalShift = 45.dp // Increased to push everything away from the left edge
+    val horizontalShift = 0.dp
 
-    // 2. Define tight, steep Line Targets
+    // 2. Define angled, outward-reaching lines
     val eyesAnchor = Offset(-35.dp.value, -45.dp.value)
-    val eyesCallout = Offset(-30.dp.value, -100.dp.value)
+    val eyesCallout = Offset(-100.dp.value, -80.dp.value) // Reaches up and left
 
     val cheeksAnchor = Offset(-45.dp.value, 25.dp.value)
-    val cheeksCallout = Offset(-45.dp.value, 75.dp.value)
+    val cheeksCallout = Offset(-110.dp.value, 50.dp.value) // Reaches out to the left (fixes the vertical line)
 
     val lipsAnchor = Offset(0.dp.value, 75.dp.value)
-    val lipsCallout = Offset(10.dp.value, 140.dp.value)
+    val lipsCallout = Offset(60.dp.value, 130.dp.value) // Safely tucked on the right
 
 
     Box(
@@ -206,10 +206,10 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
         val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
-        // 3. Deterministic Alignment Math
-        val calloutWidth = 120.dp // Slightly narrower to prevent edge-bleed
+// 3. Deterministic Alignment Math for Collapsed State
+        val calloutWidth = 100.dp // Tighter base width for the unexpanded box
         val calloutHalfWidth = calloutWidth / 2
-        val calloutHalfHeight = 36.dp // Increased to properly center the dot vertically alongside the wrapping text
+        val calloutHalfHeight = 28.dp // Calibrated for the height of the "Details" state
 
         BlueprintCallout(
             label = "EYES",
@@ -218,7 +218,6 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             modifier = Modifier
                 .width(calloutWidth)
                 .offset(
-                    // Left callout: shift left by half-width, shift down by half-height
                     x = horizontalShift + eyesCallout.x.dp - calloutHalfWidth,
                     y = blueprintOffset + eyesCallout.y.dp + calloutHalfHeight
                 ),
@@ -232,7 +231,6 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             modifier = Modifier
                 .width(calloutWidth)
                 .offset(
-                    // Left callout: shift left by half-width, shift down by half-height
                     x = horizontalShift + cheeksCallout.x.dp - calloutHalfWidth,
                     y = blueprintOffset + cheeksCallout.y.dp + calloutHalfHeight
                 ),
@@ -246,16 +244,14 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             modifier = Modifier
                 .width(calloutWidth)
                 .offset(
-                    // Right callout: shift right by half-width, shift down by half-height
                     x = horizontalShift + lipsCallout.x.dp + calloutHalfWidth,
                     y = blueprintOffset + lipsCallout.y.dp + calloutHalfHeight
                 ),
             anchorAlignment = Alignment.TopStart
         )
-
-
     }
 }
+
 @Preview(showBackground = true)
 @Composable
 fun FaceBlueprintViewPreview() {

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,19 +29,21 @@ import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulator
 
 @Composable
 fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
-    val blueprintOffset = 10.dp
-    val horizontalShift = 0.dp
 
-// Define Unified Offsets for Layout (Relative to Center)
+
+    // 1. Shift the entire face right to avoid the color palette
+    val blueprintOffset = 10.dp
+    val horizontalShift = 20.dp // Added a 20dp shift away from the left edge
+
+    // 2. Tighten the Unified Offsets (Closer to the face)
     val eyesAnchor = Offset(-35.dp.value, -45.dp.value)
-    val eyesCallout = Offset(-80.dp.value, -100.dp.value) // Brought inward from -140
+    val eyesCallout = Offset(-60.dp.value, -100.dp.value) // Brought in and pushed up
 
     val cheeksAnchor = Offset(-45.dp.value, 25.dp.value)
-    val cheeksCallout = Offset(-90.dp.value, 60.dp.value) // Brought inward from -150
+    val cheeksCallout = Offset(-70.dp.value, 90.dp.value) // Brought in and pushed down
 
     val lipsAnchor = Offset(0.dp.value, 75.dp.value)
-    val lipsCallout = Offset(80.dp.value, 140.dp.value) // Brought inward from 130
-
+    val lipsCallout = Offset(60.dp.value, 150.dp.value) // Brought in and pushed down
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -65,33 +68,51 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
 
         // Callout Lines & Shades
         Canvas(modifier = Modifier.fillMaxSize()) {
-            val center = Offset(size.width / 2 + horizontalShift.toPx(), size.height / 2 + blueprintOffset.toPx())
-            
+            val center = Offset(
+                size.width / 2 + horizontalShift.toPx(),
+                size.height / 2 + blueprintOffset.toPx()
+            )
+
             // 1. Draw "Shades" (Soft Glows on the face)
-            val eyesItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.EYES }
-            val cheeksItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
-            val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
+            val eyesItem =
+                uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.EYES }
+            val cheeksItem =
+                uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
+            val lipsItem =
+                uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
             // Eyes Shade
             eyesItem?.colorHex?.let { hex ->
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.35f), Color.Transparent),
-                        center = Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx()),
+                        center = Offset(
+                            center.x + eyesAnchor.x.dp.toPx(),
+                            center.y + eyesAnchor.y.dp.toPx()
+                        ),
                         radius = 20.dp.toPx()
                     ),
                     radius = 20.dp.toPx(),
-                    center = Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
+                    center = Offset(
+                        center.x + eyesAnchor.x.dp.toPx(),
+                        center.y + eyesAnchor.y.dp.toPx()
+                    )
                 )
                 // Right Eye
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.35f), Color.Transparent),
-                        center = Offset(center.x - eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx()),
+                        center = Offset(
+                            center.x - eyesAnchor.x.dp.toPx(),
+                            center.y + eyesAnchor.y.dp.toPx()
+                        ),
                         radius = 20.dp.toPx()
                     ),
                     radius = 20.dp.toPx(),
-                    center = Offset(center.x - eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
+                    center = Offset(
+                        center.x - eyesAnchor.x.dp.toPx(),
+                        center.y + eyesAnchor.y.dp.toPx()
+                    )
                 )
             }
 
@@ -100,20 +121,32 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.3f), Color.Transparent),
-                        center = Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx()),
+                        center = Offset(
+                            center.x + cheeksAnchor.x.dp.toPx(),
+                            center.y + cheeksAnchor.y.dp.toPx()
+                        ),
                         radius = 35.dp.toPx()
                     ),
                     radius = 35.dp.toPx(),
-                    center = Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
+                    center = Offset(
+                        center.x + cheeksAnchor.x.dp.toPx(),
+                        center.y + cheeksAnchor.y.dp.toPx()
+                    )
                 )
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.3f), Color.Transparent),
-                        center = Offset(center.x - cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx()),
+                        center = Offset(
+                            center.x - cheeksAnchor.x.dp.toPx(),
+                            center.y + cheeksAnchor.y.dp.toPx()
+                        ),
                         radius = 35.dp.toPx()
                     ),
                     radius = 35.dp.toPx(),
-                    center = Offset(center.x - cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
+                    center = Offset(
+                        center.x - cheeksAnchor.x.dp.toPx(),
+                        center.y + cheeksAnchor.y.dp.toPx()
+                    )
                 )
             }
 
@@ -122,11 +155,17 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.4f), Color.Transparent),
-                        center = Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx()),
+                        center = Offset(
+                            center.x + lipsAnchor.x.dp.toPx(),
+                            center.y + lipsAnchor.y.dp.toPx()
+                        ),
                         radius = 25.dp.toPx()
                     ),
                     radius = 25.dp.toPx(),
-                    center = Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx())
+                    center = Offset(
+                        center.x + lipsAnchor.x.dp.toPx(),
+                        center.y + lipsAnchor.y.dp.toPx()
+                    )
                 )
             }
 
@@ -136,45 +175,50 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             val lineColor = Color.DarkGray.copy(alpha = 0.4f)
 
             // Eyes (Top Left)
-            val eyesStart = Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
-            val eyesEnd = Offset(center.x + eyesCallout.x.dp.toPx(), center.y + eyesCallout.y.dp.toPx())
+            val eyesStart =
+                Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
+            val eyesEnd =
+                Offset(center.x + eyesCallout.x.dp.toPx(), center.y + eyesCallout.y.dp.toPx())
             drawLine(lineColor, eyesStart, eyesEnd, lineStroke)
             drawCircle(lineColor, anchorRadius, eyesStart)
 
             // Cheeks (Mid Left)
-            val cheeksStart = Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
-            val cheeksEnd = Offset(center.x + cheeksCallout.x.dp.toPx(), center.y + cheeksCallout.y.dp.toPx())
+            val cheeksStart =
+                Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
+            val cheeksEnd =
+                Offset(center.x + cheeksCallout.x.dp.toPx(), center.y + cheeksCallout.y.dp.toPx())
             drawLine(lineColor, cheeksStart, cheeksEnd, lineStroke)
             drawCircle(lineColor, anchorRadius, cheeksStart)
 
             // Lips (Bottom Right)
-            val lipsStart = Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx())
-            val lipsEnd = Offset(center.x + lipsCallout.x.dp.toPx(), center.y + lipsCallout.y.dp.toPx())
+            val lipsStart =
+                Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx())
+            val lipsEnd =
+                Offset(center.x + lipsCallout.x.dp.toPx(), center.y + lipsCallout.y.dp.toPx())
             drawLine(lineColor, lipsStart, lipsEnd, lineStroke)
             drawCircle(lineColor, anchorRadius, lipsStart)
         }
 
         val eyesItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.EYES }
-        val cheeksItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
+        val cheeksItem =
+            uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
         val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
-        // 3. Alignment Math for the Callout Boxes
-        // By estimating the half-width and half-height of the BlueprintCallout,
-        // we can mathematically snap its corner dot exactly to the Canvas line end.
-        val calloutHalfWidth = 50.dp // Adjust this slightly if your callout is wider than 100dp
-        val calloutHalfHeight = 20.dp
+        // 3. Deterministic Alignment Math
+        // By locking the width of the callout, we force long text to wrap,
+        // preventing UI collisions. It also makes our offset math perfectly accurate.
+        val calloutWidth = 130.dp
+        val calloutHalfWidth = calloutWidth / 2
+        val calloutHalfHeight = 24.dp // Estimated half-height for wrapping text
 
-        // Positioning Callouts such that their Anchor Dot matches the line end
-        // For Left callouts (Eyes, Cheeks), dot is at TopEnd
         BlueprintCallout(
             label = "EYES",
             productName = eyesItem?.name ?: "Pending...",
             colorHex = eyesItem?.colorHex,
             modifier = Modifier
+                .width(calloutWidth) // Strict constraint for text wrapping
                 .offset(
-                    // Shift left so the Right Edge (TopEnd) hits the line exactly
                     x = horizontalShift + eyesCallout.x.dp - calloutHalfWidth,
-                    // Shift down so the Top Edge hits the line exactly
                     y = blueprintOffset + eyesCallout.y.dp + calloutHalfHeight
                 ),
             anchorAlignment = Alignment.TopEnd
@@ -185,6 +229,7 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             productName = cheeksItem?.name ?: "Pending...",
             colorHex = cheeksItem?.colorHex,
             modifier = Modifier
+                .width(calloutWidth)
                 .offset(
                     x = horizontalShift + cheeksCallout.x.dp - calloutHalfWidth,
                     y = blueprintOffset + cheeksCallout.y.dp + calloutHalfHeight
@@ -192,22 +237,21 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             anchorAlignment = Alignment.TopEnd
         )
 
-        // For Right callouts (Lips), dot is at TopStart
         BlueprintCallout(
             label = "LIPS",
             productName = lipsItem?.name ?: "Pending...",
             colorHex = lipsItem?.colorHex,
             modifier = Modifier
+                .width(calloutWidth)
                 .offset(
-                    // Shift right so the Left Edge (TopStart) hits the line exactly
                     x = horizontalShift + lipsCallout.x.dp + calloutHalfWidth,
                     y = blueprintOffset + lipsCallout.y.dp + calloutHalfHeight
                 ),
             anchorAlignment = Alignment.TopStart
         )
+
     }
 }
-
 @Preview(showBackground = true)
 @Composable
 fun FaceBlueprintViewPreview() {

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
@@ -30,16 +30,16 @@ import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulator
 fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
     val blueprintOffset = 10.dp
     val horizontalShift = 0.dp
-    
-    // Define Unified Offsets for Layout (Relative to Center)
+
+// Define Unified Offsets for Layout (Relative to Center)
     val eyesAnchor = Offset(-35.dp.value, -45.dp.value)
-    val eyesCallout = Offset(-140.dp.value, -120.dp.value)
-    
+    val eyesCallout = Offset(-80.dp.value, -100.dp.value) // Brought inward from -140
+
     val cheeksAnchor = Offset(-45.dp.value, 25.dp.value)
-    val cheeksCallout = Offset(-150.dp.value, 60.dp.value)
-    
+    val cheeksCallout = Offset(-90.dp.value, 60.dp.value) // Brought inward from -150
+
     val lipsAnchor = Offset(0.dp.value, 75.dp.value)
-    val lipsCallout = Offset(130.dp.value, 160.dp.value)
+    val lipsCallout = Offset(80.dp.value, 140.dp.value) // Brought inward from 130
 
     Box(
         modifier = Modifier
@@ -158,6 +158,12 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
         val cheeksItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
         val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
+        // 3. Alignment Math for the Callout Boxes
+        // By estimating the half-width and half-height of the BlueprintCallout,
+        // we can mathematically snap its corner dot exactly to the Canvas line end.
+        val calloutHalfWidth = 50.dp // Adjust this slightly if your callout is wider than 100dp
+        val calloutHalfHeight = 20.dp
+
         // Positioning Callouts such that their Anchor Dot matches the line end
         // For Left callouts (Eyes, Cheeks), dot is at TopEnd
         BlueprintCallout(
@@ -166,8 +172,10 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             colorHex = eyesItem?.colorHex,
             modifier = Modifier
                 .offset(
-                    x = horizontalShift + eyesCallout.x.dp - 120.dp - 6.dp, // Include face offsets
-                    y = blueprintOffset + eyesCallout.y.dp + 6.dp
+                    // Shift left so the Right Edge (TopEnd) hits the line exactly
+                    x = horizontalShift + eyesCallout.x.dp - calloutHalfWidth,
+                    // Shift down so the Top Edge hits the line exactly
+                    y = blueprintOffset + eyesCallout.y.dp + calloutHalfHeight
                 ),
             anchorAlignment = Alignment.TopEnd
         )
@@ -178,8 +186,8 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             colorHex = cheeksItem?.colorHex,
             modifier = Modifier
                 .offset(
-                    x = horizontalShift + cheeksCallout.x.dp - 120.dp - 6.dp,
-                    y = blueprintOffset + cheeksCallout.y.dp + 6.dp
+                    x = horizontalShift + cheeksCallout.x.dp - calloutHalfWidth,
+                    y = blueprintOffset + cheeksCallout.y.dp + calloutHalfHeight
                 ),
             anchorAlignment = Alignment.TopEnd
         )
@@ -191,8 +199,9 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             colorHex = lipsItem?.colorHex,
             modifier = Modifier
                 .offset(
-                    x = horizontalShift + lipsCallout.x.dp + 6.dp,
-                    y = blueprintOffset + lipsCallout.y.dp + 6.dp
+                    // Shift right so the Left Edge (TopStart) hits the line exactly
+                    x = horizontalShift + lipsCallout.x.dp + calloutHalfWidth,
+                    y = blueprintOffset + lipsCallout.y.dp + calloutHalfHeight
                 ),
             anchorAlignment = Alignment.TopStart
         )

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
@@ -31,19 +31,21 @@ import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulator
 fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
 
 
-    // 1. Shift the entire face right to avoid the color palette
+// 1. Shift the entire face significantly right to clear the color palette
     val blueprintOffset = 10.dp
-    val horizontalShift = 20.dp // Added a 20dp shift away from the left edge
+    val horizontalShift = 45.dp // Increased to push everything away from the left edge
 
-    // 2. Tighten the Unified Offsets (Closer to the face)
+    // 2. Define tight, steep Line Targets
     val eyesAnchor = Offset(-35.dp.value, -45.dp.value)
-    val eyesCallout = Offset(-60.dp.value, -100.dp.value) // Brought in and pushed up
+    val eyesCallout = Offset(-30.dp.value, -100.dp.value)
 
     val cheeksAnchor = Offset(-45.dp.value, 25.dp.value)
-    val cheeksCallout = Offset(-70.dp.value, 90.dp.value) // Brought in and pushed down
+    val cheeksCallout = Offset(-45.dp.value, 75.dp.value)
 
     val lipsAnchor = Offset(0.dp.value, 75.dp.value)
-    val lipsCallout = Offset(60.dp.value, 150.dp.value) // Brought in and pushed down
+    val lipsCallout = Offset(10.dp.value, 140.dp.value)
+
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -205,19 +207,18 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
         val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
         // 3. Deterministic Alignment Math
-        // By locking the width of the callout, we force long text to wrap,
-        // preventing UI collisions. It also makes our offset math perfectly accurate.
-        val calloutWidth = 130.dp
+        val calloutWidth = 120.dp // Slightly narrower to prevent edge-bleed
         val calloutHalfWidth = calloutWidth / 2
-        val calloutHalfHeight = 24.dp // Estimated half-height for wrapping text
+        val calloutHalfHeight = 36.dp // Increased to properly center the dot vertically alongside the wrapping text
 
         BlueprintCallout(
             label = "EYES",
             productName = eyesItem?.name ?: "Pending...",
             colorHex = eyesItem?.colorHex,
             modifier = Modifier
-                .width(calloutWidth) // Strict constraint for text wrapping
+                .width(calloutWidth)
                 .offset(
+                    // Left callout: shift left by half-width, shift down by half-height
                     x = horizontalShift + eyesCallout.x.dp - calloutHalfWidth,
                     y = blueprintOffset + eyesCallout.y.dp + calloutHalfHeight
                 ),
@@ -231,6 +232,7 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             modifier = Modifier
                 .width(calloutWidth)
                 .offset(
+                    // Left callout: shift left by half-width, shift down by half-height
                     x = horizontalShift + cheeksCallout.x.dp - calloutHalfWidth,
                     y = blueprintOffset + cheeksCallout.y.dp + calloutHalfHeight
                 ),
@@ -244,11 +246,13 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             modifier = Modifier
                 .width(calloutWidth)
                 .offset(
+                    // Right callout: shift right by half-width, shift down by half-height
                     x = horizontalShift + lipsCallout.x.dp + calloutHalfWidth,
                     y = blueprintOffset + lipsCallout.y.dp + calloutHalfHeight
                 ),
             anchorAlignment = Alignment.TopStart
         )
+
 
     }
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
@@ -31,19 +31,22 @@ import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulator
 fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
 
 
-    // 1. Center the face to protect the right margin
+    // 1. Slight shift right to balance the new layout
     val blueprintOffset = 10.dp
-    val horizontalShift = 0.dp
+    val horizontalShift = 15.dp
 
-    // 2. Define angled, outward-reaching lines
-    val eyesAnchor = Offset(-35.dp.value, -45.dp.value)
-    val eyesCallout = Offset(-100.dp.value, -80.dp.value) // Reaches up and left
+    // 2. Define Rebalanced Line Targets
+    // EYES: Flipped to Upper Right (Positive X)
+    val eyesAnchor = Offset(35.dp.value, -45.dp.value) // Anchored to the right eye
+    val eyesCallout = Offset(100.dp.value, -90.dp.value)
 
+    // CHEEKS: Pushed to Lower Left (Safely below the color palette)
     val cheeksAnchor = Offset(-45.dp.value, 25.dp.value)
-    val cheeksCallout = Offset(-110.dp.value, 50.dp.value) // Reaches out to the left (fixes the vertical line)
+    val cheeksCallout = Offset(-90.dp.value, 120.dp.value)
 
+    // LIPS: Bottom Right
     val lipsAnchor = Offset(0.dp.value, 75.dp.value)
-    val lipsCallout = Offset(60.dp.value, 130.dp.value) // Safely tucked on the right
+    val lipsCallout = Offset(90.dp.value, 150.dp.value)
 
 
     Box(
@@ -206,11 +209,12 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
         val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
-// 3. Deterministic Alignment Math for Collapsed State
-        val calloutWidth = 100.dp // Tighter base width for the unexpanded box
+        // 3. Deterministic Alignment Math for Collapsed State
+        val calloutWidth = 100.dp
         val calloutHalfWidth = calloutWidth / 2
-        val calloutHalfHeight = 28.dp // Calibrated for the height of the "Details" state
+        val calloutHalfHeight = 28.dp
 
+        // EYES is now on the RIGHT -> Add half-width, Anchor at TopStart
         BlueprintCallout(
             label = "EYES",
             productName = eyesItem?.name ?: "Pending...",
@@ -218,12 +222,13 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             modifier = Modifier
                 .width(calloutWidth)
                 .offset(
-                    x = horizontalShift + eyesCallout.x.dp - calloutHalfWidth,
+                    x = horizontalShift + eyesCallout.x.dp + calloutHalfWidth,
                     y = blueprintOffset + eyesCallout.y.dp + calloutHalfHeight
                 ),
-            anchorAlignment = Alignment.TopEnd
+            anchorAlignment = Alignment.TopStart
         )
 
+        // CHEEKS is on the LEFT -> Subtract half-width, Anchor at TopEnd
         BlueprintCallout(
             label = "CHEEKS",
             productName = cheeksItem?.name ?: "Pending...",
@@ -237,6 +242,7 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
             anchorAlignment = Alignment.TopEnd
         )
 
+        // LIPS is on the RIGHT -> Add half-width, Anchor at TopStart
         BlueprintCallout(
             label = "LIPS",
             productName = lipsItem?.name ?: "Pending...",
@@ -249,6 +255,7 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                 ),
             anchorAlignment = Alignment.TopStart
         )
+
     }
 }
 

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/FaceBlueprintView.kt
@@ -3,13 +3,11 @@ package com.zoewave.probase.kocolor.features.analyzer.simulator.ui.components.gr
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,23 +33,20 @@ import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulator
 
 @Composable
 fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
-    // SINGLE SOURCE OF TRUTH: Tracks the currently expanded card (null = all closed)
+    // SINGLE SOURCE OF TRUTH: Tracks the currently expanded card
     var expandedCategory by remember { mutableStateOf<String?>(null) }
 
     // 1. Layout Shifts
     val blueprintOffset = 10.dp
     val horizontalShift = 15.dp
 
-    // 2. Define Rebalanced Line Targets
-    // EYES: Upper Right
+    // 2. Define Static Line Targets (Center of the features)
     val eyesAnchor = Offset(35.dp.value, -45.dp.value)
     val eyesCallout = Offset(100.dp.value, -90.dp.value)
 
-    // CHEEKS: Lower Left (Below palette)
     val cheeksAnchor = Offset(-45.dp.value, 25.dp.value)
     val cheeksCallout = Offset(-90.dp.value, 120.dp.value)
 
-    // LIPS: Bottom Right
     val lipsAnchor = Offset(0.dp.value, 75.dp.value)
     val lipsCallout = Offset(90.dp.value, 150.dp.value)
 
@@ -81,12 +76,13 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
         Canvas(modifier = Modifier.fillMaxSize()) {
             val center = Offset(size.width / 2 + horizontalShift.toPx(), size.height / 2 + blueprintOffset.toPx())
 
-            // 1. Draw "Shades" (Soft Glows on the face)
+            // Extract Items
             val eyesItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.EYES }
             val cheeksItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
             val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
-            // Eyes Shade
+            // 1. Draw "Shades" (Soft Glows on the face)
+            // ... (rest of shades logic remains the same)
             eyesItem?.colorHex?.let { hex ->
                 drawCircle(
                     brush = Brush.radialGradient(
@@ -97,7 +93,6 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                     radius = 20.dp.toPx(),
                     center = Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
                 )
-                // Left Eye (Mirrored for the shade effect)
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.35f), Color.Transparent),
@@ -108,8 +103,6 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                     center = Offset(center.x - eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
                 )
             }
-
-            // Cheeks Shade
             cheeksItem?.colorHex?.let { hex ->
                 drawCircle(
                     brush = Brush.radialGradient(
@@ -120,7 +113,6 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                     radius = 35.dp.toPx(),
                     center = Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
                 )
-                // Right Cheek (Mirrored)
                 drawCircle(
                     brush = Brush.radialGradient(
                         colors = listOf(parseColor(hex).copy(alpha = 0.3f), Color.Transparent),
@@ -131,8 +123,6 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                     center = Offset(center.x - cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
                 )
             }
-
-            // Lips Shade
             lipsItem?.colorHex?.let { hex ->
                 drawCircle(
                     brush = Brush.radialGradient(
@@ -145,97 +135,72 @@ fun FaceBlueprintView(uiState: StyleSimulatorUiState) {
                 )
             }
 
-            // 2. Draw Callout Lines (Only if NOT expanded)
+            // 4. Draw Static Callout Lines
             val lineStroke = 0.8.dp.toPx()
             val anchorRadius = 2.dp.toPx()
             val lineColor = Color.DarkGray.copy(alpha = 0.4f)
 
-            if (expandedCategory != "EYES") {
-                val eyesStart = Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx())
-                val eyesEnd = Offset(center.x + eyesCallout.x.dp.toPx(), center.y + eyesCallout.y.dp.toPx())
-                drawLine(lineColor, eyesStart, eyesEnd, lineStroke)
-                drawCircle(lineColor, anchorRadius, eyesStart)
-            }
+            drawLine(lineColor, Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx()), Offset(center.x + eyesCallout.x.dp.toPx(), center.y + eyesCallout.y.dp.toPx()), lineStroke)
+            drawCircle(lineColor, anchorRadius, Offset(center.x + eyesAnchor.x.dp.toPx(), center.y + eyesAnchor.y.dp.toPx()))
 
-            if (expandedCategory != "CHEEKS") {
-                val cheeksStart = Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx())
-                val cheeksEnd = Offset(center.x + cheeksCallout.x.dp.toPx(), center.y + cheeksCallout.y.dp.toPx())
-                drawLine(lineColor, cheeksStart, cheeksEnd, lineStroke)
-                drawCircle(lineColor, anchorRadius, cheeksStart)
-            }
+            drawLine(lineColor, Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx()), Offset(center.x + cheeksCallout.x.dp.toPx(), center.y + cheeksCallout.y.dp.toPx()), lineStroke)
+            drawCircle(lineColor, anchorRadius, Offset(center.x + cheeksAnchor.x.dp.toPx(), center.y + cheeksAnchor.y.dp.toPx()))
 
-            if (expandedCategory != "LIPS") {
-                val lipsStart = Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx())
-                val lipsEnd = Offset(center.x + lipsCallout.x.dp.toPx(), center.y + lipsCallout.y.dp.toPx())
-                drawLine(lineColor, lipsStart, lipsEnd, lineStroke)
-                drawCircle(lineColor, anchorRadius, lipsStart)
-            }
+            drawLine(lineColor, Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx()), Offset(center.x + lipsCallout.x.dp.toPx(), center.y + lipsCallout.y.dp.toPx()), lineStroke)
+            drawCircle(lineColor, anchorRadius, Offset(center.x + lipsAnchor.x.dp.toPx(), center.y + lipsAnchor.y.dp.toPx()))
         }
 
         val eyesItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.EYES }
         val cheeksItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.DIMENSION }
         val lipsItem = uiState.recommendedCosmetics.find { it.macroCategory == MacroCategory.LIPS }
 
-        // 3. Deterministic Alignment Math for Collapsed State
-        val calloutWidth = 100.dp
-        val calloutHalfWidth = calloutWidth / 2
-        val calloutHalfHeight = 28.dp
-
-        // --- EYES CALLOUT ---
-        val isEyesExpanded = expandedCategory == "EYES"
+        // 5. Render the Callouts
+        // --- EYES CALLOUT (Right Side) ---
         BlueprintCallout(
             label = "EYES",
             productName = eyesItem?.name ?: "Pending...",
             colorHex = eyesItem?.colorHex,
+            isExpanded = expandedCategory == "EYES",
+            onExpandToggle = { expandedCategory = if (expandedCategory == "EYES") null else "EYES" },
             modifier = Modifier
-                .clickable { expandedCategory = if (isEyesExpanded) null else "EYES" }
-                .zIndex(if (isEyesExpanded) 10f else 1f)
-                .then(
-                    if (isEyesExpanded) Modifier
-                    else Modifier.width(calloutWidth).offset(
-                        x = horizontalShift + eyesCallout.x.dp + calloutHalfWidth,
-                        y = blueprintOffset + eyesCallout.y.dp + calloutHalfHeight
-                    )
+                .zIndex(if (expandedCategory == "EYES") 10f else 1f)
+                .offset(
+                    x = horizontalShift + eyesCallout.x.dp,
+                    y = blueprintOffset + eyesCallout.y.dp
                 ),
-            anchorAlignment = if (isEyesExpanded) Alignment.Center else Alignment.TopStart
+            anchorAlignment = Alignment.TopStart
         )
 
-        // --- CHEEKS CALLOUT ---
-        val isCheeksExpanded = expandedCategory == "CHEEKS"
+        // --- CHEEKS CALLOUT (Left Side) ---
         BlueprintCallout(
             label = "CHEEKS",
             productName = cheeksItem?.name ?: "Pending...",
             colorHex = cheeksItem?.colorHex,
+            isExpanded = expandedCategory == "CHEEKS",
+            onExpandToggle = { expandedCategory = if (expandedCategory == "CHEEKS") null else "CHEEKS" },
             modifier = Modifier
-                .clickable { expandedCategory = if (isCheeksExpanded) null else "CHEEKS" }
-                .zIndex(if (isCheeksExpanded) 10f else 1f)
-                .then(
-                    if (isCheeksExpanded) Modifier
-                    else Modifier.width(calloutWidth).offset(
-                        x = horizontalShift + cheeksCallout.x.dp - calloutHalfWidth,
-                        y = blueprintOffset + cheeksCallout.y.dp + calloutHalfHeight
-                    )
+                .zIndex(if (expandedCategory == "CHEEKS") 10f else 1f)
+                .offset(
+                    x = horizontalShift + cheeksCallout.x.dp,
+                    y = blueprintOffset + cheeksCallout.y.dp
                 ),
-            anchorAlignment = if (isCheeksExpanded) Alignment.Center else Alignment.TopEnd
+            anchorAlignment = Alignment.TopEnd
         )
 
-        // --- LIPS CALLOUT ---
-        val isLipsExpanded = expandedCategory == "LIPS"
+        // --- LIPS CALLOUT (Right Side) ---
         BlueprintCallout(
             label = "LIPS",
             productName = lipsItem?.name ?: "Pending...",
             colorHex = lipsItem?.colorHex,
+            isExpanded = expandedCategory == "LIPS",
+            onExpandToggle = { expandedCategory = if (expandedCategory == "LIPS") null else "LIPS" },
             modifier = Modifier
-                .clickable { expandedCategory = if (isLipsExpanded) null else "LIPS" }
-                .zIndex(if (isLipsExpanded) 10f else 1f)
-                .then(
-                    if (isLipsExpanded) Modifier
-                    else Modifier.width(calloutWidth).offset(
-                        x = horizontalShift + lipsCallout.x.dp + calloutHalfWidth,
-                        y = blueprintOffset + lipsCallout.y.dp + calloutHalfHeight
-                    )
+                .zIndex(if (expandedCategory == "LIPS") 10f else 1f)
+                .offset(
+                    x = horizontalShift + lipsCallout.x.dp,
+                    y = blueprintOffset + lipsCallout.y.dp
                 ),
-            anchorAlignment = if (isLipsExpanded) Alignment.Center else Alignment.TopStart
+            anchorAlignment = Alignment.TopStart
         )
     }
 }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/HandBlueprintView.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/HandBlueprintView.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -21,6 +21,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.core.model.ritual.MacroCategory
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
@@ -29,6 +30,9 @@ import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulator
 
 @Composable
 fun HandBlueprintView(uiState: StyleSimulatorUiState) {
+    // SINGLE SOURCE OF TRUTH: Tracks the currently expanded card
+    var expandedCategory by remember { mutableStateOf<String?>(null) }
+
     val blueprintOffset = 10.dp
     val horizontalShift = 0.dp
     
@@ -107,10 +111,13 @@ fun HandBlueprintView(uiState: StyleSimulatorUiState) {
             label = "NAILS",
             productName = nailsItem?.name ?: "Pending...",
             colorHex = nailsItem?.colorHex,
+            isExpanded = expandedCategory == "NAILS",
+            onExpandToggle = { expandedCategory = if (expandedCategory == "NAILS") null else "NAILS" },
             modifier = Modifier
+                .zIndex(if (expandedCategory == "NAILS") 10f else 1f)
                 .offset(
-                    x = horizontalShift + nailsCallout.x.dp + 7.dp,
-                    y = blueprintOffset + nailsCallout.y.dp + 7.dp
+                    x = horizontalShift + nailsCallout.x.dp,
+                    y = blueprintOffset + nailsCallout.y.dp
                 ),
             anchorAlignment = Alignment.TopStart
         )


### PR DESCRIPTION
I have implemented the logic to ensure only one BlueprintCallout is expanded at a time and that it shifts toward the center of the screen when expanded.
Key Changes Applied
1.
Mutual Exclusion State:
◦
In each blueprint view (Face, Hand, Clothing), I added a single expandedCategory state.
◦
When you click a callout, it sets itself as the active category and collapses any previously expanded one.
2.
Adaptive Shifting Logic:
◦
I updated the BlueprintCallout component to handle its own shifting math based on its screen position.
◦
Left-side items (like "CHEEKS"): These are anchored on their right edge (TopEnd). When expanded, they now shift Right (+40dp) to avoid going off-screen and to move toward the center.
◦
Right-side items (like "EYES"): These are anchored on their left edge (TopStart). When expanded, they now shift Left (-40dp) toward the center.
3.
Refined Z-Indexing:
◦
Expanded cards are now given a higher zIndex (10f vs 1f) so they always float above other UI elements and lines when active.
4.
Cleaner Component Architecture:
◦
Hoisted the expansion state out of the individual BlueprintCallout and into the parent views. This makes the interaction predictable across the entire canvas.
You can now tap any detail card to see its full product info and color ribbon, and the interface will automatically adjust to keep the content centered and visible.