### PR TITLE
refactor: update starter pack schema to v2 and enforce versioning

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
@@ -148,6 +148,10 @@ class StarterPackRepository @Inject constructor(
                 throw PackException.SchemaException("Failed to parse decompressed JSON payload.")
             }
 
+            if (response.schemaVersion > 2) {
+                throw PackException.SchemaException("Payload schema version ${response.schemaVersion} too new for this client.")
+            }
+
             // Flatten items for UI
             response.cosmetics + response.clothing
         } finally {

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackItem.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackItem.kt
@@ -44,7 +44,7 @@ data class PackItem(
 
 @Serializable
 data class RemoteStarterPackResponse(
-    val version: Int,
+    @SerialName("schema_version") val schemaVersion: Int,
     val cosmetics: List<PackItem>,
     val clothing: List<PackItem> = emptyList()
 )

--- a/server/docs/PackageDistribution/KCPS_Product_Authoring_Guide.md
+++ b/server/docs/PackageDistribution/KCPS_Product_Authoring_Guide.md
@@ -8,7 +8,7 @@ All source data should be structured as a `StarterPackResponse`. You can author 
 
 ```json
 {
-  "version": 1,
+  "schema_version": 2,
   "cosmetics": [ ... ],
   "clothing": [ ... ]
 }

--- a/server/docs/PackageDistribution/KCPS_v2_SPEC.md
+++ b/server/docs/PackageDistribution/KCPS_v2_SPEC.md
@@ -5,17 +5,27 @@ This document defines the strict data contract for KoColor Distribution Packages
 **KCPS Version**: 2  
 **`schema_version`**: 2
 
-## 🏗 Package Layout
+After successful verification and decompression, every `.kpkg` package MUST produce exactly one JSON document conforming to this schema.
 
-A compliant `.kpkg` binary, when decompressed, MUST contain a JSON object with the following top-level structure:
+## Decompressed Payload Format
+
+A compliant `.kpkg` payload MUST contain a JSON object with the following top-level structure:
 
 ```json
 {
-  "version": 1,
+  "schema_version": 2,
   "cosmetics": [ ... ],
   "clothing": [ ... ]
 }
 ```
+
+### Payload Invariants
+
+- **Exactly one root JSON object**.
+- **`cosmetics` and `clothing` MUST exist** as top-level arrays.
+- **Arrays MAY be empty**.
+- **Unknown top-level fields MUST be ignored** by the consumer.
+- **Duplicate `id` values MUST NOT exist anywhere** in the package, regardless of whether the items are in the cosmetics or clothing arrays.
 
 ---
 
@@ -34,6 +44,7 @@ A compliant `.kpkg` binary, when decompressed, MUST contain a JSON object with t
 - **Forward Compatibility**: Adding optional fields is backward compatible. Clients MUST ignore unknown fields.
 - **Breaking Changes**: Removing required fields or renaming existing fields requires a new schema version.
 - **Enum Evolution**: Existing enum values MUST NOT change meaning. New enum values MAY only be added in a new schema version.
+- **Enum Philosophy**: Enum values are part of the wire protocol and are case-sensitive. Their serialized names MUST remain stable across compiler implementations.
 
 ---
 
@@ -49,9 +60,9 @@ A compliant `.kpkg` binary, when decompressed, MUST contain a JSON object with t
 | `macro_category` | ✓ | `String` | High-level group. See [Reference Enums](#enums). |
 | `micro_category` | ✓ | `String` | Specific item type. See [Reference Enums](#enums). |
 
-### 3.2 Professional Facets (AI Styling)
+### 3.2 Professional Facets (Cosmetic Items Only)
 
-These fields are **strictly validated** for Cosmetic items.
+These fields are strictly validated for Cosmetic items. **Clothing-only fields MUST NOT appear on cosmetic items.**
 
 | Field | Required | Wire Type | Description |
 | :--- | :--- | :--- | :--- |
@@ -91,7 +102,9 @@ These fields are **strictly validated** for Cosmetic items.
 | `is_vegan` | Optional | `Boolean?` | Contains no animal products. |
 | `is_cruelty_free` | Optional | `Boolean?` | Not tested on animals. |
 
-### 3.6 Wardrobe Metadata (Clothing Only)
+### 3.6 Wardrobe Metadata (Clothing Items Only)
+
+These fields are specific to the Wardrobe Color Engine. **Cosmetic-only fields MUST NOT appear on clothing items.**
 
 | Field | Required | Wire Type | Description |
 | :--- | :--- | :--- | :--- |
@@ -107,7 +120,7 @@ A package (`.kpkg`) MUST be rejected if:
 2. A field type does not match the **Wire Type** specified.
 3. An enum field contains a value not present in the [Reference Enums](#enums).
 4. The `schema_version` of the package is unsupported by the client.
-5. Duplicate `id` values exist within the same package.
+5. Duplicate `id` values exist anywhere in the package.
 6. The `id` or `name` of any item is empty or whitespace only.
 7. Any array contains `null` values.
 8. JSON object keys are not unique.

--- a/server/package/KoColor/src/bin/generate_payload.rs
+++ b/server/package/KoColor/src/bin/generate_payload.rs
@@ -24,7 +24,7 @@ fn main() {
 
     // 1. Generate Full Starter Pack
     let starter_pack = StarterPackResponse {
-        version: 1,
+        schema_version: 2,
         cosmetics: full_cosmetics.clone(),
         clothing: full_clothing.clone(),
     };
@@ -46,7 +46,7 @@ fn main() {
         vec!["kc-cloth-001"]
     );
     let winter_pack = StarterPackResponse {
-        version: 1,
+        schema_version: 2,
         cosmetics: winter_cosm.clone(),
         clothing: winter_cloth.clone(),
     };
@@ -68,7 +68,7 @@ fn main() {
         vec![]
     );
     let spring_pack = StarterPackResponse {
-        version: 1,
+        schema_version: 2,
         cosmetics: spring_cosm.clone(),
         clothing: vec![],
     };

--- a/server/package/KoColor/src/lib.rs
+++ b/server/package/KoColor/src/lib.rs
@@ -12,7 +12,7 @@ pub struct SignedPayloadEnvelope {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StarterPackResponse {
-    pub version: u32,
+    pub schema_version: u32,
     pub cosmetics: Vec<CosmeticItem>,
     pub clothing: Vec<ClothingItem>,
 }
@@ -70,11 +70,11 @@ pub struct CosmeticItem {
     pub micro_category: String,
 
     // Level 3 Professional Facets
-    pub formulation: String,
-    pub chemistry_base: String,
-    pub finish: String,
-    pub coverage: String,
-    pub temperature: String,
+    pub formulation: Option<String>,
+    pub chemistry_base: Option<String>,
+    pub finish: Option<String>,
+    pub coverage: Option<String>,
+    pub temperature: Option<String>,
 
     // UI Visuals
     pub color_hex: String,
@@ -123,9 +123,8 @@ pub struct ClothingItem {
     pub brand: Option<String>,
     pub macro_category: String,
     pub micro_category: String,
-    pub formality: String,
+    pub formality: Option<String>,
     pub color_hex: String,
-    pub size: Option<String>,
     pub material: Option<String>,
     pub price: Option<f64>,
     pub image_url: String,


### PR DESCRIPTION
This commit migrates the starter pack data model to schema version 2, renaming the versioning field and introducing stricter validation logic. It also refactors the Rust models to make certain facet fields optional and aligns the specification documentation with these changes.

- **Schema & Versioning Updates**:
    - Renamed `version` to `schema_version` across Kotlin and Rust models.
    - Updated the Rust payload generator and documentation examples to target schema version 2.
    - Added a client-side check in `StarterPackRepository` to reject payloads with a `schema_version` greater than 2.
- **Model Refinement**:
    - Updated `CosmeticItem` in the Rust library to make professional facets (`formulation`, `finish`, `coverage`, etc.) optional.
    - Updated `ClothingItem` to make `formality` optional and removed the `size` field.
    - Updated Kotlin's `RemoteStarterPackResponse` to use `@SerialName("schema_version")`.
- **Specification & Documentation**:
    - Refined `KCPS_v2_SPEC.md` to include explicit payload invariants, such as mandatory top-level arrays and global `id` uniqueness.
    - Clarified enum stability requirements and case-sensitivity in the wire protocol.
    - Explicitly defined field exclusivity between cosmetic and clothing items in the specification.