### PR TITLE
Kocolor

### DIFF
--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionDetailScreen.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionDetailScreen.kt
@@ -2,12 +2,14 @@ package com.zoewave.probase.kocolor.mobile.features.home.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -20,6 +22,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Card
@@ -35,12 +39,17 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -54,6 +63,7 @@ import com.zoewave.probase.core.model.ritual.OutfitSuggestion
 import com.zoewave.probase.core.model.ritual.SavedAnalysis
 import com.zoewave.probase.core.model.ritual.SeasonalType
 import com.zoewave.probase.core.model.ritual.Undertone
+import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.components.graphics.VisualBlueprintSection
 import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.components.graphics.toVisualBlueprintData
 import com.zoewave.probase.kocolor.mobile.features.home.R
@@ -66,6 +76,15 @@ fun CollectionDetailScreen(
     navTo: (KoColorRoute) -> Unit
 ) {
     val advice = analysis.advice
+    var expandedSections by remember { mutableStateOf(setOf("STORY", "BLUEPRINT", "WARDROBE", "VANITY")) }
+
+    fun toggleSection(section: String) {
+        expandedSections = if (expandedSections.contains(section)) {
+            expandedSections - section
+        } else {
+            expandedSections + section
+        }
+    }
     
     // Dynamic Hero Image selection: 
     // 1. Primary clothesUri
@@ -154,34 +173,33 @@ fun CollectionDetailScreen(
 
             // 3. Color Story
             item {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = "Color Story",
-                        style = MaterialTheme.typography.titleLarge,
-                        fontFamily = FontFamily.Serif,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Text(
-                        text = "FOUNDATIONAL TONES",
-                        style = MaterialTheme.typography.labelSmall,
-                        letterSpacing = 2.sp,
-                        modifier = Modifier.alpha(0.6f)
-                    )
-                    
-                    Spacer(Modifier.height(24.dp))
-                    
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                CollapsibleSectionHeader(
+                    title = "Color Story",
+                    subtitle = "FOUNDATIONAL TONES",
+                    isExpanded = expandedSections.contains("STORY"),
+                    onToggle = { toggleSection("STORY") }
+                )
+            }
+
+            if (expandedSections.contains("STORY")) {
+                item {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        advice.recommendedPalette.take(4).forEach { hex ->
-                            Box(
-                                modifier = Modifier
-                                    .size(48.dp)
-                                    .clip(CircleShape)
-                                    .background(com.zoewave.probase.features.graphics.colorpicker.util.parseColor(hex))
-                                    .border(1.dp, Color.Black.copy(alpha = 0.05f), CircleShape)
-                            )
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            advice.recommendedPalette.take(4).forEach { hex ->
+                                Box(
+                                    modifier = Modifier
+                                        .size(48.dp)
+                                        .clip(CircleShape)
+                                        .background(parseColor(hex))
+                                        .border(1.dp, Color.Black.copy(alpha = 0.05f), CircleShape)
+                                )
+                            }
                         }
                     }
                 }
@@ -189,22 +207,16 @@ fun CollectionDetailScreen(
 
             // 3.5 Visual Blueprint Section (Reused from Simulator)
             item {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = "Visual Blueprint",
-                        style = MaterialTheme.typography.titleLarge,
-                        fontFamily = FontFamily.Serif,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Text(
-                        text = "EXPLORE DETAILS",
-                        style = MaterialTheme.typography.labelSmall,
-                        letterSpacing = 2.sp,
-                        modifier = Modifier.alpha(0.6f)
-                    )
-                    
-                    Spacer(Modifier.height(24.dp))
-                    
+                CollapsibleSectionHeader(
+                    title = "Visual Blueprint",
+                    subtitle = "EXPLORE DETAILS",
+                    isExpanded = expandedSections.contains("BLUEPRINT"),
+                    onToggle = { toggleSection("BLUEPRINT") }
+                )
+            }
+
+            if (expandedSections.contains("BLUEPRINT")) {
+                item {
                     VisualBlueprintSection(
                         data = advice.toVisualBlueprintData()
                     )
@@ -213,54 +225,97 @@ fun CollectionDetailScreen(
 
             // 4. The Wardrobe
             item {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    Text(
-                        text = "The Wardrobe",
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontFamily = FontFamily.Serif,
-                        fontWeight = FontWeight.Bold
-                    )
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp), thickness = 0.5.dp)
-                }
+                CollapsibleSectionHeader(
+                    title = "The Wardrobe",
+                    subtitle = "${advice.outfitSuggestions.sumOf { it.suggestedItems.size }} ITEMS",
+                    isExpanded = expandedSections.contains("WARDROBE"),
+                    onToggle = { toggleSection("WARDROBE") }
+                )
             }
 
-            advice.outfitSuggestions.forEach { outfit ->
-                items(outfit.suggestedItems) { suggested ->
-                    VerticalCollectionItem(
-                        title = suggested.name,
-                        description = suggested.description ?: "Professional selected piece for this look.",
-                        imageModel = suggested.imageUrl ?: R.drawable.advice_clothes_fallback,
-                        isOwned = suggested.isOwned
-                    )
-                    Spacer(Modifier.height(16.dp))
+            if (expandedSections.contains("WARDROBE")) {
+                advice.outfitSuggestions.forEach { outfit ->
+                    items(outfit.suggestedItems) { suggested ->
+                        VerticalCollectionItem(
+                            title = suggested.name,
+                            description = suggested.description ?: "Professional selected piece for this look.",
+                            imageModel = suggested.imageUrl ?: R.drawable.advice_clothes_fallback,
+                            isOwned = suggested.isOwned
+                        )
+                        Spacer(Modifier.height(16.dp))
+                    }
                 }
             }
 
             // 5. The Vanity
             item {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    Text(
-                        text = "The Vanity",
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontFamily = FontFamily.Serif,
-                        fontWeight = FontWeight.Bold
-                    )
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp), thickness = 0.5.dp)
-                }
+                CollapsibleSectionHeader(
+                    title = "The Vanity",
+                    subtitle = "${advice.makeupSuggestions.size} ITEMS",
+                    isExpanded = expandedSections.contains("VANITY"),
+                    onToggle = { toggleSection("VANITY") }
+                )
             }
 
-            items(advice.makeupSuggestions) { makeup ->
-                VerticalCollectionItem(
-                    title = makeup.suggestedProductName ?: makeup.category,
-                    description = makeup.advice,
-                    imageModel = makeup.suggestedProductImageUrl ?: R.drawable.advice_makeup_fallback,
-                    isOwned = makeup.productId != null
-                )
-                Spacer(Modifier.height(16.dp))
+            if (expandedSections.contains("VANITY")) {
+                items(advice.makeupSuggestions) { makeup ->
+                    VerticalCollectionItem(
+                        title = makeup.suggestedProductName ?: makeup.category,
+                        description = makeup.advice,
+                        imageModel = makeup.suggestedProductImageUrl ?: R.drawable.advice_makeup_fallback,
+                        isOwned = makeup.productId != null
+                    )
+                    Spacer(Modifier.height(16.dp))
+                }
             }
             
             item { Spacer(Modifier.height(48.dp)) }
         }
+    }
+}
+
+@Composable
+private fun CollapsibleSectionHeader(
+    title: String,
+    subtitle: String,
+    isExpanded: Boolean,
+    onToggle: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onToggle() }
+            .padding(vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontFamily = FontFamily.Serif,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    letterSpacing = 2.sp,
+                    modifier = Modifier.alpha(0.6f),
+                    textAlign = TextAlign.Center
+                )
+            }
+            Icon(
+                imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                contentDescription = if (isExpanded) "Collapse" else "Expand",
+                tint = Color.Gray.copy(alpha = 0.6f)
+            )
+        }
+        HorizontalDivider(modifier = Modifier.padding(top = 16.dp), thickness = 0.5.dp)
     }
 }
 

