### PR TITLE
Kocolor sev sec

### DIFF
--- a/server/docs/Security/Phase1/implementation_plan_1.md
+++ b/server/docs/Security/Phase1/implementation_plan_1.md
@@ -26,7 +26,10 @@ Migrate the KoColor Secure Package Distribution Platform from plaintext JSON pay
     3. **Hash**: Calculate SHA-256 strictly on the **compressed bytes**.
     4. **Sign**: Generate Ed25519 signature strictly on the **compressed bytes**.
     5. **Output**: Save as `[id].kpkg`.
-- Update manifest generation to point to `.kpkg` endpoints and include the hashes/signatures of the compressed binaries.
+- Update manifest generation:
+    - Point to `.kpkg` endpoints.
+    - Include the hashes/signatures of the compressed binaries.
+    - **Optimization**: Include `uncompressed_size_bytes` for each pack to facilitate safe memory allocation on memory-constrained devices (e.g., Pixel Watch).
 
 ---
 
@@ -44,6 +47,7 @@ Migrate the KoColor Secure Package Distribution Platform from plaintext JSON pay
     2. **Integrity**: Verify SHA-256 hash against the manifest.
     3. **Authenticity**: Verify Ed25519 signature via `SignatureVerifier`.
     4. **Decompress**: Invoke `Zstd.decompress()` ONLY if the above steps pass.
+        - **Memory Safety**: Use `uncompressed_size_bytes` from the manifest to allocate the exact buffer size required, preventing `OutOfMemory` errors on wearables.
     5. **Ingest**: Parse the decompressed JSON and persist to Room in an atomic transaction.
 
 #### [MODIFY] [PackSyncRepositoryImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/repository/PackSyncRepositoryImpl.kt)
@@ -52,6 +56,9 @@ Migrate the KoColor Secure Package Distribution Platform from plaintext JSON pay
 ---
 
 ### [Data Models]
+
+#### [MODIFY] [PackManifest.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackManifest.kt)
+- Add `uncompressed_size_bytes` field to `PackInfo`.
 
 #### [MODIFY] [Provenance.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/Provenance.kt)
 - Ensure the `Provenance` object correctly reflects the verification status of the compressed payload.

--- a/server/docs/Security/Phase1/implementation_plan_1.md
+++ b/server/docs/Security/Phase1/implementation_plan_1.md
@@ -1,0 +1,63 @@
+# Implementation Plan - Phase 1: The Static-First Compression Pipeline
+
+Migrate the KoColor Secure Package Distribution Platform from plaintext JSON payloads to compressed, signed binary packages (`.kpkg`) using Zstandard (zstd) and Ed25519 signatures.
+
+## Architectural Principle
+
+> [!IMPORTANT]
+> **Verify-First Rule**: All binary payloads must be cryptographically verified (SHA-256 integrity + Ed25519 authenticity) before decompression. This provides immunity against "zip bomb" attacks and ensures only trusted data is processed by the client.
+
+## User Review Required
+
+> [!CAUTION]
+> This change introduces a breaking change in the package format. The Rust compiler must be run to generate the new `.kpkg` files before the updated Android client can successfully ingest data.
+
+## Proposed Changes
+
+### [Rust Backend (Compiler)]
+
+#### [MODIFY] [Cargo.toml](file:///Users/developer/AndroidStudioProjects/ProBase/server/package/KoColor/Cargo.toml)
+- Add `zstd = "0.13"` dependency.
+
+#### [MODIFY] [generate_payload.rs](file:///Users/developer/AndroidStudioProjects/ProBase/server/package/KoColor/src/bin/generate_payload.rs)
+- Update `save_signed_payload` to implement the new binary pipeline:
+    1. Minified JSON serialization.
+    2. Zstd compression (level 3).
+    3. SHA-256 hashing of **compressed bytes**.
+    4. Ed25519 signing of **compressed bytes**.
+    5. Save as `[id].kpkg`.
+- Update manifest generation to use `.kpkg` endpoints and include computed hashes/signatures.
+
+---
+
+### [Android Client]
+
+#### [MODIFY] [build.gradle.kts](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/build.gradle.kts)
+- Add `implementation("com.github.luben:zstd-jni:1.5.5-4")`.
+
+#### [MODIFY] [KocolorApiService.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/KocolorApiService.kt)
+- Add `downloadPackageBinary(packId: String): ResponseBody` to fetch the new `.kpkg` artifacts.
+
+#### [MODIFY] [StarterPackRepository.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt)
+- Update `getPackItems` to implement the new verification and decompression pipeline:
+    1. Download raw binary bytes.
+    2. Verify SHA-256 integrity against the manifest.
+    3. Verify Ed25519 authenticity using the existing `SignatureVerifier`.
+    4. Decompress using `Zstd.decompress`.
+    5. Parse JSON and persist to Room.
+
+#### [MODIFY] [PackSyncRepositoryImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/repository/PackSyncRepositoryImpl.kt)
+- Align the legacy ingestion flow with the new `.kpkg` binary verification logic.
+
+## Verification Plan
+
+### Automated Tests
+- Unit tests for the new `Zstd` decompression logic on Android.
+- Verification that tampered `.kpkg` files (incorrect hash or signature) are rejected before decompression.
+
+### Manual Verification
+1. Run the updated Rust compiler to generate `.kpkg` and `manifest.json`.
+2. Push the new files to the local/remote CDN.
+3. Launch the KoColor Android app and navigate to the Sync Hub.
+4. Verify that packs can be searched, previewed, and imported successfully.
+5. Check logcat to confirm that verification occurs before decompression.

