### PR TITLE
feat: secure payload generation with environment-based key management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ google-services-zoewave.json
 /server/kocolor/starter-pack.json
 /server/kocolor/winter-essentials.json
 /server/kocolor/spring-prep.json
+
+# Security & Keys
+.env
+.env.*

--- a/applications/kocolor/Docs/PackageInvetory/HowToRun.md
+++ b/applications/kocolor/Docs/PackageInvetory/HowToRun.md
@@ -4,15 +4,21 @@ Based on Section 4 of your document, here is exactly how to run the process to c
 
 ### How to Run the Payload Generator
 
-Run these commands in your terminal from the root of your project:
-
+**Step 0: Set Security Keys**
+Before running the generator, you must set your private signing key as an environment variable. Create a `.env` file in `server/kocolor/` or export it in your shell:
 ```bash
-# Navigate to the specific crate directory
+export CDN_PRIVATE_KEY_HEX="your_private_key_hex"
+```
+You can use the provided `.env.example` as a template.
+
+**Step 1: Navigate to the specific crate directory**
+```bash
 cd server/kocolor
+```
 
-# Run the binary that compiles the definitions into JSON
+**Step 2: Run the binary that compiles the definitions into JSON**
+```bash
 cargo run --bin generate_payload
-
 ```
 
 ### What This Command Does

--- a/server/KoColor/src/bin/generate_payload.rs
+++ b/server/KoColor/src/bin/generate_payload.rs
@@ -6,9 +6,12 @@ use p256::ecdsa::{SigningKey, signature::Signer};
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 
 fn main() {
-    // SECP256R1 Private Key (Placeholder - in production use environment variables)
-    let sk_hex = "41f26f634582f3c7e6c4349377833a6b83f3e1b7c02b37a1a1f0a1f0a1f0a1f0";
-    let signing_key = SigningKey::from_slice(&hex::decode(sk_hex).unwrap()).expect("Invalid private key");
+    // SECP256R1 Private Key - Read from environment variable for security
+    let sk_hex = std::env::var("CDN_PRIVATE_KEY_HEX")
+        .expect("ERROR: CDN_PRIVATE_KEY_HEX environment variable not set. Please set your SECP256R1 private key hex.");
+
+    let signing_key = SigningKey::from_slice(&hex::decode(sk_hex).expect("Invalid hex in CDN_PRIVATE_KEY_HEX"))
+        .expect("Invalid private key format");
 
     let full_cosmetics = InventoryRegistry::all_cosmetics();
     let full_clothing = InventoryRegistry::all_clothing();


### PR DESCRIPTION
This commit enhances the security of the payload generation process by removing hardcoded signing keys and transitioning to environment variable configuration.

- **Payload Generator Security**:
    - Updated `generate_payload.rs` to fetch the SECP256R1 private key from the `CDN_PRIVATE_KEY_HEX` environment variable.
    - Implemented explicit error handling and descriptive messages for missing or malformed keys during execution.
- **Documentation & Workflow**:
    - Updated `HowToRun.md` to include a new prerequisite step for setting security keys before running the generator.
    - Provided instructions for using `.env` files or exporting variables in the shell.
- **Repository Hygiene**:
    - Modified `.gitignore` to exclude `.env` and other environment configuration files (`.env.*`) to prevent accidental leakage of sensitive credentials.