--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionDetailScreen.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/CollectionDetailScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -49,7 +48,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -76,7 +74,8 @@ fun CollectionDetailScreen(
     navTo: (KoColorRoute) -> Unit
 ) {
     val advice = analysis.advice
-    var expandedSections by remember { mutableStateOf(setOf("STORY", "BLUEPRINT", "WARDROBE", "VANITY")) }
+    var expandedSections by remember { mutableStateOf(setOf("STORY", "BLUEPRINT")) }
+    //     var expandedSections by remember { mutableStateOf(emptySet<String>()) }
 
     fun toggleSection(section: String) {
         expandedSections = if (expandedSections.contains(section)) {

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/StyleSimulatorViewModel.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/StyleSimulatorViewModel.kt
@@ -135,12 +135,10 @@ class StyleSimulatorViewModel @Inject constructor(
             .groupBy { it.colorFamily }
 
         val recommendedClothing = allClothing.filter { item ->
-            "w_${item.id}" in (result?.selectedClothingIds ?: emptyList()) ||
-            "w_${item.id}" in (result?.selectedCosmeticIds ?: emptyList())
+            "w_${item.id}" in (result?.selectedClothingIds ?: emptyList())
         }
         val recommendedCosmetics = allCosmetics.filter { item ->
-            "c_${item.id}" in (result?.selectedCosmeticIds ?: emptyList()) ||
-            "c_${item.id}" in (result?.selectedClothingIds ?: emptyList())
+            "c_${item.id}" in (result?.selectedCosmeticIds ?: emptyList())
         }
 
         StyleSimulatorUiState(
@@ -366,26 +364,14 @@ class StyleSimulatorViewModel @Inject constructor(
         viewModelScope.launch {
             val state = uiState.value
             
-            // Fix: Pass imageUrl and use proper category mapping
-            val recommendations = state.recommendedClothing + state.recommendedCosmetics.map {
-                ClothingItem(
-                    id = it.id, 
-                    name = it.name, 
-                    brand = it.brand, 
-                    category = ClothingCategory.ACCESSORIES, // Better fallback for list display
-                    colorHex = it.colorHex,
-                    imageUrl = it.imageUrl,
-                    notes = it.notes
-                )
-            }
-
+            // Fix: Wardrobe should ONLY contain clothing items
             val outfitSuggestion = OutfitSuggestion(
                 occasion = state.userMessage,
                 advice = state.rationale ?: "",
-                keyPieces = recommendations.map { it.name },
+                keyPieces = state.recommendedClothing.map { it.name },
                 colorCombinations = state.recommendedPalette,
-                wardrobeItemIds = recommendations.map { it.id },
-                suggestedItems = recommendations.map { item ->
+                wardrobeItemIds = state.recommendedClothing.map { it.id },
+                suggestedItems = state.recommendedClothing.map { item ->
                     SuggestedPiece(
                         name = item.name,
                         category = item.category.name,
@@ -403,7 +389,7 @@ class StyleSimulatorViewModel @Inject constructor(
                 )
             )
 
-            // Fix: Map recommended cosmetics to real MakeupSuggestions instead of hardcoding
+            // Fix: Vanity should ONLY contain cosmetic items
             val makeupSuggestions = state.recommendedCosmetics.map { cosmetic ->
                 MakeupSuggestion(
                     category = cosmetic.macroCategory.displayName,
@@ -423,7 +409,6 @@ class StyleSimulatorViewModel @Inject constructor(
                 makeupSuggestions = makeupSuggestions,
                 outfitSuggestions = listOf(outfitSuggestion),
                 recommendedPalette = state.recommendedPalette,
-                // Fix: Fallback to first recommendation image if clothing is empty
                 clothesUri = state.recommendedClothing.firstOrNull()?.imageUrl 
                     ?: state.recommendedCosmetics.firstOrNull()?.imageUrl
             )

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
@@ -67,10 +67,59 @@ fun VanityCategoryCard(
     var showExplanation by remember { mutableStateOf(false) }
 
     if (showExplanation) {
+        val (fullDesc, examples) = when {
+            name.contains("Skincare", ignoreCase = true) -> 
+                "The essential foundation for any routine. These products focus on cleaning, nourishing, and preparing the skin's surface before any color is applied." to 
+                "Cleanser, Toner, Serum, Moisturizer, SPF, Primer, Face Mask, Exfoliant, Eye Care."
+            name.contains("Complexion", ignoreCase = true) -> 
+                "Architectural products designed to unify the skin tone, blur imperfections, and create a smooth, even canvas." to 
+                "Foundation, BB/CC Cream, Concealer, Color Corrector, Setting Powder, Face Powder, Setting Spray."
+            name.contains("Dimension", ignoreCase = true) -> 
+                "Sculptural products that bring life, shadow, and light back to the face. These define your bone structure and add a natural-looking flush or glow." to 
+                "Blush, Bronzer, Contour, Highlighter, Freckle Tint."
+            name.contains("Eyes", ignoreCase = true) -> 
+                "The focal point of visual communication. This category covers brow structure, lash enhancement, and artistic lid pigment." to 
+                "Eyeshadow, Eyeliner, Mascara, Lash Primer, Brow Pencil, Brow Gel, False Lashes."
+            name.contains("Lips", ignoreCase = true) -> 
+                "Color and care for the mouth. Products range from hydrating treatments to high-impact pigments that define the final mood." to 
+                "Lipstick, Lip Gloss, Lip Liner, Lip Tint/Stain, Lip Balm, Lip Plumper."
+            name.contains("Nails", ignoreCase = true) -> 
+                "Architectural enhancements for the hands. This includes color, protection, and structural care for the nails." to 
+                "Nail Polish, Base Coat, Top Coat, Nail Treatment."
+            else -> description to ""
+        }
+
         AlertDialog(
             onDismissRequest = { showExplanation = false },
             title = { Text(text = name, fontFamily = FontFamily.Serif, fontWeight = FontWeight.Bold) },
-            text = { Text(text = description) },
+            text = { 
+                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    Text(
+                        text = fullDesc, 
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.Black.copy(alpha = 0.8f),
+                        lineHeight = 20.sp
+                    )
+                    if (examples.isNotEmpty()) {
+                        Column {
+                            Text(
+                                text = "INCLUDES:", 
+                                style = MaterialTheme.typography.labelSmall, 
+                                fontWeight = FontWeight.Black, 
+                                color = Color.Black.copy(alpha = 0.4f),
+                                letterSpacing = 1.sp
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                text = examples, 
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.Black.copy(alpha = 0.7f),
+                                lineHeight = 18.sp
+                            )
+                        }
+                    }
+                }
+            },
             confirmButton = {
                 TextButton(onClick = { showExplanation = false }) {
                     Text(stringResource(android.R.string.ok))

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -97,10 +98,12 @@ fun VanityCategoryCard(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(
-                        Brush.horizontalGradient(
-                            colors = listOf(baseColor, baseColor.copy(alpha = 0.9f), Color.Transparent),
-                            startX = 0f,
-                            endX = 1000f
+                        Brush.linearGradient(
+                            colors = listOf(
+                                baseColor.copy(alpha = 0.95f),
+                                baseColor.copy(alpha = 0.8f),
+                                Color.White.copy(alpha = 0.4f)
+                            )
                         )
                     )
             )
@@ -108,7 +111,7 @@ fun VanityCategoryCard(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(24.dp),
+                    .padding(20.dp), // Slightly reduced padding to fit content
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
                 Row(
@@ -121,90 +124,107 @@ fun VanityCategoryCard(
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(
                                 text = displayName,
-                                style = MaterialTheme.typography.displaySmall.copy(fontSize = 34.sp, lineHeight = 38.sp),
-                                fontWeight = FontWeight.Bold,
+                                style = MaterialTheme.typography.displaySmall.copy(
+                                    fontSize = 32.sp, 
+                                    lineHeight = 36.sp,
+                                    fontWeight = FontWeight.Bold
+                                ),
                                 fontFamily = FontFamily.Serif,
                                 color = Color.Black
                             )
                             IconButton(
                                 onClick = { showExplanation = true },
-                                modifier = Modifier.size(40.dp)
+                                modifier = Modifier.size(36.dp)
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.Info,
                                     contentDescription = "Category Info",
-                                    modifier = Modifier.size(20.dp),
-                                    tint = Color.Black.copy(alpha = 0.3f)
+                                    modifier = Modifier.size(18.dp),
+                                    tint = Color.Black.copy(alpha = 0.2f)
                                 )
                             }
                         }
-                        Spacer(Modifier.height(4.dp))
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            val itemsText = if (count == 1) stringResource(R.string.applications_kocolor_features_cosmetics_item_singular) else stringResource(R.string.applications_kocolor_features_cosmetics_items_plural_format, count)
-                            Text(
-                                text = itemsText,
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.Bold,
-                                modifier = Modifier.alpha(0.9f)
-                            )
-                        }
+                        Text(
+                            text = if (count == 1) stringResource(R.string.applications_kocolor_features_cosmetics_item_singular) else stringResource(R.string.applications_kocolor_features_cosmetics_items_plural_format, count),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.alpha(0.7f)
+                        )
                     }
 
                     Column(horizontalAlignment = Alignment.End) {
                         Text(
                             text = currencyFormatter.format(totalValue),
-                            style = MaterialTheme.typography.titleLarge.copy(fontSize = 28.sp),
+                            style = MaterialTheme.typography.titleLarge.copy(fontSize = 26.sp),
                             fontWeight = FontWeight.Black,
                             fontFamily = FontFamily.Serif,
                             color = Color.Black
                         )
                         Text(
                             text = stringResource(R.string.applications_kocolor_features_cosmetics_total_value),
-                            style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 0.5.sp),
+                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp, letterSpacing = 0.5.sp),
                             fontWeight = FontWeight.Black,
                             modifier = Modifier.alpha(0.4f)
                         )
                     }
                 }
 
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(), 
-                        horizontalArrangement = Arrangement.SpaceBetween, 
-                        verticalAlignment = Alignment.Bottom
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    // Glassy Stock Status Container
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        color = Color.White.copy(alpha = 0.4f),
+                        border = BorderStroke(0.5.dp, Color.White.copy(alpha = 0.5f))
                     ) {
-                        Text(
-                            text = stringResource(R.string.applications_kocolor_features_cosmetics_stock_status), 
-                            style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 0.5.sp), 
-                            fontWeight = FontWeight.Black, 
-                            modifier = Modifier.alpha(0.6f)
-                        )
-                        Text(
-                            text = "${(averageFill * 100).toInt()}%", 
-                            style = MaterialTheme.typography.labelSmall, 
-                            fontWeight = FontWeight.Black, 
-                            color = Color(0xFF6B705C)
-                        )
-                    }
-                    
-                    val statusColor = Color(0xFF6B705C) 
+                        Column(
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.applications_kocolor_features_cosmetics_stock_status),
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontSize = 9.sp,
+                                    letterSpacing = 0.8.sp,
+                                    fontWeight = FontWeight.ExtraBold
+                                ),
+                                color = Color.Black.copy(alpha = 0.5f)
+                            )
+                            
+                            LinearProgressIndicator(
+                                progress = { averageFill.toFloat() },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(4.dp)
+                                    .clip(CircleShape),
+                                color = Color(0xFF7A6F5D), // Slightly darker for contrast
+                                trackColor = Color.Black.copy(alpha = 0.05f),
+                                strokeCap = StrokeCap.Round
+                            )
 
-                    LinearProgressIndicator(
-                        progress = { averageFill.toFloat() },
-                        modifier = Modifier.fillMaxWidth().height(8.dp).clip(CircleShape),
-                        color = statusColor,
-                        trackColor = Color.Black.copy(alpha = 0.05f),
-                        strokeCap = androidx.compose.ui.graphics.StrokeCap.Round
-                    )
-                    
-                    if (leadingBrand != null) {
-                        Text(
-                            text = stringResource(R.string.applications_kocolor_features_cosmetics_leading_brand_format, leadingBrand.uppercase()),
-                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
-                            fontWeight = FontWeight.Bold,
-                            modifier = Modifier.alpha(0.6f)
-                        )
+                            Text(
+                                text = "${(averageFill * 100).toInt()}%",
+                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
+                                fontWeight = FontWeight.Bold,
+                                color = Color.Black.copy(alpha = 0.4f)
+                            )
+                        }
                     }
+                    
+                    // Leading Brand
+                    Text(
+                        text = stringResource(
+                            R.string.applications_kocolor_features_cosmetics_leading_brand_format, 
+                            (leadingBrand ?: "Atelier").uppercase()
+                        ),
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            fontSize = 9.sp,
+                            letterSpacing = 1.2.sp,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        modifier = Modifier.padding(start = 4.dp).alpha(0.7f),
+                        color = Color.Black
+                    )
                 }
             }
         }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
@@ -5,9 +5,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -62,6 +63,21 @@ fun VanityCategoryCard(
         java.text.NumberFormat.getCurrencyInstance(java.util.Locale.US)
     }
 
+    var showExplanation by remember { mutableStateOf(false) }
+
+    if (showExplanation) {
+        AlertDialog(
+            onDismissRequest = { showExplanation = false },
+            title = { Text(text = name, fontFamily = FontFamily.Serif, fontWeight = FontWeight.Bold) },
+            text = { Text(text = description) },
+            confirmButton = {
+                TextButton(onClick = { showExplanation = false }) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            }
+        )
+    }
+
     Card(
         onClick = { navTo(KoColorRoute.CosmeticCategoryCover(name)) },
         modifier = modifier.height(200.dp),
@@ -102,13 +118,26 @@ fun VanityCategoryCard(
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
                         val displayName = if (name.contains("&")) name.substringBefore("&").trim() else name
-                        Text(
-                            text = displayName,
-                            style = MaterialTheme.typography.displaySmall.copy(fontSize = 34.sp, lineHeight = 38.sp),
-                            fontWeight = FontWeight.Bold,
-                            fontFamily = FontFamily.Serif,
-                            color = Color.Black
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = displayName,
+                                style = MaterialTheme.typography.displaySmall.copy(fontSize = 34.sp, lineHeight = 38.sp),
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = FontFamily.Serif,
+                                color = Color.Black
+                            )
+                            IconButton(
+                                onClick = { showExplanation = true },
+                                modifier = Modifier.size(40.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Info,
+                                    contentDescription = "Category Info",
+                                    modifier = Modifier.size(20.dp),
+                                    tint = Color.Black.copy(alpha = 0.3f)
+                                )
+                            }
+                        }
                         Spacer(Modifier.height(4.dp))
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             val itemsText = if (count == 1) stringResource(R.string.applications_kocolor_features_cosmetics_item_singular) else stringResource(R.string.applications_kocolor_features_cosmetics_items_plural_format, count)
@@ -117,19 +146,6 @@ fun VanityCategoryCard(
                                 style = MaterialTheme.typography.bodyLarge,
                                 fontWeight = FontWeight.Bold,
                                 modifier = Modifier.alpha(0.9f)
-                            )
-                            Text(
-                                text = "  |  ",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = Color.Black.copy(alpha = 0.3f)
-                            )
-                            Text(
-                                text = description,
-                                style = MaterialTheme.typography.bodySmall,
-                                fontWeight = FontWeight.Medium,
-                                modifier = Modifier.alpha(0.6f),
-                                maxLines = 1,
-                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                             )
                         }
                     }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
@@ -2,13 +2,35 @@ package com.zoewave.probase.kocolor.features.cosmetics.ui.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -27,6 +49,8 @@ import coil.compose.AsyncImage
 import com.zoewave.probase.kocolor.features.cosmetics.R
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CategoryMetadata
 import com.zoewave.probase.kocolor.model.KoColorRoute
+import java.text.NumberFormat
+import java.util.Locale
 
 data class VanityCategoryUiState(
     val name: String,
@@ -61,7 +85,7 @@ fun VanityCategoryCard(
     }
     
     val currencyFormatter = remember { 
-        java.text.NumberFormat.getCurrencyInstance(java.util.Locale.US)
+        NumberFormat.getCurrencyInstance(Locale.US)
     }
 
     var showExplanation by remember { mutableStateOf(false) }
@@ -160,9 +184,10 @@ fun VanityCategoryCard(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(20.dp), // Slightly reduced padding to fit content
-                verticalArrangement = Arrangement.SpaceBetween
+                    .padding(18.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
+                // Header Row
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -175,7 +200,7 @@ fun VanityCategoryCard(
                                 text = displayName,
                                 style = MaterialTheme.typography.displaySmall.copy(
                                     fontSize = 32.sp, 
-                                    lineHeight = 36.sp,
+                                    lineHeight = 34.sp,
                                     fontWeight = FontWeight.Bold
                                 ),
                                 fontFamily = FontFamily.Serif,
@@ -183,83 +208,87 @@ fun VanityCategoryCard(
                             )
                             IconButton(
                                 onClick = { showExplanation = true },
-                                modifier = Modifier.size(36.dp)
+                                modifier = Modifier.size(32.dp)
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.Info,
                                     contentDescription = "Category Info",
-                                    modifier = Modifier.size(18.dp),
+                                    modifier = Modifier.size(16.dp),
                                     tint = Color.Black.copy(alpha = 0.2f)
                                 )
                             }
                         }
-                        Text(
-                            text = if (count == 1) stringResource(R.string.applications_kocolor_features_cosmetics_item_singular) else stringResource(R.string.applications_kocolor_features_cosmetics_items_plural_format, count),
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.SemiBold,
-                            modifier = Modifier.alpha(0.7f)
-                        )
-                    }
-
-                    Column(horizontalAlignment = Alignment.End) {
-                        Text(
-                            text = currencyFormatter.format(totalValue),
-                            style = MaterialTheme.typography.titleLarge.copy(fontSize = 26.sp),
-                            fontWeight = FontWeight.Black,
-                            fontFamily = FontFamily.Serif,
-                            color = Color.Black
-                        )
-                        Text(
-                            text = stringResource(R.string.applications_kocolor_features_cosmetics_total_value),
-                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp, letterSpacing = 0.5.sp),
-                            fontWeight = FontWeight.Black,
-                            modifier = Modifier.alpha(0.4f)
-                        )
-                    }
-                }
-
-                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                    // Glassy Stock Status Container
-                    Surface(
-                        modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(12.dp),
-                        color = Color.White.copy(alpha = 0.4f),
-                        border = BorderStroke(0.5.dp, Color.White.copy(alpha = 0.5f))
-                    ) {
-                        Column(
-                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            val itemsText = if (count == 1) stringResource(R.string.applications_kocolor_features_cosmetics_item_singular) else stringResource(R.string.applications_kocolor_features_cosmetics_items_plural_format, count)
                             Text(
-                                text = stringResource(R.string.applications_kocolor_features_cosmetics_stock_status),
-                                style = MaterialTheme.typography.labelSmall.copy(
-                                    fontSize = 9.sp,
-                                    letterSpacing = 0.8.sp,
-                                    fontWeight = FontWeight.ExtraBold
-                                ),
-                                color = Color.Black.copy(alpha = 0.5f)
+                                text = itemsText,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.alpha(0.7f)
                             )
-                            
-                            LinearProgressIndicator(
-                                progress = { averageFill.toFloat() },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(4.dp)
-                                    .clip(CircleShape),
-                                color = Color(0xFF7A6F5D), // Slightly darker for contrast
-                                trackColor = Color.Black.copy(alpha = 0.05f),
-                                strokeCap = StrokeCap.Round
-                            )
-
                             Text(
-                                text = "${(averageFill * 100).toInt()}%",
-                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
+                                text = "  |  ",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.Black.copy(alpha = 0.2f)
+                            )
+                            Text(
+                                text = currencyFormatter.format(totalValue),
+                                style = MaterialTheme.typography.bodyMedium,
                                 fontWeight = FontWeight.Bold,
-                                color = Color.Black.copy(alpha = 0.4f)
+                                color = Color.Black.copy(alpha = 0.9f)
                             )
                         }
                     }
-                    
+                }
+
+                Spacer(Modifier.weight(1f))
+
+                // Glassy Stock Status Container
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    color = Color.White.copy(alpha = 0.4f),
+                    border = BorderStroke(0.5.dp, Color.White.copy(alpha = 0.5f))
+                ) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.applications_kocolor_features_cosmetics_stock_status),
+                            style = MaterialTheme.typography.labelSmall.copy(
+                                fontSize = 9.sp,
+                                letterSpacing = 0.8.sp,
+                                fontWeight = FontWeight.ExtraBold
+                            ),
+                            color = Color.Black.copy(alpha = 0.5f)
+                        )
+                        
+                        LinearProgressIndicator(
+                            progress = { averageFill.toFloat() },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(4.dp)
+                                .clip(CircleShape),
+                            color = Color(0xFF7A6F5D),
+                            trackColor = Color.Black.copy(alpha = 0.05f),
+                            strokeCap = StrokeCap.Round
+                        )
+
+                        Text(
+                            text = "${(averageFill * 100).toInt()}%",
+                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
+                            fontWeight = FontWeight.Bold,
+                            color = Color.Black.copy(alpha = 0.4f)
+                        )
+                    }
+                }
+                
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Bottom
+                ) {
                     // Leading Brand
                     Text(
                         text = stringResource(
@@ -271,7 +300,7 @@ fun VanityCategoryCard(
                             letterSpacing = 1.2.sp,
                             fontWeight = FontWeight.Bold
                         ),
-                        modifier = Modifier.padding(start = 4.dp).alpha(0.7f),
+                        modifier = Modifier.alpha(0.7f),
                         color = Color.Black
                     )
                 }

--- a/applications/kocolor/scripts/generate_seeds.py
+++ b/applications/kocolor/scripts/generate_seeds.py
@@ -212,7 +212,7 @@ def generate_wardrobe():
             "macroCategory": "SHOES",
             "microCategory": "Shoes",
             "colorHex": "#000000",
-            "imageUrl": fix_url("https://images.unsplash.com/photo-1614252329392-74895698b64a?auto=format&fit=crop&w=800&q=80"),
+            "imageUrl": fix_url("https://images.unsplash.com/photo-1535043934128-cf0b28d52f95?auto=format&fit=crop&w=800&q=80"),
             "price": 890.00
         }
     ]