--- a/server/docs/Security/Phase1/implementation_plan_1.md
+++ b/server/docs/Security/Phase1/implementation_plan_1.md
@@ -1,63 +1,70 @@
 # Implementation Plan - Phase 1: The Static-First Compression Pipeline
 
-Migrate the KoColor Secure Package Distribution Platform from plaintext JSON payloads to compressed, signed binary packages (`.kpkg`) using Zstandard (zstd) and Ed25519 signatures.
+Migrate the KoColor Secure Package Distribution Platform from plaintext JSON payloads to compressed, signed binary packages (`.kpkg`) using Zstandard (zstd) and Ed25519 signatures. This phase focuses on bandwidth optimization and zero-trust security without requiring dynamic infrastructure.
 
 ## Architectural Principle
 
 > [!IMPORTANT]
-> **Verify-First Rule**: All binary payloads must be cryptographically verified (SHA-256 integrity + Ed25519 authenticity) before decompression. This provides immunity against "zip bomb" attacks and ensures only trusted data is processed by the client.
+> **Verify-First Rule**: All binary payloads must be cryptographically verified (SHA-256 integrity + Ed25519 authenticity) before decompression. This protects against "zip bomb" attacks and ensures that the client only processes trusted, uncorrupted data.
 
 ## User Review Required
 
 > [!CAUTION]
-> This change introduces a breaking change in the package format. The Rust compiler must be run to generate the new `.kpkg` files before the updated Android client can successfully ingest data.
+> This change introduces a breaking update to the package format. The Rust compiler must be executed to generate the new `.kpkg` files before the updated Android client can successfully ingest data.
 
 ## Proposed Changes
 
 ### [Rust Backend (Compiler)]
 
 #### [MODIFY] [Cargo.toml](file:///Users/developer/AndroidStudioProjects/ProBase/server/package/KoColor/Cargo.toml)
-- Add `zstd = "0.13"` dependency.
+- Add `zstd = "0.13"` to the dependencies.
 
 #### [MODIFY] [generate_payload.rs](file:///Users/developer/AndroidStudioProjects/ProBase/server/package/KoColor/src/bin/generate_payload.rs)
