### PR TITLE
Ko color sec

### DIFF
--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -1,6 +1,7 @@
 package com.zoewave.probase.kocolor.mobile.ui
 
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -502,6 +503,16 @@ fun koColorNavEntryProvider(
         }
         is KoColorRoute.PackPreview -> NavEntry(route) {
             val viewModel: PackPreviewViewModel = hiltViewModel()
+
+            LaunchedEffect(route.packId) {
+                viewModel.initialize(
+                    packId = route.packId,
+                    targetItemId = route.targetItemId,
+                    sha256 = route.sha256,
+                    publisher = route.publisher
+                )
+            }
+
             val state by viewModel.uiState.collectAsStateWithLifecycle()
             PackPreviewScreen(
                 uiState = state,

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/SearchIndexEntry.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/SearchIndexEntry.kt
@@ -1,5 +1,6 @@
 package com.zoewave.probase.kocolor.features.starterpack.data.remote.model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -7,5 +8,5 @@ data class SearchIndexEntry(
     val id: String,
     val term: String,
     val brand: String,
-    val packId: String
+    @SerialName("pack_id") val packId: String
 )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
@@ -1,6 +1,5 @@
 package com.zoewave.probase.kocolor.features.starterpack.ui
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.kocolor.features.starterpack.data.StarterPackRepository
@@ -22,32 +21,39 @@ data class PackPreviewUiState(
 
 @HiltViewModel
 class PackPreviewViewModel @Inject constructor(
-    private val repository: StarterPackRepository,
-    savedStateHandle: SavedStateHandle
+    private val repository: StarterPackRepository
 ) : ViewModel() {
 
-    private val packId: String = checkNotNull(savedStateHandle["packId"])
-    private val targetItemId: String? = savedStateHandle["targetItemId"]
-    private val sha256: String? = savedStateHandle["sha256"]
-    private val publisher: String? = savedStateHandle["publisher"]
+    private var packId: String? = null
+    private var sha256: String? = null
+    private var publisher: String? = null
 
-    private val _uiState = MutableStateFlow(PackPreviewUiState(targetItemId = targetItemId))
+    private val _uiState = MutableStateFlow(PackPreviewUiState())
     val uiState: StateFlow<PackPreviewUiState> = _uiState.asStateFlow()
 
-    init {
+    fun initialize(packId: String, targetItemId: String?, sha256: String?, publisher: String?) {
+        if (this.packId != null) return // Already initialized
+        
+        this.packId = packId
+        this.sha256 = sha256
+        this.publisher = publisher
+        
+        _uiState.update { it.copy(targetItemId = targetItemId) }
         loadPackItems()
     }
 
     private fun loadPackItems() {
+        val currentPackId = packId ?: return
+        
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             try {
-                val items = repository.getPackItems(packId, sha256, publisher)
-                _uiState.update { 
-                    it.copy(
+                val items = repository.getPackItems(currentPackId, sha256, publisher)
+                _uiState.update { state ->
+                    state.copy(
                         items = items, 
                         isLoading = false,
-                        selectedIds = if (targetItemId != null) setOf(targetItemId) else emptySet()
+                        selectedIds = if (state.targetItemId != null) setOf(state.targetItemId) else emptySet()
                     ) 
                 }
             } catch (e: Exception) {

--- a/server/docs/Security/Full/Info.md
+++ b/server/docs/Security/Full/Info.md
@@ -1,0 +1,138 @@
+Here is the complete architectural documentation detailing the implementation of advanced compression and partner IP protection.
+
+You can save this directly into your repository's `docs/` folder as `ADVANCED_PACKAGING_ARCHITECTURE.md`.
+
+---
+
+# Architecture Extension: Advanced Compression & IP Protection
+
+This document outlines the strategic evolution of the KoColor Secure Package Distribution Platform. It details the transition from raw JSON payloads to a highly compressed, optionally encrypted binary format (`.kpkg`) designed to minimize CDN bandwidth and protect proprietary partner IP (e.g., formulations, AI styling tags) from competitor scraping.
+
+## 1. The Split Architecture (Public vs. Protected)
+
+To maintain a fast, fluid user experience in the Android Glow Sync Hub without decrypting massive payloads on the fly, the architecture splits data into two distinct layers: **Public Metadata** and **Protected Content**.
+
+### The Public Manifest (`manifest.json`)
+
+The manifest remains in **plaintext JSON**. It acts as the public catalog and root of trust, containing enough metadata to render UI previews and power local search without touching the actual package data.
+
+```json
+{
+  "packs": [
+    {
+      "id": "com.kocolor.pack.mac.core",
+      "version": "1.1.0",
+      "publisher": "MAC Cosmetics",
+      "category": "lips",
+      "thumbnail_url": "https://cdn.kocolor.com/assets/mac-core-thumb.webp",
+      "search_tags": ["matte", "ruby woo", "red"], 
+      "sha256": "a1b2c3d4...", 
+      "signature": "e5f6g7h8..."
+    }
+  ]
+}
+
+```
+
+### The Protected Package (`.kpkg`)
+
+The individual package is no longer a raw JSON file. It is a proprietary KoColor Package (`.kpkg`) binary. It contains the heavy, sensitive payload (full ingredients, extended attributes, AI nodes) and is completely unreadable to casual network scanners.
+
+## 2. The `.kpkg` Pipeline Strategy
+
+The system utilizes a sequential pipeline in the Rust Normalization Compiler to transform canonical data into a `.kpkg` file.
+
+### Step 1: Canonicalization (The Foundation)
+
+External vendor data is mapped into the strictly typed `CanonicalPackItem` Rust structs.
+
+### Step 2: Zstandard (zstd) Compression
+
+Instead of relying on HTTP transit compression (Gzip), the Rust compiler applies **Zstandard (zstd)** directly to the byte array.
+
+* **Why Zstd?** It offers 4–6x compression ratios at significantly higher decompression speeds on mobile devices compared to standard Gzip.
+* **Result:** A 5MB JSON cosmetics database becomes a ~800KB binary blob.
+
+### Step 3: AES-256-GCM Encryption (Optional per Partner)
+
+If a partner requires IP protection, the compressed bytes are encrypted using AES-256-GCM.
+
+* **Why GCM?** Galois/Counter Mode provides both data confidentiality and authenticated encryption.
+
+### Step 4: Ed25519 Signing (The Anchor)
+
+The final compressed (and optionally encrypted) byte array is hashed (SHA-256) and signed using the KoColor Ed25519 Private Key. This guarantees the package was not tampered with after compilation.
+
+---
+
+## 3. The End-to-End Flow Diagram
+
+```mermaid
+graph TD
+    subgraph Rust Compiler (Backend)
+        A[Vendor JSON] --> B[Canonical DTO Mapping]
+        B --> C[Serialize to Bytes]
+        C --> D[Zstandard Compression]
+        D --> E{Encrypt?}
+        E -- Yes --> F[AES-256-GCM]
+        E -- No --> G
+        F --> G[SHA-256 Hash]
+        G --> H[Ed25519 Signature]
+        H --> I[Output: .kpkg Binary]
+    end
+
+    subgraph CDN (Cloudflare)
+        I --> J((Cloudflare Edge))
+        M[manifest.json] --> J
+    end
+
+    subgraph Android Client (Zero-Trust Receiver)
+        J --> K[Download .kpkg]
+        K --> L[Verify Ed25519 Signature]
+        L -- Pass --> N{Is Encrypted?}
+        N -- Yes --> O[Fetch AES Key via KMS]
+        O --> P[Decrypt AES-256]
+        N -- No --> Q
+        P --> Q[Decompress Zstd]
+        Q --> R[Deserialize to Kotlin DTO]
+        R --> S[(Room DB @Transaction)]
+        L -- Fail --> T[Throw PackException]
+    end
+
+```
+
+---
+
+## 4. The Encryption Reality: Key Management Service (KMS)
+
+**The Threat Model:**
+If a package is encrypted on the CDN, the Android app requires the symmetric AES decryption key to open it. **Hardcoding this AES key inside the Android APK is a critical security vulnerability.** A malicious actor can decompile the APK, extract the hardcoded key, and decrypt the CDN files.
+
+**The KMS Solution:**
+To achieve true IP protection, KoColor will implement a lightweight Key Management Service (KMS) separated from the static CDN.
+
+1. **Discovery:** The Android app downloads the static `.kpkg` from the free CDN.
+2. **Authentication:** When the user clicks "Import", the app makes an authenticated, lightweight API request to a KoColor server (e.g., Firebase Auth / Cloud Run): *"User 123 is requesting the AES key for pack `kc-001`."*
+3. **Delivery:** The server verifies the user's authorization and returns the specific AES key for that pack.
+4. **Decryption:** The app decrypts the `.kpkg` purely in memory and persists the cleartext data into the local Room Database. The AES key is discarded.
+
+*Note: This keeps 99% of your bandwidth (the heavy packages) on the free CDN, while only routing a few kilobytes of traffic (the AES keys) through your dynamic servers.*
+
+---
+
+## 5. Strategic Implementation Roadmap
+
+This architecture will be implemented in two distinct phases to ensure stability.
+
+### Phase 1: The Compression Era (Bandwidth Optimization)
+
+* **Goal:** Reduce CDN costs and speed up Android import times.
+* **Action (Rust):** Add the `zstd` crate. Update the compiler to compress the payload before signing. Change the output extension to `.kpkg`.
+* **Action (Android):** Add a Zstd JNI library. Update the `SignatureVerifier` to decompress the byte array immediately after validating the Ed25519 signature.
+
+### Phase 2: The Privacy Era (IP Protection)
+
+* **Goal:** Protect sensitive partner data from unauthorized scraping.
+* **Action (Cloud):** Stand up a lightweight KMS endpoint to serve symmetric AES keys to authenticated app users.
+* **Action (Rust):** Add the `aes-gcm` crate. Encrypt the compressed payload before signing.
+* **Action (Android):** Add decryption logic between the Signature Verification and Decompression steps, utilizing the securely fetched KMS keys.

--- a/server/docs/Security/Full/Instructions.md
+++ b/server/docs/Security/Full/Instructions.md
@@ -1,0 +1,43 @@
+Here is the execution-grade prompt to feed directly into your GenAI agent. It specifies the integration of the `zstd` crate for your Rust backend and the `zstd-jni` library for your Android client to establish the secure `.kpkg` binary pipeline.
+
+---
+
+**Copy everything below this line:**
+
+> **Role:** Expert Rust & Android Software Architect and Cryptography Specialist
+> **Context:**
+> We are implementing "Phase 1: The Compression Era" for the KoColor Secure Package Distribution Platform. We are migrating our individual payload files from raw `.json` files to compressed `.kpkg` binaries using Zstandard (zstd) to reduce CDN bandwidth and speed up mobile ingestion. The root `manifest.json` will remain plaintext JSON.
+> **Current Architecture Overview:**
+> 1. Rust normalizes external data into Canonical JSON, hashes the bytes (SHA-256), signs them (Ed25519), and saves as `.json`.
+> 2. Android downloads the `.json` using Retrofit, intercepts the raw bytes, verifies the SHA-256 and Ed25519 signatures using BouncyCastle, and then deserializes to persist atomically in Room.
+>
+>
+> **Task 1: Rust Compiler Setup (`kocolor-compiler`)**
+> * Add the `zstd` crate to `Cargo.toml`.
+> * Modify the Rust pipeline so that *after* serializing the DTOs to JSON bytes, it compresses those bytes using Zstandard.
+> * Calculate the SHA-256 hash and Ed25519 signature on the *compressed* bytes (the zstd output), NOT the plaintext JSON.
+> * Output the final signed payload as a `[package_id].kpkg` binary file instead of `.json`.
+> * Update the `manifest.json` generator to reflect the hash of the compressed `.kpkg` payload.
+>
+>
+> **Task 2: Android Setup (`:features:starterpack`)**
+> * Add the Zstandard JNI dependency to the `build.gradle.kts`: `implementation("com.github.luben:zstd-jni:1.5.5-4")`
+> * Modify the Retrofit `KocolorApiService` to download the `.kpkg` file as a raw `ResponseBody` or `ByteArray`.
+>
+>
+> **Task 3: Android Verification & Decompression**
+> * Update `SignatureVerifier` (and the `StarterPackRepositoryImpl` pipeline) to accept the compressed `.kpkg` byte array.
+> * The integrity (SHA-256) and authenticity (Ed25519 via BouncyCastle) checks must run strictly against the *compressed* bytes.
+> * If verification passes, use `Zstd.decompress` or `ZstdInputStream` to decompress the byte array back into the canonical JSON string.
+> * Pass the decompressed JSON string to the deserializer and commit to the Room database inside an atomic `@Transaction`.
+>
+>
+> **Strict Constraints (CRITICAL):**
+> * **DO NOT** modify any Jetpack Compose UI files.
+> * **DO NOT** break the existing BouncyCastle Ed25519 verifier logic.
+> * **Security Rule:** Verification must happen *before* decompression. You must never decompress an untrusted stream.
+> * **State Management:** Maintain the current atomic Room `@Transaction` for the final data insertion.
+>
+>
+> **Execution Phase:**
+> Please analyze my workspace, identify the `kocolor-compiler` logic and the `StarterPackRepositoryImpl`, and implement these tasks.

--- a/server/package/KoColor/Cargo.lock
+++ b/server/package/KoColor/Cargo.lock
@@ -81,12 +81,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,18 +189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,7 +232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -267,9 +248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -281,20 +260,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
 ]
 
 [[package]]
@@ -317,26 +282,6 @@ dependencies = [
  "ed25519",
  "serde",
  "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "pem-rfc7468",
- "pkcs8",
- "rand_core",
- "sec1",
  "subtle",
  "zeroize",
 ]
@@ -371,16 +316,6 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core",
- "subtle",
-]
 
 [[package]]
 name = "fiat-crypto"
@@ -471,7 +406,6 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -496,17 +430,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -539,15 +462,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "http"
@@ -845,11 +759,9 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "base64 0.21.7",
- "ecdsa",
  "ed25519-dalek",
  "hex",
  "jsonwebtoken",
- "p256",
  "reqwest",
  "serde",
  "serde_json",
@@ -1020,18 +932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,15 +962,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -1115,15 +1006,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1208,16 +1090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,20 +1160,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "security-framework"
@@ -1431,7 +1289,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
  "rand_core",
 ]
 

--- a/server/package/KoColor/manifest.json
+++ b/server/package/KoColor/manifest.json
@@ -1,16 +1,16 @@
 {
-  "signature": "MEUCIQDHHFqIeQH7r8T8w2T8eZVYOHa8muQUyLbKIdcUXsOn4gIgeZYrarnrlYFphVZR5ipHi5PM7Z4wkeAEwqAv4d8rUUw=",
-  "payload": {
+  "data": {
     "packs": [
       {
         "description": "The foundational high-fidelity product library for all users.",
         "endpoint": "starter-pack.json",
         "expires_at": null,
-        "hash": "sha256:abc123full",
         "hero_image_url": null,
-        "id": "starter_pack_v1",
+        "id": "com.kocolor.pack.core",
         "item_count": 9,
         "name": "Core Collection",
+        "publisher": "KoColor Official",
+        "sha256": "a3b1c3ea9172f58e3af515a9dcf4a6665c35035f1fc4f504f364610facc399c3",
         "size_bytes": 1200000,
         "type": "STARTER_PACK",
         "version": 1
@@ -19,11 +19,12 @@
         "description": "Curated seasonal picks for Winter color profiles.",
         "endpoint": "winter-essentials.json",
         "expires_at": null,
-        "hash": "sha256:xyz456winter",
         "hero_image_url": null,
-        "id": "winter_2026_kit",
-        "item_count": 2,
+        "id": "com.kocolor.pack.winter2026",
+        "item_count": 3,
         "name": "Winter 2026 Trend Kit",
+        "publisher": "KoColor Official",
+        "sha256": "483e6805a8cfb84643445d8dd599e0d0bbdbce6e27a91fe77bc58fca03feea76",
         "size_bytes": 450000,
         "type": "SAMPLE_PACK",
         "version": 1
@@ -32,15 +33,19 @@
         "description": "Revitalizing routine for the new season.",
         "endpoint": "spring-prep.json",
         "expires_at": 1748736000000,
-        "hash": "sha256:def789spring",
         "hero_image_url": null,
-        "id": "spring_prep_2026",
+        "id": "com.kocolor.pack.spring2026",
         "item_count": 2,
         "name": "Spring Skin Prep",
+        "publisher": "KoColor Official",
+        "sha256": "197485e6f2e06dd402ffa367739e8116303c5883eccd80301257d125dbbd797c",
         "size_bytes": 320000,
         "type": "SAMPLE_PACK",
         "version": 1
       }
     ]
-  }
+  },
+  "signature": "2e09368c7f6b6624b93a6f88f48acf5bf10b0f403cab4508f9e27c610a7975f3b2085282186f8b7e461bf34a432a5ca339de9d21b5772b549b1b0863d6b2bf0d",
+  "package_version": "1.0.0",
+  "schema_version": 2
 }

--- a/server/package/KoColor/search_index.json
+++ b/server/package/KoColor/search_index.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "kc-cosm-001",
+    "term": "KoColor Purifying Gel Cleanser",
+    "brand": "KoColor",
+    "pack_id": "com.kocolor.pack.core"
+  },
+  {
+    "id": "kc-cosm-002",
+    "term": "KoColor Luminescent C Serum",
+    "brand": "KoColor",
+    "pack_id": "com.kocolor.pack.core"
+  },
+  {
+    "id": "kc-cosm-084",
+    "term": "Anthelios Melt-in Milk Sunscreen",
+    "brand": "La Roche-Posay",
+    "pack_id": "com.kocolor.pack.core"
+  },
+  {
+    "id": "kc-cosm-005",
+    "term": "Glow Catalyst Lip Stain",
+    "brand": "KoColor",
+    "pack_id": "com.kocolor.pack.core"
+  },
+  {
+    "id": "kc-cosm-026",
+    "term": "Blotted Lip",
+    "brand": "ColourPop",
+    "pack_id": "com.kocolor.pack.core"
+  },
+  {
+    "id": "kc-cosm-003",
+    "term": "KoColor Seamless Silk Foundation",
+    "brand": "KoColor",
+    "pack_id": "com.kocolor.pack.core"
+  },
+  {
+    "id": "kc-cosm-004",
+    "term": "KoColor Petal Touch Flush Blush",
+    "brand": "KoColor",
+    "pack_id": "com.kocolor.pack.core"
+  },
+  {
+    "id": "kc-cloth-001",
+    "term": "KoColor Silk Drape Executive Blouse",
+    "brand": "KoColor Studio",
+    "pack_id": "com.kocolor.pack.core"
+  },
+  {
+    "id": "kc-cloth-002",
+    "term": "KoColor Tailored Sculpted Blazer",
+    "brand": "KoColor Studio",
+    "pack_id": "com.kocolor.pack.core"
+  },
+  {
+    "id": "kc-cosm-005",
+    "term": "Glow Catalyst Lip Stain",
+    "brand": "KoColor",
+    "pack_id": "com.kocolor.pack.winter2026"
+  },
+  {
+    "id": "kc-cosm-004",
+    "term": "KoColor Petal Touch Flush Blush",
+    "brand": "KoColor",
+    "pack_id": "com.kocolor.pack.winter2026"
+  },
+  {
+    "id": "kc-cloth-001",
+    "term": "KoColor Silk Drape Executive Blouse",
+    "brand": "KoColor Studio",
+    "pack_id": "com.kocolor.pack.winter2026"
+  },
+  {
+    "id": "kc-cosm-001",
+    "term": "KoColor Purifying Gel Cleanser",
+    "brand": "KoColor",
+    "pack_id": "com.kocolor.pack.spring2026"
+  },
+  {
+    "id": "kc-cosm-002",
+    "term": "KoColor Luminescent C Serum",
+    "brand": "KoColor",
+    "pack_id": "com.kocolor.pack.spring2026"
+  }
+]

--- a/server/package/KoColor/spring-prep.json
+++ b/server/package/KoColor/spring-prep.json
@@ -1,6 +1,5 @@
 {
-  "signature": "MEYCIQCZpc8A2uQCap1qZI/c7urj6c6NvIODID7ubbfpebLLVQIhAJpiuEmB6tHU474DyVFByOWBx062VciKUi/k6HswIa9T",
-  "payload": {
+  "data": {
     "clothing": [],
     "cosmetics": [
       {
@@ -50,6 +49,7 @@
         "shade_name": "Clear Crystal",
         "skin_compatibility": "All Skin Types, Sensitive Skin Safe",
         "temperature": "NEUTRAL",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/purifying_gel_cleanser_thumb.webp",
         "volume": "150ml"
       },
       {
@@ -99,9 +99,13 @@
         "shade_name": "Luminous Glow",
         "skin_compatibility": "Normal, Combination, Dry",
         "temperature": "NEUTRAL",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/luminescent_c_serum_thumb.webp",
         "volume": "30ml"
       }
     ],
     "version": 1
-  }
+  },
+  "signature": "be1772cab743b8207bce190b9d32ac6ba09cce2ee23a4ce08e81231d9a59c913701bc0ba7119a7b6634f18355cd839512bac4393a94948371c2cb7cf9846090a",
+  "package_version": "1.0.0",
+  "schema_version": 2
 }

--- a/server/package/KoColor/starter-pack.json
+++ b/server/package/KoColor/starter-pack.json
@@ -1,6 +1,5 @@
 {
-  "signature": "MEUCIQDge14BhMRi0e7GveCZvxnrbQjRZPen6JxRlPMJF57pjAIgHWuCbzs1Yhl3TGJ3bVrRcNTt0IpmkXKpIsdH2HgTRlw=",
-  "payload": {
+  "data": {
     "clothing": [
       {
         "brand": "KoColor Studio",
@@ -28,6 +27,7 @@
         "price": 185.0,
         "seasonal_palette": "WINTER",
         "size": "M",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/silk_drape_blouse_thumb.webp",
         "vibrant_hex": "#C82333"
       },
       {
@@ -56,6 +56,7 @@
         "price": 340.0,
         "seasonal_palette": "WINTER",
         "size": "M",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/tailored_sculpted_blazer_thumb.webp",
         "vibrant_hex": "#3B474C"
       }
     ],
@@ -107,6 +108,7 @@
         "shade_name": "Clear Crystal",
         "skin_compatibility": "All Skin Types, Sensitive Skin Safe",
         "temperature": "NEUTRAL",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/purifying_gel_cleanser_thumb.webp",
         "volume": "150ml"
       },
       {
@@ -156,6 +158,7 @@
         "shade_name": "Luminous Glow",
         "skin_compatibility": "Normal, Combination, Dry",
         "temperature": "NEUTRAL",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/luminescent_c_serum_thumb.webp",
         "volume": "30ml"
       },
       {
@@ -207,6 +210,7 @@
         "shade_name": "Invisible Shield",
         "skin_compatibility": "Sensitive, All Skin Types, Dermatologist Tested",
         "temperature": "NEUTRAL",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/la_roche_posay_anthelios_melt_in_milk_sunscreen_thumb.webp",
         "volume": "150ml"
       },
       {
@@ -254,6 +258,7 @@
         "shade_name": "Signature Crimson",
         "skin_compatibility": "All Skin Types",
         "temperature": "NEUTRAL",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/signature_crimson_lipstick_thumb.webp",
         "volume": "3.8g"
       },
       {
@@ -298,6 +303,7 @@
         "shade_name": "Bee's Knees Crimson",
         "skin_compatibility": "All Lip Types",
         "temperature": "WARM",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/colourpop_blotted_lip_thumb.webp",
         "volume": "1.0g"
       },
       {
@@ -348,6 +354,7 @@
         "shade_name": "Warm Silk 220W",
         "skin_compatibility": "All Skin Types",
         "temperature": "WARM",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/seamless_silk_foundation_thumb.webp",
         "volume": "30ml"
       },
       {
@@ -394,9 +401,13 @@
         "shade_name": "Warm Rosewood",
         "skin_compatibility": "Dry, Normal, Combination",
         "temperature": "WARM",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/petal_touch_flush_blush_thumb.webp",
         "volume": "8g"
       }
     ],
     "version": 1
-  }
+  },
+  "signature": "8ab5f46375c561ea15111aa63c3b767ed4e3f7aaa0fa496321a1f49c8b9543496334d8d145eb3e2cf80bd75a4158b456323661727d8aa1afc75c9c256830dc01",
+  "package_version": "1.0.0",
+  "schema_version": 2
 }

--- a/server/package/KoColor/winter-essentials.json
+++ b/server/package/KoColor/winter-essentials.json
@@ -1,6 +1,5 @@
 {
-  "signature": "MEYCIQCS+IDevAItMPaL1gGQYSWqcTIi/i4KMnYW9Z96pcDtPwIhAJQIvZl9UJzjNK6DzLiBhKhEmjwT1JoeBBOoGcAdQR9t",
-  "payload": {
+  "data": {
     "clothing": [
       {
         "brand": "KoColor Studio",
@@ -28,6 +27,7 @@
         "price": 185.0,
         "seasonal_palette": "WINTER",
         "size": "M",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/silk_drape_blouse_thumb.webp",
         "vibrant_hex": "#C82333"
       }
     ],
@@ -77,9 +77,60 @@
         "shade_name": "Signature Crimson",
         "skin_compatibility": "All Skin Types",
         "temperature": "NEUTRAL",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/signature_crimson_lipstick_thumb.webp",
         "volume": "3.8g"
+      },
+      {
+        "allergens": [],
+        "batch_code": "KC-2026-B4",
+        "brand": "KoColor",
+        "chemistry_base": "OIL",
+        "color_hex": "#E07A7A",
+        "contains_fragrance": false,
+        "coverage": "MEDIUM",
+        "eco_score": "A",
+        "expiry_date": 1798761600000,
+        "fda_active_ingredients": [],
+        "fda_adverse_event_count": 0,
+        "fda_clinical_warnings": [],
+        "fda_recall_status": "Clear",
+        "fda_top_reactions": [],
+        "finish": "SATIN",
+        "formulation": "CREAM",
+        "hero_ingredient": "Jojoba Seed Oil & Vitamin E",
+        "id": "kc-cosm-004",
+        "image_url": "https://cdn.kocolor.com/inventory/assets/petal_touch_flush_blush.webp",
+        "ingredients": [
+          "Caprylic/Capric Triglyceride",
+          "Simmondsia Chinensis (Jojoba) Seed Oil",
+          "Euphorbia Cerifera (Candelilla) Wax",
+          "Mica",
+          "Red 7 Lake",
+          "Iron Oxides",
+          "Tocopherol"
+        ],
+        "instructions": "Dab onto cheeks using fingertips or a dense blush brush, then diffuse upward toward temples for an elevated lifted look.",
+        "is_cruelty_free": true,
+        "is_fda_checked": true,
+        "is_vegan": true,
+        "macro_category": "Color & Dimension",
+        "micro_category": "BLUSH",
+        "name": "KoColor Petal Touch Flush Blush",
+        "notes": "Nourishing cream blush that melts on contact with skin to produce a dewy, natural-looking flush with buildable pigments.",
+        "pao_months": 18,
+        "price": 36.0,
+        "recycling_instructions": "Compact crafted from 100% PCR aluminum. Place directly in aluminum recycling.",
+        "ritual_placement": "Dimension Application (Step 7)",
+        "shade_name": "Warm Rosewood",
+        "skin_compatibility": "Dry, Normal, Combination",
+        "temperature": "WARM",
+        "thumbnail_url": "https://cdn.kocolor.com/inventory/assets/petal_touch_flush_blush_thumb.webp",
+        "volume": "8g"
       }
     ],
     "version": 1
-  }
+  },
+  "signature": "93745374d94de897d7f2c7202a8c5e71a79f3a6e4416596c48c2b64ce4c9466599f424d1128442dc10ef6fc823b8979bd1fff809f307f1d5511896e4ab3be90b",
+  "package_version": "1.0.0",
+  "schema_version": 2
 }