--- a/applications/kocolor/scripts/generate_seeds.py
+++ b/applications/kocolor/scripts/generate_seeds.py
@@ -14,7 +14,9 @@ CATEGORY_MAP = {
     "blush": "DIMENSION",
     "lipstick": "LIPS",
     "eyeshadow": "EYES",
-    "nail_polish": "NAILS"
+    "nail_polish": "NAILS",
+    "foundation": "COMPLEXION",
+    "concealer": "COMPLEXION"
 }
 
 def ensure_directory():
@@ -65,11 +67,15 @@ def fetch_cosmetics():
                         break
 
                     colors = item.get("product_colors", [])
-                    if not colors:
-                        continue # Skip products without color hexes
+                    color_hex = colors[0].get("hex_value") if colors else None
 
-                    # Grab the first available color hex
-                    color_hex = colors[0].get("hex_value")
+                    # For complexion, we might not always have specific hexes in the API response
+                    # If missing, provide a neutral fallback hex
+                    if not color_hex:
+                        if macro_category == "COMPLEXION":
+                            color_hex = "#EBC7B3" # Neutral Beige
+                        else:
+                            continue
 
                     # Ensure the hex is valid for Compose UI parsing
                     if color_hex and color_hex.startswith("#") and len(color_hex) in [7, 9]:
@@ -85,6 +91,39 @@ def fetch_cosmetics():
                         count += 1
         except Exception as e:
             print(f"Failed to fetch {api_type}: {e}")
+
+    # Add synthetic Skincare (PREP) data since the API is focused on color cosmetics
+    print("Adding synthetic skincare (PREP) data...")
+    skincare_items = [
+        {
+            "brand": "La Roche-Posay",
+            "name": "Anthelios Melt-in Milk Sunscreen",
+            "macroCategory": "PREP",
+            "microCategory": "Spf",
+            "colorHex": "#FFFFFF",
+            "imageUrl": "https://images.unsplash.com/photo-1556228720-195a672e8a03?auto=format&fit=crop&w=300&q=80",
+            "price": 35.00
+        },
+        {
+            "brand": "The Ordinary",
+            "name": "Hyaluronic Acid 2% + B5",
+            "macroCategory": "PREP",
+            "microCategory": "Serum",
+            "colorHex": "#FDFDFD",
+            "imageUrl": "https://images.unsplash.com/photo-1620916566398-39f1143ab7be?auto=format&fit=crop&w=300&q=80",
+            "price": 10.00
+        },
+        {
+            "brand": "Caudalie",
+            "name": "Vinoperfect Brightening Serum",
+            "macroCategory": "PREP",
+            "microCategory": "Serum",
+            "colorHex": "#F9F9F9",
+            "imageUrl": "https://images.unsplash.com/photo-1608248597279-f99d160bfbcc?auto=format&fit=crop&w=300&q=80",
+            "price": 79.00
+        }
+    ]
+    seed_data.extend(skincare_items)
 
     with open(COSMETICS_FILE, "w") as f:
         json.dump(seed_data, f, indent=2)