-- Update `save_signed_payload` to implement the new binary pipeline:
-    1. Minified JSON serialization.
-    2. Zstd compression (level 3).
-    3. SHA-256 hashing of **compressed bytes**.
-    4. Ed25519 signing of **compressed bytes**.
-    5. Save as `[id].kpkg`.
-- Update manifest generation to use `.kpkg` endpoints and include computed hashes/signatures.
+- Update `save_signed_payload` to implement the new binary transformation pipeline:
+    1. **Serialize**: Minified JSON serialization (`serde_json::to_vec`).
+    2. **Compress**: Zstd compression (level 3).
+    3. **Hash**: Calculate SHA-256 strictly on the **compressed bytes**.
+    4. **Sign**: Generate Ed25519 signature strictly on the **compressed bytes**.
+    5. **Output**: Save as `[id].kpkg`.
+- Update manifest generation to point to `.kpkg` endpoints and include the hashes/signatures of the compressed binaries.
 
 ---
 
 ### [Android Client]
 
 #### [MODIFY] [build.gradle.kts](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/build.gradle.kts)
-- Add `implementation("com.github.luben:zstd-jni:1.5.5-4")`.
+- Add `implementation("com.github.luben:zstd-jni:1.5.5-4")` for high-performance native decompression.
 
 #### [MODIFY] [KocolorApiService.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/KocolorApiService.kt)
-- Add `downloadPackageBinary(packId: String): ResponseBody` to fetch the new `.kpkg` artifacts.
+- Add `downloadPackageBinary(packId: String): ResponseBody` to fetch raw binary data.
 
 #### [MODIFY] [StarterPackRepository.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt)
-- Update `getPackItems` to implement the new verification and decompression pipeline:
-    1. Download raw binary bytes.
-    2. Verify SHA-256 integrity against the manifest.
-    3. Verify Ed25519 authenticity using the existing `SignatureVerifier`.
-    4. Decompress using `Zstd.decompress`.
-    5. Parse JSON and persist to Room.
+- Update `getPackItems` to implement the verified decompression pipeline:
+    1. **Fetch**: Download raw binary bytes (`.kpkg`).
+    2. **Integrity**: Verify SHA-256 hash against the manifest.
+    3. **Authenticity**: Verify Ed25519 signature via `SignatureVerifier`.
+    4. **Decompress**: Invoke `Zstd.decompress()` ONLY if the above steps pass.
+    5. **Ingest**: Parse the decompressed JSON and persist to Room in an atomic transaction.
 
 #### [MODIFY] [PackSyncRepositoryImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/repository/PackSyncRepositoryImpl.kt)
-- Align the legacy ingestion flow with the new `.kpkg` binary verification logic.
+- Align the legacy ingestion logic with the new binary verification pipeline.
+
+---
+
+### [Data Models]
+
+#### [MODIFY] [Provenance.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/Provenance.kt)
+- Ensure the `Provenance` object correctly reflects the verification status of the compressed payload.
 
 ## Verification Plan
 
 ### Automated Tests
-- Unit tests for the new `Zstd` decompression logic on Android.
-- Verification that tampered `.kpkg` files (incorrect hash or signature) are rejected before decompression.
+- **Decompression Unit Tests**: Verify that `Zstd.decompress` correctly restores minified JSON on Android.
+- **Security Rejection Tests**: Confirm that the client throws `PackException.SignatureException` or `PackException.ManifestException` if the binary hash or signature is tampered with, and that decompression is *never* called in these cases.
 
 ### Manual Verification
-1. Run the updated Rust compiler to generate `.kpkg` and `manifest.json`.
-2. Push the new files to the local/remote CDN.
-3. Launch the KoColor Android app and navigate to the Sync Hub.
-4. Verify that packs can be searched, previewed, and imported successfully.
-5. Check logcat to confirm that verification occurs before decompression.
+1. **Run Compiler**: Execute the Rust script and confirm `.kpkg` files are generated.
+2. **Deploy**: Update the local/remote CDN with the new binaries and manifest.
+3. **Android Sync**: Navigate to the Sync Hub in the app and verify search and preview still function.
+4. **Import**: Confirm that importing a pack works end-to-end and data appears in the local inventory.
+5. **Logcat Audit**: Monitor logs to ensure the verification sequence follows the **Integrity -> Authenticity -> Decompression** order.

