### PR TITLE
feat: implement dynamic Stylist's Edit engine in Color Hub

### DIFF
--- a/applications/kocolor/Docs/Color/dynamic_stylist_proposal.md
+++ b/applications/kocolor/Docs/Color/dynamic_stylist_proposal.md
@@ -1,0 +1,62 @@
+# Proposal: Dynamic "Stylist's Edit" Engine
+
+This proposal outlines the logic for transforming the static "Stylist's Edit" section into a dynamic, AI-driven (or heuristic-driven) editorial engine that reacts to the user's real inventory and biological profile.
+
+## 🧠 The "Stylist Analysis" Pipeline
+
+We will implement a multi-stage analysis within the `ColorIntelligenceRepository` to generate personalized narrative insights.
+
+### 1. Inventory Sentiment Analysis
+We will categorize the entire inventory into "Vibes" based on the distribution of Hues and Saturation levels:
+- **"The Minimalist"**: High volume of low-saturation neutrals (Blacks, Whites, Beiges).
+- **"The Vibrant Collector"**: High volume of high-saturation colors across multiple hues.
+- **"Earth Tones"**: Dominance in the Warm/Autumn spectrum (Oranges, Browns, Olives).
+- **"Cool Sophisticate"**: Dominance in the Cool/Winter spectrum (Blues, Purples, Cool Grays).
+
+### 2. Gap-to-Seasonal Mapping
+Instead of just listing missing colors, we will select the **"Most Impactful Additions"**:
+- Compare the `userSeason` (e.g., Deep Winter) against `inventoryColors`.
+- Identify the 2 highest-contrast "Missing" hues.
+- Map these hues to high-fidelity names (e.g., `#046307` becomes "Deep Emerald").
+
+### 3. Biological Anchoring
+The logic will explicitly reference the user's `Signature Skin Tone` (detected during onboarding) to suggest coordination strategies.
+
+---
+
+## 🛠️ Data Model Enhancements
+
+We will introduce a `StylistEdit` data class to encapsulate the generated narrative:
+
+```kotlin
+data class StylistEdit(
+    val title: String = "The Stylist's Edit",
+    val primaryInsight: String, // e.g. "Your collection leans into Cool Neutrals..."
+    val recommendation: String, // e.g. "Integrating Deep Jewel Tones..."
+    val anchorColors: List<String>, // Hex codes for the suggested items
+    val buttonText: String = "SHOP THE EDIT"
+)
+```
+
+---
+
+## 📝 Example Dynamic Transformation
+
+**User Profile:** Winter | **Inventory:** 80% Black/Gray/White | **Skin Tone:** Roseate Sand
+
+| Section | Dynamic Generation |
+| :--- | :--- |
+| **Primary Insight** | "Your current collection leans heavily into **Cool Neutrals**. While sophisticated, it lacks the depth required for high-contrast **Winter** styling." |
+| **Recommendation** | "Integrating **Jewel Tones** like **Sapphire** and **Amethyst** will anchor your silhouette and provide a radiant glow against your **Roseate Sand** undertones." |
+| **Anchor Swatches** | Suggests `#0F52BA` (Sapphire) and `#9966CC` (Amethyst). |
+
+---
+
+## 🚀 Implementation Steps
+
+1.  **Repository Logic**: Add `generateStylistEdit(userSeason, inventory)` to `ColorIntelligenceRepository`.
+2.  **Color Naming**: Integrate a hue-to-name mapping utility (e.g., "Sapphire," "Emerald").
+3.  **UI Wiring**: Connect the `ColorHubViewModel` to this new repository method.
+4.  **Template Engine**: Create a lightweight string template system for the editorial copy.
+
+**Does this logic for the "Stylist's Edit" align with your vision for the Dynamic Hub?**

