### PR TITLE
ui: transition cosmetic UI to landscape aspect ratios and add impleme…

### DIFF
--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticDetailScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticDetailScreen.kt
@@ -268,7 +268,7 @@ fun CosmeticDetailScreen(
                 modifier = Modifier
                     .padding(horizontal = 24.dp, vertical = 8.dp)
                     .fillMaxWidth()
-                    .aspectRatio(1f),
+                    .aspectRatio(4f / 3f),
                 shape = RoundedCornerShape(12.dp),
                 border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFF0F0F0)),
                 color = Color(0xFFFBF8F5)
@@ -279,7 +279,7 @@ fun CosmeticDetailScreen(
                             model = item.imageUrl,
                             contentDescription = item.name,
                             modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(8.dp)),
-                            contentScale = ContentScale.Fit
+                            contentScale = ContentScale.Crop
                         )
                     } else {
                         Icon(Icons.Default.Image, null, modifier = Modifier.size(100.dp), tint = Color.LightGray)

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductGridCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductGridCard.kt
@@ -30,7 +30,7 @@ fun CosmeticProductGridCard(
     val item = uiState
     val onClick = { navTo(KoColorRoute.CosmeticDetail(item.id)) }
     Card(
-        modifier = Modifier.fillMaxWidth().aspectRatio(0.75f).clickable { onClick() },
+        modifier = Modifier.fillMaxWidth().aspectRatio(4f / 3f).clickable { onClick() },
         shape = RoundedCornerShape(24.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {

--- a/server/docs/implementation_plan_images.md
+++ b/server/docs/implementation_plan_images.md
@@ -1,0 +1,19 @@
+# Implementation Plan: KoColor UI Landscape Refinement (Origin-Blind)
+
+Update the cosmetic UI to natively support the new 4:3 landscape professional assets while ensuring a seamless, crop-safe experience for user-captured CameraX images.
+
+## Proposed Changes
+
+### 1. Cosmetic Product Grid
+#### [MODIFY] [CosmeticProductGridCard.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductGridCard.kt)
+- Change `aspectRatio` from `0.75f` (portrait) to **`4f / 3f`** (landscape).
+- Ensure `ContentScale.Crop` is used to prevent letterboxing for non-landscape images.
+
+### 2. Cosmetic Detail Screen
+#### [MODIFY] [CosmeticDetailScreen.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticDetailScreen.kt)
+- Update the hero image container `aspectRatio` from `1f` (square) to **`4f / 3f`**.
+- Switch `ContentScale.Fit` to **`ContentScale.Crop`** to eliminate the checkerboard bars on all asset types.
+
+## Verification Plan
+- Deploy the app and verify the "Glow Catalyst Lip Stain" (CDN) fits perfectly.
+- Take a portrait photo with the camera and verify it is center-cropped to the landscape container without empty gaps.


### PR DESCRIPTION
…ntation plan

This commit updates the cosmetic product displays to support a 4:3 landscape aspect ratio, aligning the UI with professional assets while ensuring a consistent experience for user-captured images.

- **Layout Aspect Ratio Updates**:
    - Modified `CosmeticProductGridCard` to use a `4f / 3f` aspect ratio, moving away from the previous `0.75f` portrait layout.
    - Updated the hero image container in `CosmeticDetailScreen` from a square (`1f`) to a `4f / 3f` landscape ratio.
- **Image Scaling Adjustments**:
    - Changed `contentScale` in `CosmeticDetailScreen` from `Fit` to `Crop` to eliminate letterboxing and ensure images fill the landscape container.
- **Documentation**:
    - Added `implementation_plan_images.md` to document the technical strategy for landscape refinement and origin-blind image handling (professional vs. user-captured).