--- a/server/docs/Security/Phase1/implementation_plan_1.md
+++ b/server/docs/Security/Phase1/implementation_plan_1.md
@@ -1,16 +1,21 @@
 # Implementation Plan - Phase 1: The Static-First Compression Pipeline
 
-Migrate the KoColor Secure Package Distribution Platform from plaintext JSON payloads to compressed, signed binary packages (`.kpkg`) using Zstandard (zstd) and Ed25519 signatures. This phase focuses on bandwidth optimization and zero-trust security without requiring dynamic infrastructure.
+Migrate the KoColor Secure Package Distribution Platform from plaintext JSON payloads to compressed, signed binary packages (`.kpkg`) using Zstandard (zstd) and Ed25519 signatures. This phase focuses on bandwidth optimization and zero-trust security.
+
+> **Package Format Contract**: The `.kpkg` binary is the canonical distribution artifact. Client applications never consume raw vendor JSON or unsigned payloads.
 
 ## Architectural Principle
 
 > [!IMPORTANT]
-> **Verify-First Rule**: All binary payloads must be cryptographically verified (SHA-256 integrity + Ed25519 authenticity) before decompression. This protects against "zip bomb" attacks and ensures that the client only processes trusted, uncorrupted data.
+> **Verify-First Rule**: All binary payloads must be cryptographically verified before decompression. This protects against "zip bomb" attacks and ensures that the client only processes trusted data.
+>
+> *   **SHA-256**: Used for fast integrity checks, identification, CDN deduplication, and quick corruption detection.
+> *   **Ed25519**: Used for authenticity and tamper resistance.
 
 ## User Review Required
 
 > [!CAUTION]
-> This change introduces a breaking update to the package format. The Rust compiler must be executed to generate the new `.kpkg` files before the updated Android client can successfully ingest data.
+> **All package assets must be regenerated using the updated Rust Normalization Compiler before deployment. Legacy JSON payloads are not compatible with the new binary package format.**
 
 ## Proposed Changes
 
@@ -21,15 +26,16 @@ Migrate the KoColor Secure Package Distribution Platform from plaintext JSON pay
 
 #### [MODIFY] [generate_payload.rs](file:///Users/developer/AndroidStudioProjects/ProBase/server/package/KoColor/src/bin/generate_payload.rs)
 - Update `save_signed_payload` to implement the new binary transformation pipeline:
-    1. **Serialize**: Minified JSON serialization (`serde_json::to_vec`).
-    2. **Compress**: Zstd compression (level 3).
-    3. **Hash**: Calculate SHA-256 strictly on the **compressed bytes**.
-    4. **Sign**: Generate Ed25519 signature strictly on the **compressed bytes**.
-    5. **Output**: Save as `[id].kpkg`.
+    1.  **Serialize**: Minified JSON serialization (`serde_json::to_vec`).
+    2.  **Compress**: Zstd compression (level 3).
+    3.  **Hash**: Calculate SHA-256 strictly on the **compressed bytes**.
+    4.  **Sign**: Generate Ed25519 signature strictly on the **compressed bytes**.
+    5.  **Output**: Save as `[id]-[hash].kpkg` for immutable CDN caching.
 - Update manifest generation:
-    - Point to `.kpkg` endpoints.
+    - Point to `.kpkg` endpoints (using immutable hashed filenames).
     - Include the hashes/signatures of the compressed binaries.
-    - **Optimization**: Include `uncompressed_size_bytes` for each pack to facilitate safe memory allocation on memory-constrained devices (e.g., Pixel Watch).
+    - **Optimization**: Include `uncompressed_size_bytes` and `compressed_size_bytes` for each pack to facilitate safe memory allocation and download progress UI.
+    - **Future-proofing**: Include `compression_type` (e.g., `"zstd-v1"`).
 
 ---
 
@@ -39,39 +45,50 @@ Migrate the KoColor Secure Package Distribution Platform from plaintext JSON pay
 - Add `implementation("com.github.luben:zstd-jni:1.5.5-4")` for high-performance native decompression.
 
 #### [MODIFY] [KocolorApiService.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/KocolorApiService.kt)