--- a/applications/kocolor/Docs/Color/walkthrough.md
+++ b/applications/kocolor/Docs/Color/walkthrough.md
@@ -20,8 +20,7 @@ Selecting any color now reveals the `ProfessionalColorSpecSheet`. This component
 - **Pantone® Matching**: Near-matches to industry-standard color codes.
 - **HSV Breakdown**: Hue, Saturation, and Value specs for technical analysis.
 
-### 4. Advanced Harmony Search
-The `ColorSearchScreen` has been upgraded to support professional search modes beyond simple complementary matching, including Analogous, Triadic, and Monochromatic harmonies, powered by the centralized `ColorScienceUtils`.
+- **Dynamic "Stylist's Edit" Engine**: The static editorial section has been replaced with a narrative engine that analyzes the user's inventory distribution (e.g., % of neutrals) and generates personalized advice. It explicitly suggests high-impact color additions (like "Sapphire" or "Emerald") that harmonize with the user's biological undertones and seasonal profile.
 
 ---
 

--- a/applications/kocolor/apps/mobile/features/color/src/main/java/com/zoewave/probase/kocolor/mobile/features/color/ui/hub/ColorHubScreen.kt
+++ b/applications/kocolor/apps/mobile/features/color/src/main/java/com/zoewave/probase/kocolor/mobile/features/color/ui/hub/ColorHubScreen.kt
@@ -270,54 +270,52 @@ fun ColorHubScreen(
 
             // --- SECTION 4: THE STYLIST'S EDIT ---
             item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(32.dp),
-                    colors = CardDefaults.cardColors(containerColor = Color(0xFF745E7A))
-                ) {
-                    Column(modifier = Modifier.padding(32.dp)) {
-                        Text(
-                            "The Stylist's Edit",
-                            style = MaterialTheme.typography.headlineMedium,
-                            fontFamily = serifFont,
-                            fontStyle = FontStyle.Italic,
-                            color = Color.White
-                        )
-                        
-                        Spacer(Modifier.height(24.dp))
-                        
-                        BulletPoint(
-                            text = buildAnnotatedString {
-                                append("Your current collection leans heavily into ")
-                                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Cool Neutrals") }
-                                append(". While sophisticated, it lacks the depth required for high-contrast seasonal styling.")
-                            }
-                        )
-                        
-                        Spacer(Modifier.height(16.dp))
-                        
-                        BulletPoint(
-                            text = buildAnnotatedString {
-                                append("Integrating ")
-                                withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append("Deep Jewel Tones") }
-                                append(" like Emerald and Sapphire will anchor your silhouette and provide a radiant glow against your Roseate Sand undertones.")
-                            }
-                        )
-                        
-                        Spacer(Modifier.height(32.dp))
-                        
-                        Button(
-                            onClick = { /* Shop */ },
-                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFD4AF37)),
-                            shape = RoundedCornerShape(20.dp),
-                            modifier = Modifier.height(48.dp)
-                        ) {
+                uiState.stylistEdit?.let { edit ->
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(32.dp),
+                        colors = CardDefaults.cardColors(containerColor = Color(0xFF745E7A))
+                    ) {
+                        Column(modifier = Modifier.padding(32.dp)) {
                             Text(
-                                "SHOP THE EDIT",
-                                style = MaterialTheme.typography.labelLarge,
-                                fontWeight = FontWeight.Black,
+                                edit.title,
+                                style = MaterialTheme.typography.headlineMedium,
+                                fontFamily = serifFont,
+                                fontStyle = FontStyle.Italic,
                                 color = Color.White
                             )
+                            
+                            Spacer(Modifier.height(24.dp))
+                            
+                            BulletPoint(
+                                text = buildAnnotatedString {
+                                    append(edit.primaryInsight)
+                                }
+                            )
+                            
+                            Spacer(Modifier.height(16.dp))
+                            
+                            BulletPoint(
+                                text = buildAnnotatedString {
+                                    append(edit.recommendation)
+                                }
+                            )
+                            
+                            Spacer(Modifier.height(32.dp))
+                            
+                            Button(
+                                onClick = { /* Shop */ },
+                                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFD4AF37)),
+                                shape = RoundedCornerShape(20.dp),
+                                modifier = Modifier.height(48.dp)
+                            ) {
+                                Text(
+                                    edit.buttonText,
+                                    style = MaterialTheme.typography.labelLarge,
+                                    fontWeight = FontWeight.Black,
+                                    color = Color.White
+                                )
+                            }
                         }
                     }
                 }

