### PR TITLE
refactor: switch Zstd decompression library to zstd-jni

### DIFF
--- a/applications/kocolor/features/starterpack/build.gradle.kts
+++ b/applications/kocolor/features/starterpack/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     implementation(libs.coil.compose)
 
     implementation("org.bouncycastle:bcprov-jdk18on:1.77")
-    implementation("io.airlift:aircompressor:2.0.3")
+    implementation(libs.zstdJni)
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.Log
 import coil.imageLoader
 import coil.request.ImageRequest
-import io.airlift.compress.zstd.ZstdDecompressor
+import com.github.luben.zstd.Zstd
 import com.zoewave.probase.core.model.ritual.*
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.KocolorApiService
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.*
@@ -135,13 +135,7 @@ class StarterPackRepository @Inject constructor(
 
             // 9. Decompress (Verify-First Rule enforced: decompression ONLY after successful verification)
             val decompressedBytes = try {
-                val decompressor = ZstdDecompressor()
-                val output = ByteArray(packInfo.uncompressedSizeBytes.toInt())
-                decompressor.decompress(
-                    fileBytes, 0, fileBytes.size,
-                    output, 0, output.size
-                )
-                output
+                Zstd.decompress(fileBytes, packInfo.uncompressedSizeBytes.toInt())
             } catch (e: Exception) {
                 throw PackException.IntegrityException("Decompression failed. Binary might be corrupt.")
             }


### PR DESCRIPTION
This commit replaces the `aircompressor` library with `zstd-jni` for handling Zstd decompression within the starter pack repository. This change simplifies the decompression implementation and adopts a more standard JNI-based approach for handling compressed pack data.

- **Library Migration**:
    - Replaced `io.airlift:aircompressor` with `libs.zstdJni` in `build.gradle.kts`.
- **Decompression Logic Optimization**:
    - Updated `StarterPackRepository` to use `Zstd.decompress` directly.
    - Simplified the decompression process by removing manual `ByteArray` output buffer allocation and `ZstdDecompressor` instantiation, resulting in cleaner and more concise code.