### PR TITLE
ui: improve header visibility and item formatting in starter pack pre…

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewCategoryHeader.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewCategoryHeader.kt
@@ -24,50 +24,56 @@ fun PackPreviewCategoryHeader(
     onSelectAll: () -> Unit,
     onClear: () -> Unit
 ) {
+    // Top-level surface must be fully opaque to block scrolling items beneath it
     Surface(
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-        shape = RoundedCornerShape(8.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 4.dp)
+        color = MaterialTheme.colorScheme.surface, // 100% opaque surface
+        modifier = Modifier.fillMaxWidth()
     ) {
-        Row(
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f), // Darker darkened transparency
+            shape = RoundedCornerShape(8.dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
+                .padding(vertical = 4.dp)
         ) {
             Row(
-                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
-                    .weight(1f)
-                    .clickable { onToggleCollapse() }
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Icon(
-                    imageVector = if (isCollapsed) Icons.Default.KeyboardArrowRight else Icons.Default.KeyboardArrowDown,
-                    contentDescription = "Expand/Collapse"
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "$categoryName ($selectedCount/$totalCount)",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-
-            Row {
-                TextButton(
-                    onClick = onSelectAll,
-                    contentPadding = PaddingValues(horizontal = 8.dp)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable { onToggleCollapse() }
                 ) {
-                    Text("Select All", style = MaterialTheme.typography.labelMedium)
+                    Icon(
+                        imageVector = if (isCollapsed) Icons.Default.KeyboardArrowRight else Icons.Default.KeyboardArrowDown,
+                        contentDescription = "Expand/Collapse"
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "$categoryName ($selectedCount/$totalCount)",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
                 }
-                TextButton(
-                    onClick = onClear,
-                    contentPadding = PaddingValues(horizontal = 8.dp)
-                ) {
-                    Text("Clear", style = MaterialTheme.typography.labelMedium)
+
+                Row {
+                    TextButton(
+                        onClick = onSelectAll,
+                        contentPadding = PaddingValues(horizontal = 8.dp)
+                    ) {
+                        Text("Select All", style = MaterialTheme.typography.labelMedium)
+                    }
+                    TextButton(
+                        onClick = onClear,
+                        contentPadding = PaddingValues(horizontal = 8.dp)
+                    ) {
+                        Text("Clear", style = MaterialTheme.typography.labelMedium)
+                    }
                 }
             }
         }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
@@ -78,8 +78,15 @@ fun PackPreviewItemRow(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
             )
+            val subtitleText = remember(item.brand, item.shade) {
+                if (!item.shade.isNullOrBlank()) {
+                    "${item.brand} • ${item.shade}"
+                } else {
+                    item.brand
+                }
+            }
             Text(
-                text = "${item.brand} • ${item.shade}",
+                text = subtitleText,
                 style = MaterialTheme.typography.bodyMedium,
                 color = Color.Gray
             )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
@@ -44,6 +44,7 @@ fun PackPreviewScreen(
     }
 
     Scaffold(
+        containerColor = MaterialTheme.colorScheme.surface, // Match opaque headers
         topBar = {
             PackPreviewTopAppBar(
                 onBack = onBack,


### PR DESCRIPTION
…view

This commit enhances the visual clarity of the starter pack preview by fixing sticky header transparency issues and refining the display logic for item metadata.

- **Sticky Header Optimization**:
    - Wrapped `PackPreviewCategoryHeader` in an opaque `Surface` to prevent list items from bleeding through when the header is pinned during scrolling.
    - Increased the header background alpha from 0.5 to 0.8 for better contrast.
    - Explicitly set the `Scaffold` container color in `PackPreviewScreen` to ensure background consistency with the opaque headers.
- **Item Row Refinement**:
    - Updated `PackPreviewItemRow` to conditionally display the shade information, preventing empty separators when only the brand is available.
    - Memoized the subtitle text construction using `remember` to optimize recomposition.