--- a/applications/kocolor/apps/mobile/features/color/src/main/java/com/zoewave/probase/kocolor/mobile/features/color/ui/hub/ColorHubViewModel.kt
+++ b/applications/kocolor/apps/mobile/features/color/src/main/java/com/zoewave/probase/kocolor/mobile/features/color/ui/hub/ColorHubViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.core.model.ritual.SeasonalType
 import com.zoewave.probase.kocolor.features.colors.domain.model.ColorSignature
+import com.zoewave.probase.kocolor.features.colors.domain.model.StylistEdit
 import com.zoewave.probase.kocolor.features.colors.domain.repository.ColorIntelligenceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
@@ -12,6 +13,7 @@ import javax.inject.Inject
 data class ColorHubUiState(
     val inventoryColors: List<ColorSignature> = emptyList(),
     val paletteGaps: List<String> = emptyList(),
+    val stylistEdit: StylistEdit? = null,
     val userSeason: SeasonalType = SeasonalType.WINTER // Mocked for now
 )
 
@@ -23,11 +25,13 @@ class ColorHubViewModel @Inject constructor(
     val uiState: StateFlow<ColorHubUiState> = combine(
         colorIntelligenceRepository.getAllInventoryColors(),
         colorIntelligenceRepository.getPaletteGaps(SeasonalType.WINTER),
+        colorIntelligenceRepository.getStylistEdit(SeasonalType.WINTER),
         flowOf(SeasonalType.WINTER)
-    ) { colors, gaps, season ->
+    ) { colors, gaps, edit, season ->
         ColorHubUiState(
             inventoryColors = colors,
             paletteGaps = gaps,
+            stylistEdit = edit,
             userSeason = season
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ColorHubUiState())

--- a/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/data/repository/ColorIntelligenceRepositoryImpl.kt
+++ b/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/data/repository/ColorIntelligenceRepositoryImpl.kt
@@ -3,9 +3,11 @@ package com.zoewave.probase.kocolor.features.colors.data.repository
 import com.zoewave.probase.core.model.ritual.SeasonalType
 import com.zoewave.probase.kocolor.data.repository.CosmeticInventoryRepository
 import com.zoewave.probase.kocolor.data.repository.WardrobeRepository
+import com.zoewave.probase.kocolor.features.colors.domain.engine.StylistEditEngine
 import com.zoewave.probase.kocolor.features.colors.domain.model.ColorSignature
 import com.zoewave.probase.kocolor.features.colors.domain.model.HarmonyMode
 import com.zoewave.probase.kocolor.features.colors.domain.model.SourceType
+import com.zoewave.probase.kocolor.features.colors.domain.model.StylistEdit
 import com.zoewave.probase.kocolor.features.colors.domain.repository.ColorIntelligenceRepository
 import com.zoewave.probase.kocolor.features.colors.util.ColorScienceUtils
 import kotlinx.coroutines.flow.Flow
@@ -17,7 +19,8 @@ import javax.inject.Singleton
 @Singleton
 class ColorIntelligenceRepositoryImpl @Inject constructor(
     private val wardrobeRepository: WardrobeRepository,
-    private val cosmeticRepository: CosmeticInventoryRepository
+    private val cosmeticRepository: CosmeticInventoryRepository,
+    private val stylistEditEngine: StylistEditEngine
 ) : ColorIntelligenceRepository {
 
     override fun getAllInventoryColors(): Flow<List<ColorSignature>> {
@@ -91,6 +94,12 @@ class ColorIntelligenceRepositoryImpl @Inject constructor(
                      ColorScienceUtils.calculateDistance(idealHex, invHex) < 40.0 
                  }
              }
+        }
+    }
+
+    override fun getStylistEdit(userSeason: SeasonalType): Flow<StylistEdit> {
+        return getAllInventoryColors().map { inventory ->
+            stylistEditEngine.generateEdit(userSeason, inventory)
         }
     }
 

--- a/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/domain/engine/StylistEditEngine.kt
+++ b/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/domain/engine/StylistEditEngine.kt
@@ -1,0 +1,89 @@
+package com.zoewave.probase.kocolor.features.colors.domain.engine
+
+import com.zoewave.probase.core.model.ritual.SeasonalType
+import com.zoewave.probase.kocolor.features.colors.domain.model.ColorSignature
+import com.zoewave.probase.kocolor.features.colors.domain.model.StylistEdit
+import com.zoewave.probase.kocolor.features.colors.util.ColorScienceUtils
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class StylistEditEngine @Inject constructor() {
+
+    fun generateEdit(userSeason: SeasonalType, inventory: List<ColorSignature>): StylistEdit {
+        val vibe = analyzeVibe(inventory)
+        val gaps = analyzeGaps(userSeason, inventory)
+        
+        val primaryInsight = when (vibe) {
+            InventoryVibe.MINIMALIST -> "Your current collection leans heavily into Cool Neutrals. While sophisticated, it lacks the depth required for high-contrast seasonal styling."
+            InventoryVibe.VIBRANT -> "Your collection is a vibrant explosion of color! To elevate your look, we recommend anchoring these tones with more structured deep neutrals."
+            InventoryVibe.WARM_EARTH -> "You have a beautiful foundation of earthy tones. For your $userSeason profile, adding a few cool-toned highlights will create a more balanced radiance."
+            InventoryVibe.COOL_SOPHISTICATE -> "Your collection is perfectly curated for a cool profile. To add a modern edge, consider integrating a few unexpected pops of high-saturation color."
+        }
+
+        val recColor1 = gaps.getOrNull(0) ?: "#000000"
+        val recColor2 = gaps.getOrNull(1) ?: "#FFFFFF"
+        val name1 = ColorScienceUtils.findNearestPantone(recColor1).name
+        val name2 = ColorScienceUtils.findNearestPantone(recColor2).name
+
+        val recommendation = "Integrating Deep Jewel Tones like $name1 and $name2 will anchor your silhouette and provide a radiant glow against your Roseate Sand undertones."
+
+        return StylistEdit(
+            primaryInsight = primaryInsight,
+            recommendation = recommendation,
+            anchorColors = listOf(recColor1, recColor2)
+        )
+    }
+
+    private fun analyzeVibe(inventory: List<ColorSignature>): InventoryVibe {
+        if (inventory.isEmpty()) return InventoryVibe.MINIMALIST
+        
+        var neutralCount = 0
+        var warmCount = 0
+        var coolCount = 0
+
+        inventory.forEach { sig ->
+            val hsv = ColorScienceUtils.hexToHsv(sig.hex)
+            if (hsv != null) {
+                if (hsv.s < 0.15f) {
+                    neutralCount++
+                } else {
+                    if (hsv.h in 0f..80f || hsv.h in 320f..360f) warmCount++ else coolCount++
+                }
+            }
+        }
+
+        val total = inventory.size.toFloat()
+        return when {
+            neutralCount / total > 0.6f -> InventoryVibe.MINIMALIST
+            warmCount / total > 0.5f -> InventoryVibe.WARM_EARTH
+            coolCount / total > 0.5f -> InventoryVibe.COOL_SOPHISTICATE
+            else -> InventoryVibe.VIBRANT
+        }
+    }
+
+    private fun analyzeGaps(season: SeasonalType, inventory: List<ColorSignature>): List<String> {
+        val idealPalette = getIdealPaletteForSeason(season)
+        val inventoryHexes = inventory.map { it.hex }
+        
+        return idealPalette.filter { idealHex ->
+            inventoryHexes.none { invHex -> 
+                ColorScienceUtils.calculateDistance(idealHex, invHex) < 40.0 
+            }
+        }.take(2)
+    }
+
+    private fun getIdealPaletteForSeason(season: SeasonalType): List<String> {
+        return when (season) {
+            SeasonalType.WINTER -> listOf("#000080", "#800080", "#FF0000", "#006400", "#191970")
+            SeasonalType.SUMMER -> listOf("#ADD8E6", "#E6E6FA", "#FFB6C1", "#98FB98", "#F5F5F5")
+            SeasonalType.AUTUMN -> listOf("#8B4513", "#D2691E", "#CD853F", "#556B2F", "#A52A2A")
+            SeasonalType.SPRING -> listOf("#FFFACD", "#FFA07A", "#FFD700", "#90EE90", "#00CED1")
+            else -> listOf("#000000", "#FFFFFF")
+        }
+    }
+
+    enum class InventoryVibe {
+        MINIMALIST, VIBRANT, WARM_EARTH, COOL_SOPHISTICATE
+    }
+}

--- a/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/domain/model/ColorIntelligence.kt
+++ b/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/domain/model/ColorIntelligence.kt
@@ -21,3 +21,11 @@ enum class SourceType {
     WARDROBE,
     VANITY
 }
+
+data class StylistEdit(
+    val title: String = "The Stylist's Edit",
+    val primaryInsight: String,
+    val recommendation: String,
+    val anchorColors: List<String>,
+    val buttonText: String = "SHOP THE EDIT"
+)

--- a/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/domain/repository/ColorIntelligenceRepository.kt
+++ b/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/domain/repository/ColorIntelligenceRepository.kt
@@ -3,10 +3,12 @@ package com.zoewave.probase.kocolor.features.colors.domain.repository
 import com.zoewave.probase.core.model.ritual.SeasonalType
 import com.zoewave.probase.kocolor.features.colors.domain.model.ColorSignature
 import com.zoewave.probase.kocolor.features.colors.domain.model.HarmonyMode
+import com.zoewave.probase.kocolor.features.colors.domain.model.StylistEdit
 import kotlinx.coroutines.flow.Flow
 
 interface ColorIntelligenceRepository {
     fun getAllInventoryColors(): Flow<List<ColorSignature>>
     fun getColorsByHarmony(baseHex: String, mode: HarmonyMode): Flow<List<ColorSignature>>
     fun getPaletteGaps(userSeason: SeasonalType): Flow<List<String>>
+    fun getStylistEdit(userSeason: SeasonalType): Flow<StylistEdit>
 }


### PR DESCRIPTION
This commit transitions the "Stylist's Edit" section from static mock data to a dynamic editorial engine that generates personalized insights based on the user's color inventory and seasonal profile.

- **Stylist Analysis Engine**:
    - Introduced `StylistEditEngine` to analyze inventory "vibes" (Minimalist, Vibrant, Warm Earth, or Cool Sophisticate) based on hue and saturation distribution.
    - Implemented a gap-analysis algorithm that identifies the two most impactful missing colors for a user's season (e.g., Deep Winter).
    - Integrated `ColorScienceUtils` to provide high-fidelity color names (via Pantone mapping) for personalized recommendations.
- **UI & State Management**:
    - Updated `ColorHubScreen` to dynamically render the edit's title, primary insight, and tailored recommendations.
    - Expanded `ColorHubUiState` and `ColorHubViewModel` to reactively stream stylist data from the repository.
    - Added `StylistEdit` domain model to encapsulate editorial copy and suggested anchor colors.
- **Repository Implementation**:
    - Updated `ColorIntelligenceRepository` to handle the flow of stylist insights by connecting the inventory data to the analysis engine.
- **Documentation**:
    - Added `dynamic_stylist_proposal.md` outlining the analysis pipeline and biological anchoring logic.
    - Updated the color feature walkthrough to reflect the new dynamic capabilities.