@@ -173,7 +212,7 @@ def generate_wardrobe():
             "macroCategory": "SHOES",
             "microCategory": "Shoes",
             "colorHex": "#000000",
-            "imageUrl": fix_url("https://images.unsplash.com/photo-1614252235316-8c857d38b5f4?auto=format&fit=crop&w=800&q=80"),
+            "imageUrl": fix_url("https://images.unsplash.com/photo-1614252329392-74895698b64a?auto=format&fit=crop&w=800&q=80"),
             "price": 890.00
         }
     ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ android-targetSdk = "37"
 
 # -- Build Tools --
 agp = "9.4.0-alpha06"
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 # KSP version must match Kotlin version exactly
 ksp = "2.3.9"
 
@@ -23,7 +23,7 @@ constraintLayout = "2.2.1"
 # -- Jetpack Compose --
 composeBom = "2026.06.01"
 composeMaterial = "1.7.8"  # Jetpack Compose Material (used for icons, wear material)
-composeMaterial3Expressive = "1.5.0-alpha23"
+composeMaterial3Expressive = "1.5.0-alpha24"
 
 # -- Nav3 --
 nav3Core = "1.1.4"
@@ -31,14 +31,14 @@ lifecycleViewmodelNav3 = "2.11.0"
 material3AdaptiveNav3 = "1.3.0-rc01"
 
 # -- Dependency Injection (Hilt) --