### PR DESCRIPTION
You are getting these errors because the JSON files currently on your GitHub (the CDN) are still in the old format, while your Android app has been upgraded to the new security and search architecture.
Here is the breakdown of the two issues:
1. MissingFieldException: Field 'packId'
•
The Cause: The  search_index.json on your GitHub uses pack_id (snake_case), but the Kotlin code was looking for packId (camelCase).
•
The Fix: I have updated  SearchIndexEntry.kt to include @SerialName("pack_id"), so it now correctly maps the JSON field to your Kotlin property.
2. IllegalStateException: Required value was null (Crash)
•
The Cause: This was happening in PackPreviewViewModel. It was trying to pull packId from Hilt's SavedStateHandle, but since we are using a custom navigation provider (koColorNavEntryProvider), those arguments weren't being automatically injected.
•
The Fix:
i.
I refactored  PackPreviewViewModel.kt to remove the strict SavedStateHandle requirement and added an initialize(...) method.
ii.
I updated  KoColorNavEntryProvider.kt to explicitly pass the route parameters (packId, sha256, etc.) to the ViewModel using a LaunchedEffect.
🚀 Critical Final Step
To stop the MissingFieldException for the manifest and search index, you must push the new JSON files to GitHub.
Your local Rust compiler has already generated the correct files (I verified this with a cat on your local  manifest.json), but the app is still fetching the old ones from developerY/kc-cdn.