-- Add `downloadPackageBinary(packId: String): ResponseBody` to fetch raw binary data.
+- Add `downloadPackageBinary(url: String): ResponseBody` to fetch raw binary data using the full URL from the manifest.
 
 #### [MODIFY] [StarterPackRepository.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt)
-- Update `getPackItems` to implement the verified decompression pipeline:
-    1. **Fetch**: Download raw binary bytes (`.kpkg`).
-    2. **Integrity**: Verify SHA-256 hash against the manifest.
-    3. **Authenticity**: Verify Ed25519 signature via `SignatureVerifier`.
-    4. **Decompress**: Invoke `Zstd.decompress()` ONLY if the above steps pass.
-        - **Memory Safety**: Use `uncompressed_size_bytes` from the manifest to allocate the exact buffer size required, preventing `OutOfMemory` errors on wearables.
-    5. **Ingest**: Parse the decompressed JSON and persist to Room in an atomic transaction.
-
-#### [MODIFY] [PackSyncRepositoryImpl.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/repository/PackSyncRepositoryImpl.kt)
-- Align the legacy ingestion logic with the new binary verification pipeline.
+- Rename `getPackItems` to `fetchVerifiedPackage`.
+- Implement the refined verification sequence:
+    1.  **Download**: Stream binary bytes (`.kpkg`).
+    2.  **Verify Manifest**: Ensure the manifest itself is signed and verified.
+    3.  **Verify Package Hash**: Check SHA-256 against the manifest entry.
+    4.  **Verify Signature**: Check Ed25519 authenticity.
+    5.  **Verify Compression Header**: Perform basic sanity check on Zstd magic bytes before invoking JNI.
+    6.  **Decompress**: Invoke `Zstd.decompress()` ONLY if all checks pass.
+        - **Memory Safety**: Use `uncompressed_size_bytes` from the manifest to allocate the exact buffer size required.
+    7.  **Ingest**: Parse the decompressed JSON and persist to Room in an atomic transaction.
 
 ---
 
 ### [Data Models]
 
 #### [MODIFY] [PackManifest.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackManifest.kt)
-- Add `uncompressed_size_bytes` field to `PackInfo`.
+- Add `uncompressed_size_bytes`, `compressed_size_bytes`, and `compression_type` fields to `PackInfo`.
 
 #### [MODIFY] [Provenance.kt](file:///Users/developer/AndroidStudioProjects/ProBase/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/Provenance.kt)
-- Ensure the `Provenance` object correctly reflects the verification status of the compressed payload.
+- Add `contentHash` to track the exact immutable binary identity of the source package.
+
+---
+
+## Failure Handling
+
+| Failure Point | Action |
+| :--- | :--- |
+| **Hash Mismatch** | Reject package immediately. |
+| **Signature Failure** | Reject package immediately. |
+| **Schema Mismatch** | Reject package (unsupported client). |
+| **Decompression Failure** | Reject package (corrupt or malicious). |
+| **Transaction Failure** | Rollback database changes. |
 
 ## Verification Plan
 
 ### Automated Tests
-- **Decompression Unit Tests**: Verify that `Zstd.decompress` correctly restores minified JSON on Android.
-- **Security Rejection Tests**: Confirm that the client throws `PackException.SignatureException` or `PackException.ManifestException` if the binary hash or signature is tampered with, and that decompression is *never* called in these cases.
+- **Decompression Unit Tests**: Verify `Zstd.decompress` restores minified JSON correctly.
+- **Security Rejection Tests**: Verify rejection of tampered hashes, signatures, and malformed headers.
 
 ### Manual Verification
-1. **Run Compiler**: Execute the Rust script and confirm `.kpkg` files are generated.
-2. **Deploy**: Update the local/remote CDN with the new binaries and manifest.
-3. **Android Sync**: Navigate to the Sync Hub in the app and verify search and preview still function.
-4. **Import**: Confirm that importing a pack works end-to-end and data appears in the local inventory.
-5. **Logcat Audit**: Monitor logs to ensure the verification sequence follows the **Integrity -> Authenticity -> Decompression** order.
+1.  **Run Compiler**: Confirm generation of `[id]-[hash].kpkg` and updated `manifest.json`.
+2.  **Deploy**: Update CDN and verify Cloudflare cache performance for hashed filenames.
+3.  **Import**: Confirm end-to-end import on a memory-constrained device (wearable).
+4.  **Audit**: Verify provenance `contentHash` in the Room database matches the manifest.

