### PR TITLE
feat: add package content preview to Sync Hub

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackManifest.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackManifest.kt
@@ -35,5 +35,12 @@ data class PackInfo(
     @SerialName("schema_version") val schemaVersion: Int,
     val encryption: String,
     @SerialName("hero_image_url") val heroImageUrl: String? = null,
-    @SerialName("expires_at") val expiresAt: Long? = null
+    @SerialName("expires_at") val expiresAt: Long? = null,
+    @SerialName("preview_items") val previewItems: List<PreviewItem> = emptyList()
+)
+
+@Serializable
+data class PreviewItem(
+    val name: String,
+    val description: String
 )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/CatalogPackageCard.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/CatalogPackageCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,6 +29,7 @@ fun CatalogPackageCard(
     status: PackStatus,
     onImportClick: () -> Unit,
     onWipeClick: () -> Unit,
+    onInfoClick: () -> Unit,
     isLoading: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -52,6 +54,17 @@ fun CatalogPackageCard(
                     contentScale = ContentScale.Crop
                 )
                 
+                // Info Button
+                IconButton(
+                    onClick = onInfoClick,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp)
+                        .size(24.dp)
+                ) {
+                    Icon(Icons.Default.Info, contentDescription = "Info", tint = Color.Black.copy(alpha = 0.6f))
+                }
+
                 if (status == PackStatus.INSTALLED) {
                     Surface(
                         modifier = Modifier.align(Alignment.TopEnd).padding(8.dp),
@@ -142,6 +155,7 @@ private fun CatalogPackageCardPreview() {
             status = PackStatus.AVAILABLE,
             onImportClick = {},
             onWipeClick = {},
+            onInfoClick = {},
             isLoading = false
         )
     }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/HeroPackageCard.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/HeroPackageCard.kt
@@ -1,8 +1,11 @@
 package com.zoewave.probase.kocolor.features.starterpack.ui.synchub
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -24,7 +27,8 @@ import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackIn
 fun HeroPackageCard(
     pack: PackInfo,
     status: PackStatus,
-    onImportClick: () -> Unit
+    onImportClick: () -> Unit,
+    onInfoClick: () -> Unit
 ) {
     val serifFont = FontFamily.Serif
     val plumColor = Color(0xFF5A3854)
@@ -45,6 +49,17 @@ fun HeroPackageCard(
                 contentScale = ContentScale.Crop
             )
             
+            // Info Button (mockup image_4c0f3c.jpg top right of hero)
+            IconButton(
+                onClick = onInfoClick,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+                    .background(Color.White.copy(alpha = 0.5f), CircleShape)
+            ) {
+                Icon(Icons.Default.Info, contentDescription = "Info", tint = Color.Black)
+            }
+
             // Content Card
             Surface(
                 modifier = Modifier
@@ -134,7 +149,8 @@ private fun HeroPackageCardPreview() {
                 encryption = "none"
             ),
             status = PackStatus.AVAILABLE,
-            onImportClick = {}
+            onImportClick = {},
+            onInfoClick = {}
         )
     }
 }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/PackageInfoDialog.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/PackageInfoDialog.kt
