### PR TITLE
refactor: migrate Zstd decompression to Airlift Aircompressor in star…

### DIFF
--- a/applications/kocolor/features/starterpack/build.gradle.kts
+++ b/applications/kocolor/features/starterpack/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     implementation(libs.coil.compose)
 
     implementation("org.bouncycastle:bcprov-jdk18on:1.77")
-    implementation("com.github.luben:zstd-jni:1.5.5-4")
+    implementation("io.airlift:aircompressor:2.0.3")
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.Log
 import coil.imageLoader
 import coil.request.ImageRequest
-import com.github.luben.zstd.Zstd
+import io.airlift.compress.zstd.ZstdDecompressor
 import com.zoewave.probase.core.model.ritual.*
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.KocolorApiService
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.*
@@ -135,7 +135,13 @@ class StarterPackRepository @Inject constructor(
 
             // 9. Decompress (Verify-First Rule enforced: decompression ONLY after successful verification)
             val decompressedBytes = try {
-                Zstd.decompress(fileBytes, packInfo.uncompressedSizeBytes.toInt())
+                val decompressor = ZstdDecompressor()
+                val output = ByteArray(packInfo.uncompressedSizeBytes.toInt())
+                decompressor.decompress(
+                    fileBytes, 0, fileBytes.size,
+                    output, 0, output.size
+                )
+                output
             } catch (e: Exception) {
                 throw PackException.IntegrityException("Decompression failed. Binary might be corrupt.")
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ androidxSecurity = "1.1.0"
 
 # -- Background --
 work = "2.11.2"
+zstd-jni = "1.5.7-12"
 
 # -- Networking (Rest & GQL) --
 okhttp = "5.4.0"
@@ -301,6 +302,7 @@ androidx-runner = { group = "androidx.test", name = "runner", version.ref = "run
 androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "androidxProfiling" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "androidxProfiling" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
+zstdJni = { group = "com.github.luben", name = "zstd-jni", version.ref = "zstd-jni" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito-kotlin" }


### PR DESCRIPTION
…ter pack

This commit replaces the JNI-based Zstd decompression library with the Airlift Aircompressor implementation within the starter pack feature to handle package extraction.

- **Decompression Logic Update**:
    - Updated `StarterPackRepository` to use `ZstdDecompressor` instead of `com.github.luben.zstd.Zstd`.
    - Refactored the decompression flow to explicitly allocate a `ByteArray` buffer based on `uncompressedSizeBytes` before decompressing the package data.
- **Dependency Management**:
    - Replaced `zstd-jni` with `io.airlift:aircompressor:2.0.3` in the `starterpack` module `build.gradle.kts`.
    - Updated `libs.versions.toml` to include `zstd-jni` version `1.5.7-12` and added the `zstdJni` library alias to the version catalog for project-wide availability.