--- a/server/docs/Security/Phase1/info.md
+++ b/server/docs/Security/Phase1/info.md
@@ -1,0 +1,140 @@
+Here is the definitive architectural and operational guide for building Phase 1.
+
+You can save this directly into your repository's `docs/` folder as `PHASE_1_STATIC_PIPELINE.md`.
+
+---
+
+# Phase 1: The Static-First Compression Pipeline (Zstd + Ed25519)
+
+This document details the exact implementation path for migrating the KoColor Secure Package Distribution Platform from plaintext JSON payloads to highly compressed, cryptographically signed binary packages (`.kpkg`).
+
+This architecture maintains a **$0-budget static infrastructure**. It requires no dynamic servers, KMS, or live backend compute, operating entirely via Rust build-time compilation and Android on-device verification.
+
+## 1. Architectural Objectives
+
+1. **Bandwidth Optimization:** Compress heavy canonical payloads using Zstandard (zstd) to reduce CDN egress costs and accelerate mobile ingestion.
+2. **Zero-Trust Security:** Calculate SHA-256 hashes and Ed25519 signatures strictly against the *compressed* binary sequence.
+3. **Public Cataloging:** Maintain `manifest.json` in plaintext to power the Glow Sync Hub UI and search indexes without forcing the client to download massive data payloads first.
+4. **Static Isolation:** Ensure the CDN remains a pure, dumb file host (Cloudflare Pages/R2).
+
+---
+
+## 2. The Rust Compiler Implementation (`kocolor-compiler`)
+
+The Rust compiler is responsible for aggregating data, applying compression, signing the output, and writing the final `.kpkg` binaries.
+
+### A. Dependencies
+
+Update `Cargo.toml` to include the Zstandard compression library:
+
+```toml
+[dependencies]
+zstd = "0.13" # Adds Zstandard compression
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+ed25519-dalek = "2.0"
+sha2 = "0.10"
+hex = "0.4"
+
+```
+
+### B. The Transformation Pipeline
+
+The compiler's `main.rs` must execute operations in this exact order to prevent signature mismatches:
+
+1. **Serialize DTOs:** Convert the `CanonicalPackItem` vector into a minified JSON string (`serde_json::to_vec`).
+2. **Compress:** Stream the JSON bytes through a Zstd encoder.
+```rust
+let compressed_bytes = zstd::stream::encode_all(json_bytes.as_slice(), 3).unwrap();
+
+```
+
+
+3. **Hash:** Calculate the SHA-256 digest of the `compressed_bytes`.
+4. **Sign:** Generate the Ed25519 signature of the `compressed_bytes`.
+5. **Output:** Write the `compressed_bytes` to disk as `[package_id].kpkg`.
+6. **Manifest:** Write the plaintext `manifest.json`, ensuring the `sha256` and `signature` fields map to the `.kpkg` file, and include UI metadata (`thumbnail_url`, `search_tags`).
+
+---
+
+## 3. The Android Client Implementation (`:features:starterpack`)
+
+The Android application acts as a Zero-Trust Receiver. It intercepts the binary stream, verifies the cryptography, decompresses the payload in memory, and persists it.
+
+### A. Dependencies
+
+Update `build.gradle.kts` to include the Zstandard JNI bindings:
+
+```kotlin
+dependencies {
+    // Cryptography
+    implementation("org.bouncycastle:bcprov-jdk18on:1.77")
+    // Fast native Zstandard decompression
+    implementation("com.github.luben:zstd-jni:1.5.5-4")
+}
+
+```
+
+### B. Network Layer adjustments
+
+Modify the Retrofit `KocolorApiService` to handle raw binary downloads for packages, rather than attempting automatic JSON deserialization.
+
+```kotlin
+@GET("packs/{packId}.kpkg")
+suspend fun downloadPackageBinary(@Path("packId") packId: String): ResponseBody
+
+```
+
+### C. The Verification & Ingestion Pipeline
+
+In `StarterPackRepositoryImpl.kt`, enforce the **Verify-First Rule**. Never decompress a byte array that has not been cryptographically authenticated.
+
+1. **Fetch Manifest:** Download the plaintext `manifest.json`.
+2. **Stream Binary:** Download the `.kpkg` file as a raw `ByteArray`.
+3. **Verify Integrity:** Hash the `ByteArray` and check it against the manifest's SHA-256 string. Fast-fail if mismatched.
+4. **Verify Authenticity:** Pass the `ByteArray` to the BouncyCastle `Ed25519Signer`. Fast-fail if the signature is invalid.
+5. **Decompress:**
+```kotlin
+val decompressedBytes = Zstd.decompress(verifiedByteArray, originalSizeLimit)
+val jsonString = String(decompressedBytes, Charsets.UTF_8)
+
+```
+
+
+6. **Deserialize & Persist:** Parse `jsonString` into `CanonicalPackItem` data classes and insert them into the Room database inside an atomic `@Transaction`.
+
+---
+
+## 4. Security & Safety Invariants
+
+* **Zip Bomb Protection:** By strictly verifying the Ed25519 signature *before* invoking `Zstd.decompress`, the app is immune to malicious actors swapping a legitimate `.kpkg` file on the network with a highly compressed "zip bomb" designed to crash the device's memory.
+* **Deterministic Output:** Ensure the Rust compiler does not inject timestamps or unpredictable metadata into the JSON payload before compression, guaranteeing reproducible hashes.
+* **Key Isolation:** The Android app only ships with `KOCOLOR_ROOT_PUBLIC_KEY`. The private key remains entirely local to the compiler environment.
+
+## 5. Flow Diagram
+
+```mermaid
+graph TD
+    subgraph Rust Compiler
+        A[Canonical JSON Bytes] --> B[Zstd Compression]
+        B --> C[SHA-256 Hash]
+        C --> D[Ed25519 Sign]
+        D --> E[.kpkg Binary File]
+        D --> F[Manifest.json Updater]
+    end
+
+    subgraph Static Infrastructure
+        E --> G((Cloudflare CDN))
+        F --> G
+    end
+
+    subgraph Android Client
+        G --> H[Download .kpkg]
+        H --> I[Verify Ed25519 Signature]
+        I -- Pass --> J[Zstd Decompress]
+        I -- Fail --> K[Throw SecurityException]
+        J --> L[Deserialize JSON]
+        L --> M[(Room @Transaction)]
+    end
+
+```

