### PR TITLE
feat: implement multi-dimensional HSV sorting for color analytics

### DIFF
--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticAnalyticsScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticAnalyticsScreen.kt
@@ -175,15 +175,29 @@ fun CosmeticAnalyticsScreen(
                             .filter { it.colorHex.isNotBlank() }
                             .groupBy { it.colorHex }
                             .toList()
-                            .sortedBy { (hex, _) ->
-                                val hsv = FloatArray(3)
-                                try {
-                                    AndroidColor.colorToHSV(AndroidColor.parseColor(hex), hsv)
-                                    hsv[0] // Sort primarily by Hue
-                                } catch (e: Exception) {
-                                    0f
+                            .sortedWith(compareBy(
+                                { (hex, _) ->
+                                    val hsv = FloatArray(3)
+                                    try {
+                                        AndroidColor.colorToHSV(AndroidColor.parseColor(hex), hsv)
+                                        hsv[0] // 1. Hue (Rainbow order)
+                                    } catch (e: Exception) { 0f }
+                                },
+                                { (hex, _) ->
+                                    val hsv = FloatArray(3)
+                                    try {
+                                        AndroidColor.colorToHSV(AndroidColor.parseColor(hex), hsv)
+                                        hsv[1] // 2. Saturation (Muted to Vibrant)
+                                    } catch (e: Exception) { 0f }
+                                },
+                                { (hex, _) ->
+                                    val hsv = FloatArray(3)
+                                    try {
+                                        AndroidColor.colorToHSV(AndroidColor.parseColor(hex), hsv)
+                                        hsv[2] // 3. Value (Dark to Light)
+                                    } catch (e: Exception) { 0f }
                                 }
-                            }
+                            ))
                     }
 
                     var selectedGroup by remember { mutableStateOf<Pair<String, List<CosmeticItem>>?>(null) }

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeAnalyticsScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeAnalyticsScreen.kt
@@ -171,15 +171,29 @@ fun WardrobeAnalyticsScreen(
                             .filter { it.colorHex.isNotBlank() }
                             .groupBy { it.colorHex }
                             .toList()
-                            .sortedBy { (hex, _) ->
-                                val hsv = FloatArray(3)
-                                try {
-                                    AndroidColor.colorToHSV(AndroidColor.parseColor(hex), hsv)
-                                    hsv[0] // Sort primarily by Hue
-                                } catch (e: Exception) {
-                                    0f
+                            .sortedWith(compareBy(
+                                { (hex, _) ->
+                                    val hsv = FloatArray(3)
+                                    try {
+                                        AndroidColor.colorToHSV(AndroidColor.parseColor(hex), hsv)
+                                        hsv[0] // 1. Hue (Rainbow order)
+                                    } catch (e: Exception) { 0f }
+                                },
+                                { (hex, _) ->
+                                    val hsv = FloatArray(3)
+                                    try {
+                                        AndroidColor.colorToHSV(AndroidColor.parseColor(hex), hsv)
+                                        hsv[1] // 2. Saturation (Muted to Vibrant)
+                                    } catch (e: Exception) { 0f }
+                                },
+                                { (hex, _) ->
+                                    val hsv = FloatArray(3)
+                                    try {
+                                        AndroidColor.colorToHSV(AndroidColor.parseColor(hex), hsv)
+                                        hsv[2] // 3. Value (Dark to Light)
+                                    } catch (e: Exception) { 0f }
                                 }
-                            }
+                            ))
                     }
 
                     var selectedGroup by remember { mutableStateOf<Pair<String, List<ClothingItem>>?>(null) }


### PR DESCRIPTION
This update refines the visual organization of color groups in the analytics screens by transitioning from a simple hue-based sort to a comprehensive HSV (Hue, Saturation, Value) sorting strategy. This ensures that items are grouped in a more intuitive rainbow order, followed by their vibrancy and brightness.

- **Enhanced Color Ordering**:
    - Updated `CosmeticAnalyticsScreen` and `WardrobeAnalyticsScreen` to use `sortedWith` instead of a single-property `sortedBy`.
    - Implemented a three-tier comparison logic:
        1.  **Hue**: Establishes primary rainbow order.
        2.  **Saturation**: Orders items from muted to vibrant within the same hue. 3.  **Value**: Orders items from dark to light within the same hue and saturation.
- **Robustness**:
    - Maintained safe color parsing with try-catch blocks, ensuring that invalid hex strings do not crash the analytics view and default to a fallback sort value of `0f`.