@@ -1,0 +1,149 @@
+package com.zoewave.probase.kocolor.features.starterpack.ui.synchub
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackInfo
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PreviewItem
+
+@Composable
+fun PackageInfoDialog(
+    pack: PackInfo,
+    onDismiss: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .heightIn(max = 600.dp)
+                .padding(16.dp),
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.98f),
+            tonalElevation = 12.dp,
+            shadowElevation = 12.dp
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp)
+            ) {
+                // Header
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = pack.name,
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontFamily = FontFamily.Serif,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = "Collection Contents:",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                    IconButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.offset(x = 12.dp, y = (-12).dp)
+                    ) {
+                        Icon(Icons.Default.Close, contentDescription = "Close")
+                    }
+                }
+                
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Scrollable list of items
+                LazyColumn(
+                    modifier = Modifier.weight(1f, fill = false),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(pack.previewItems) { item ->
+                        Column {
+                            Text(
+                                text = item.name,
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = "- ${item.description}",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+                
+                if (pack.previewItems.isEmpty()) {
+                    Text(
+                        "No item details available for this preview.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+                
+                Text(
+                    text = "Total items: ${pack.itemCount}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PackageInfoDialogPreview() {
+    MaterialTheme {
+        PackageInfoDialog(
+            pack = PackInfo(
+                id = "core",
+                name = "Core Collection",
+                description = "Essentials",
+                version = 1,
+                publisher = "KoColor",
+                packType = "STARTER_PACK",
+                endpoint = "",
+                itemCount = 9,
+                compressedSizeBytes = 0,
+                uncompressedSizeBytes = 0,
+                sha256 = "",
+                signature = "",
+                compressionAlgorithm = "",
+                hashAlgorithm = "",
+                hashEncoding = "",
+                signatureAlgorithm = "",
+                signatureEncoding = "",
+                packageFormatVersion = 1,
+                schemaVersion = 2,
+                encryption = "",
+                previewItems = listOf(
+                    PreviewItem("Iconic Red Lipstick", "Signature Crimson • SATIN • FULL COVERAGE"),
+                    PreviewItem("Luminescent C Serum", "Luminous Glow • RADIANT • SHEER COVERAGE")
+                )
+            ),
+            onDismiss = {}
+        )
+    }
+}

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/SyncHubScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/SyncHubScreen.kt
@@ -1,25 +1,36 @@
 package com.zoewave.probase.kocolor.features.starterpack.ui.synchub
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AutoAwesome
-import androidx.compose.material3.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.kocolor.db.entity.PackStatus
@@ -39,6 +50,7 @@ fun SyncHubScreen(
 ) {
     val serifFont = FontFamily.Serif
     var showWipeConfirmByPackId by remember { mutableStateOf<String?>(null) }
+    var selectedInfoPack by remember { mutableStateOf<PackInfo?>(null) }
 
     if (showWipeConfirmByPackId != null) {
         AlertDialog(
@@ -114,7 +126,8 @@ fun SyncHubScreen(
                     HeroPackageCard(
                         pack = heroPack,
                         status = uiState.installedPacks.find { it.packId == heroPack.id }?.status ?: PackStatus.AVAILABLE,
-                        onImportClick = { onNavigateTo(KoColorRoute.PackPreview(packId = heroPack.id, sha256 = heroPack.sha256, publisher = heroPack.publisher)) }
+                        onImportClick = { onNavigateTo(KoColorRoute.PackPreview(packId = heroPack.id, sha256 = heroPack.sha256, publisher = heroPack.publisher)) },
+                        onInfoClick = { selectedInfoPack = heroPack }
                     )
                 }
             }
@@ -144,6 +157,7 @@ fun SyncHubScreen(
                             status = installed?.status ?: PackStatus.AVAILABLE,
                             onImportClick = { onNavigateTo(KoColorRoute.PackPreview(packId = pack.id, sha256 = pack.sha256, publisher = pack.publisher)) },
                             onWipeClick = { showWipeConfirmByPackId = pack.id },
+                            onInfoClick = { selectedInfoPack = pack },
                             isLoading = uiState.seedingState is SeedingState.Loading,
                             modifier = Modifier.weight(1f)
                         )
@@ -158,6 +172,13 @@ fun SyncHubScreen(
                 Spacer(modifier = Modifier.height(80.dp))
             }
         }
+    }
+
+    selectedInfoPack?.let { pack ->
+        PackageInfoDialog(
+            pack = pack,
+            onDismiss = { selectedInfoPack = null }
+        )
     }
 }
 

--- a/server/package/KoColor/src/bin/generate_payload.rs
+++ b/server/package/KoColor/src/bin/generate_payload.rs
@@ -40,6 +40,8 @@ fn main() {
         "KoColor Official",
         "STARTER_PACK",
         &starter_pack,
+        &full_cosmetics,
+        &full_clothing,
         &signing_key,
         "1.0.0"
     );
@@ -62,6 +64,8 @@ fn main() {
         "KoColor Official",
         "SAMPLE_PACK",
         &winter_pack,
+        &winter_cosm,
+        &winter_cloth,
         &signing_key,
         "1.0.0"
     );
@@ -84,6 +88,8 @@ fn main() {
         "KoColor Official",
         "SAMPLE_PACK",
         &spring_pack,
+        &spring_cosm,
+        &vec![],
         &signing_key,
         "1.0.0"
     );
@@ -118,29 +124,70 @@ fn compile_and_sign_pack<T: serde::Serialize>(
     publisher: &str,
     pack_type: &str,
     payload: &T,
+    cosmetics: &Vec<CosmeticItem>,
+    clothing: &Vec<ClothingItem>,
     signing_key: &SigningKey,
     _package_version: &str
 ) -> PackInfo {
     // 1. Deterministic Minified JSON Serialization
-    // Note: Rust Normalization Compiler is the canonical serializer.
-    // The implementation MUST ensure deterministic field ordering, encoding, and escaping.
     let json_bytes = serde_json::to_vec(payload).expect("Failed to serialize to JSON");
     let uncompressed_size = json_bytes.len() as u64;
 
-    // 2. Zstandard Compression (Level 3 - mobile optimized)
+    // 2. Zstandard Compression
     let compressed_bytes = zstd::stream::encode_all(json_bytes.as_slice(), 3).expect("Failed to compress with zstd");
     let compressed_size = compressed_bytes.len() as u64;
 
-    // 3. Calculate SHA-256 strictly on COMPRESSED bytes
+    // 3. Calculate SHA-256
     let mut hasher = Sha256::new();
     hasher.update(&compressed_bytes);
     let sha256_hex = hex::encode(hasher.finalize());
 
-    // 4. Sign COMPRESSED bytes with Ed25519
+    // 4. Sign
     let signature = signing_key.sign(&compressed_bytes);
     let signature_hex = hex::encode(signature.to_bytes());
 
-    // 5. Save as immutable binary artifact
+    // 5. Build Preview Projection
+    let mut preview_items: Vec<kocolor::PreviewItem> = Vec::new();
+
+    // Add cosmetics to preview
+    for item in cosmetics {
+        let shade = item.shade_name.clone().unwrap_or_else(|| "Standard".to_string());
+        let desc = format!(
+            "{} • {} • {} COVERAGE",
+            shade,
+            item.finish.as_deref().unwrap_or("NATURAL"),
+            item.coverage.as_deref().unwrap_or("MEDIUM")
+        );
+        preview_items.push(kocolor::PreviewItem {
+            name: item.name.clone(),
+            description: desc,
+        });
+    }
+
+    // Add clothing to preview if room
+    for item in clothing {
+        let desc = format!(
+            "{} • {} FORMALITY",
+            item.material.as_deref().unwrap_or("Mixed Fiber"),
+            item.formality.as_deref().unwrap_or("CASUAL")
+        );
+        preview_items.push(kocolor::PreviewItem {
+            name: item.name.clone(),
+            description: desc,
+        });
+    }
+
+    // Cap to 10 items for manifest efficiency
+    let actual_count = preview_items.len();
+    if preview_items.len() > 10 {
+        preview_items.truncate(10);
+        preview_items.push(kocolor::PreviewItem {
+            name: "...".to_string(),
+            description: format!("And {} more high-fidelity items", actual_count - 10),
+        });
+    }
+
+    // 6. Save as immutable binary artifact
     let filename = format!("{}-{}.kpkg", id, sha256_hex);
     let filepath = format!("{}/{}", DIST_DIR, filename);
     let mut file = File::create(&filepath).expect("Failed to create kpkg file");
@@ -154,15 +201,7 @@ fn compile_and_sign_pack<T: serde::Serialize>(
         version: 1,
         pack_type: pack_type.to_string(),
         endpoint: filename,
-        item_count: match serde_json::to_value(payload).unwrap() {
-            serde_json::Value::Object(map) => {
-                let mut count = 0;
-                if let Some(serde_json::Value::Array(v)) = map.get("cosmetics") { count += v.len(); }
-                if let Some(serde_json::Value::Array(v)) = map.get("clothing") { count += v.len(); }
-                count as u32
-            },
-            _ => 0
-        },
+        item_count: (cosmetics.len() + clothing.len()) as u32,
         compressed_size_bytes: compressed_size,
         uncompressed_size_bytes: uncompressed_size,
         sha256: sha256_hex,
@@ -177,6 +216,7 @@ fn compile_and_sign_pack<T: serde::Serialize>(
         encryption: "none".to_string(),
         hero_image_url: None,
         expires_at: if id.contains("spring") { Some(Utc::now().timestamp_millis() as u64 + 7776000000) } else { None },
+        preview_items,
     }
 }
 

--- a/server/package/KoColor/src/lib.rs
+++ b/server/package/KoColor/src/lib.rs
@@ -51,6 +51,13 @@ pub struct PackInfo {
     pub encryption: String,
     pub hero_image_url: Option<String>,
     pub expires_at: Option<u64>,
+    pub preview_items: Vec<PreviewItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PreviewItem {
+    pub name: String,
+    pub description: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
This commit introduces a package preview feature that allows users to view a summary of items within a collection before downloading. It includes updates to the manifest schema, the server-side payload generator, and the mobile UI components.

- **Manifest & Schema Update**:
    - Added a `preview_items` list to the `PackManifest` (Android) and `PackInfo` (Rust) data structures.
    - Defined a `PreviewItem` model consisting of a name and a formatted description.
- **UI Enhancements**:
    - Created `PackageInfoDialog` to display a scrollable list of a package's contents, including item names and key attributes.
    - Added info icons to `HeroPackageCard` and `CatalogPackageCard` to trigger the new preview dialog.
    - Updated `SyncHubScreen` to manage the selection state and visibility of the package info dialog.
- **Payload Generation Logic**:
    - Updated `generate_payload.rs` to automatically build the preview projection from cosmetic and clothing data.
    - Implemented formatted descriptions based on item properties (e.g., finish, coverage, material, and formality).
    - Capped the preview list at 10 items to maintain manifest delivery efficiency, adding a truncation indicator for larger collections.