### PR TITLE
ui: implement hue rotation for improved color grouping in Cosmetic An…

### DIFF
--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticAnalyticsScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticAnalyticsScreen.kt
@@ -190,7 +190,12 @@ fun CosmeticAnalyticsScreen(
                                     val hsv = FloatArray(3)
                                     try {
                                         AndroidColor.colorToHSV(AndroidColor.parseColor(hex), hsv)
-                                        hsv[0] // 2. Hue (Rainbow order: 0-360)
+                                        // 🛠️ HUE ROTATION:
+                                        // High hues (330°+) are Pinks/Magentas. We subtract 360 
+                                        // so they sit at -30° to 0°, grouping them perfectly 
+                                        // with the Reds (0°+) at the start of the rainbow.
+                                        val hue = hsv[0]
+                                        if (hue > 330) hue - 360 else hue
                                     } catch (e: Exception) { 0f }
                                 },
                                 { (hex, _) ->


### PR DESCRIPTION
…alytics

This update refines how colors are sorted in the Cosmetic Analytics screen by implementing a hue rotation. This ensures that pinks and magentas are grouped adjacent to reds at the start of the spectrum rather than at the extreme end.

- **Color Sorting Optimization**:
    - Adjusted the hue calculation logic to subtract 360 from values greater than 330°.
    - This change maps high-hue colors (Pinks/Magentas) to the -30° to 0° range, allowing them to flow seamlessly into Reds (0°+) for a more natural and continuous rainbow distribution.
    - Maintained error handling to return a default hue of 0f in case of hex parsing failures.