--- a/server/docs/Security/Phase1/instructions.md
+++ b/server/docs/Security/Phase1/instructions.md
@@ -1,0 +1,49 @@
+Here is the execution-grade prompt to feed directly into your GenAI coding agent (such as Cursor, GitHub Copilot, or Gemini in Android Studio) to implement the Phase 1 static pipeline.
+
+---
+
+**Copy everything below this line:**
+
+> **Role:** You are an Expert Rust & Android Software Architect and Security Engineer operating in Agent Mode.
+> **Context:**
+> We are implementing "Phase 1: The Compression Era" for the KoColor Secure Package Distribution Platform. We are migrating our payload files from plaintext `.json` to highly compressed, signed `.kpkg` binaries using Zstandard (zstd). The infrastructure is strictly static (no backend servers). The root `manifest.json` will remain plaintext JSON.
+> **Task 1: Rust Compiler Implementation (`kocolor-compiler`)**
+> 1. Add `zstd = "0.13"` to the `Cargo.toml` dependencies.
+> 2. Locate the package generation logic in `main.rs`. Modify the pipeline to execute in this exact order:
+> * Serialize the `CanonicalPackItem` DTOs into a minified JSON byte array (`serde_json::to_vec`).
+> * Compress that JSON byte array using `zstd::stream::encode_all(json_bytes, 3)`.
+> * Calculate the SHA-256 hash strictly on the **compressed bytes**.
+> * Calculate the Ed25519 signature strictly on the **compressed bytes** using the loaded private key.
+>
+>
+> 3. Save the compressed bytes to disk as `[package_id].kpkg` (do not save the raw JSON).
+> 4. Ensure the `manifest.json` output correctly reflects the SHA-256 hash and signature of the new `.kpkg` binary, and includes `thumbnail_url` and `search_tags` arrays for UI cataloging.
+>
+>
+> **Task 2: Android Network Layer (`:features:starterpack`)**
+> 1. Add `implementation("com.github.luben:zstd-jni:1.5.5-4")` to the module's `build.gradle.kts`.
+> 2. Update `KocolorApiService.kt` (Retrofit) to fetch the binary. Change the endpoint method to:
+     > `@GET("packs/{packId}.kpkg") suspend fun downloadPackageBinary(@Path("packId") packId: String): ResponseBody`
+>
+>
+> **Task 3: Android Verification & Decompression Pipeline**
+> 1. Locate the package ingestion logic in `StarterPackRepositoryImpl.kt`.
+> 2. Fetch the `manifest.json` to get the expected hash and signature.
+> 3. Download the package binary and extract the raw bytes: `val rawBytes = apiService.downloadPackageBinary(packId).bytes()`.
+> 4. **Enforce Security Pipeline (Order matters!):**
+> * *Check 1 (Integrity):* Calculate the SHA-256 hash of `rawBytes` and compare it to the manifest. If they don't match, throw `PackException.IntegrityException`.
+> * *Check 2 (Authenticity):* Pass `rawBytes` and the expected signature to our existing `SignatureVerifier` (BouncyCastle Ed25519). If it returns false, throw `PackException.SignatureException`.
+> * *Check 3 (Decompression):* ONLY if both checks pass, decompress the bytes using `Zstd.decompress()`. Note: You may need to allocate an appropriately sized buffer or use `ZstdInputStream`.
+>
+>
+> 5. Convert the decompressed bytes into a UTF-8 String, deserialize it into `List<CanonicalPackItem>`, and insert them into the Room Database inside an atomic `@Transaction`.
+>
+>
+> **Strict Constraints (CRITICAL):**
+> * **DO NOT** modify any Jetpack Compose UI files.
+> * **DO NOT** modify the underlying `SignatureVerifier` Ed25519 logic, just pass it the correct compressed byte array.
+> * **Security Rule:** Never decompress a byte array that has not been successfully cryptographically authenticated. This prevents zip-bomb memory attacks.
+>
+>
+> **Execution Phase:**
+> Please analyze my workspace, identify the `kocolor-compiler` pipeline and `StarterPackRepositoryImpl`, and implement these exact steps.


### PR DESCRIPTION
Summary of Updates:
I like this.
The compressed bytes become the canonical artifact.
•
Package Format Contract: Explicitly defined the .kpkg binary as the canonical distribution artifact.
•
Refined Manifest Schema: Added compressed_size_bytes and compression_type (e.g., zstd-v1) to the PackInfo model for better transparency and future-proofing.
Canonical JSON
      ↓
zstd
      ↓
compressed bytes
      ↓
SHA-256
      ↓
Ed25519
•
Immutable Infrastructure: Switched to a hashed filename strategy ([id]-[hash].kpkg) to optimize CDN caching and ensure file uniqueness.
•
Security Sequence Enhancement: Added a "Compression Header" sanity check to the verification pipeline as an extra layer of defense before invoking the JNI decompression.
•
Failure Handling Table: Added a clear mapping of failure points to specific actions (Rejection vs. Rollback).
•
Traceability: Expanded the Provenance model to include contentHash, allowing us to prove the exact origin of every inventory item.
•
Clean Repository Naming: Renamed the core ingestion method to fetchVerifiedPackage() to align with the new package-oriented architecture.
The plan is now highly robust and ready for execution. Please let me know if you are ready to proceed!