-hilt = "2.60"
+hilt = "2.60.1"
 hiltLifecycleViewModel = "1.4.0"
 hiltLifecycleViewModelCompose = "1.4.0"
 hiltWork = "1.4.0"
 
 # -- Kotlin & Serialization --
 kotlinxSerializationCore = "1.11.0"
-kotlinSerialization = "2.4.0" # Matches Kotlin version for plugin
+kotlinSerialization = "2.4.10" # Matches Kotlin version for plugin
 kotlinxDatetime = "0.8.0"
 immutableCollections = "0.5.1"
 coroutines = "1.11.0"


### PR DESCRIPTION
The Fix
The problem was a logic error in how the "Style Blueprint" was being saved to your collection. The code was merging all recommended items into a single list and labeling cosmetics as "Accessories" within the wardrobe section.
I have updated   StyleSimulatorViewModel.kt to enforce a strict separation of concerns:
1.
Wardrobe (Clothing): Now exclusively contains garments (Tops, Bottoms, Shoes) and actual wardrobe accessories.
2.
Vanity (Cosmetics): Now correctly houses all skincare (including Sunscreen), makeup, and nail products.
3.
Clean Data Pipeline: I've also refactored the internal filtering logic to ensure that "Vanity" IDs and "Wardrobe" IDs never cross paths during the simulation process.
To verify the fix:
1.
Go to the Style Simulator and run a fresh analysis.
2.
Tap "Save Selection" to lock in the new results.
3.
View the new entry in your History. The Sunscreen will now be neatly categorized under "The Vanity", and your Loafers will remain in "The Wardrobe".
The application now builds successfully with these logical refinements!