### PR TITLE
build: configure zstd-jni AAR and legacy JNI packaging

### DIFF
--- a/applications/kocolor/features/starterpack/build.gradle.kts
+++ b/applications/kocolor/features/starterpack/build.gradle.kts
@@ -12,6 +12,12 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    packaging {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
 }
 
 dependencies {
@@ -36,7 +42,7 @@ dependencies {
     implementation(libs.coil.compose)
 
     implementation("org.bouncycastle:bcprov-jdk18on:1.77")
-    implementation(libs.zstdJni)
+    implementation("com.github.luben:zstd-jni:1.5.7-12@aar")
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ androidxSecurity = "1.1.0"
 
 # -- Background --
 work = "2.11.2"
-zstd-jni = "1.5.7-12"
+zstd-jni = "1.5.6-3"
 
 # -- Networking (Rest & GQL) --
 okhttp = "5.4.0"


### PR DESCRIPTION
This commit updates the `starterpack` feature to use the AAR distribution of the `zstd-jni` library and enables legacy JNI packaging to ensure proper native library handling.

- **JNI Packaging Configuration**:
    - Enabled `useLegacyPackaging` for `jniLibs` in the `starterpack` module's build configuration.
- **Dependency Management**:
    - Replaced the `libs.zstdJni` catalog reference in the `starterpack` module with a direct dependency on `com.github.luben:zstd-jni:1.5.7-12@aar`.
    - Updated `libs.versions.toml` to downgrade the global `zstd-jni` version from `1.5.7-12` to `1.5.6-3`.