### PR TITLE
docs: define V1 inventory ingestion pipeline and Boutique UI specs

### DIFF
--- a/applications/kocolor/Docs/PackageInvetory/Implementation_V1_Core.md
+++ b/applications/kocolor/Docs/PackageInvetory/Implementation_V1_Core.md
@@ -1,0 +1,68 @@
+# Implementation: V1 Core Ingestion & Boutique UI
+
+This document provides the technical specification for the baseline (Version 1) inventory ingestion pipeline and the premium "Boutique" user interface.
+
+---
+
+## 🏗️ 1. Data Contract (KCPS v1)
+
+We have standardized on the **KoColor Canonical Product Schema (KCPS) Version 1**. This is the source of truth for all data exchange between the Rust backend and the Android app.
+
+### Sealed DTO Hierarchy
+We use a sealed interface to handle polymorphic collections of cosmetics and clothing within a single package.
+
+```kotlin
+@Serializable
+sealed interface PackItemDto {
+    val id: String
+    val name: String
+    val brand: String?
+    val macroCategory: String
+    val microCategory: String
+    val colorHex: String
+    val shadeName: String?
+    val imageUrl: String
+    val thumbnailUrl: String
+    val price: Double?
+    val notes: String?
+}
+
+@Serializable
+data class CosmeticItemDto(...) : PackItemDto
+
+@Serializable
+data class ClothingItemDto(...) : PackItemDto
+```
+
+---
+
+## ⚙️ 2. The Rust Package Compiler (`kocolor-compiler`)
+
+The backend has transitioned from a simple generator to a **Strict Validation Compiler**.
+
+### Key Logic:
+1.  **Strict Type Check**: Validates the source JSON against Rust structs before compilation.
+2.  **Deterministic Serialization**: Instead of hashing raw text, we serialize the Rust struct to a byte vector. This ensures that two JSON files with the same data but different whitespace result in the exact same `.kpkg` hash.
+3.  **Filenaming**: Implements the `com.kocolor.pack.{id}-{sha256}.kpkg` standard.
+4.  **Manifest Auto-Update**: Every build outputs a complete manifest entry ready for the CDN.
+
+**Usage**: `cargo run --bin kocolor-compiler -- build starter-pack ./source.json`
+
+---
+
+## 🎨 3. Boutique Hub UI (Android)
+
+The `SelectItemsScreen` has been refactored for high-fidelity rendering and efficient data management.
+
+### Technical UI Constraints:
+*   **Opaque Sticky Headers**: Category headers use a 100% opaque surface. This prevents "text bleedthrough" where list items remain visible behind the header during scroll.
+*   **Safe String Construction**: Prevents the common "null" string bug. If a product lacks a shade name, the UI renders only the brand.
+*   **Safe Drawing Insets**: All top-level scaffolds apply `Modifier.windowInsetsPadding(WindowInsets.safeDrawing)`, ensuring compatibility with modern edge-to-edge displays and punch-hole cameras.
+*   **State-Aware Selection**: The `Import Selected (X)` button is reactively enabled and updates its count as users tap items across different categories.
+
+---
+
+## 🛠️ Global Reset Policy
+*   **Database Version**: Permanently set to **1** for all pre-release development.
+*   **Migration Ban**: No manual or auto-migrations are allowed. The schema is iterated by wiping and recreating the Version 1 database.
+*   **Protocol Lock**: Only `schema_version = 1` payloads are accepted by the repository.

--- a/applications/kocolor/Docs/PackageInvetory/Walkthrough_V1_Pipeline.md
+++ b/applications/kocolor/Docs/PackageInvetory/Walkthrough_V1_Pipeline.md
@@ -1,0 +1,40 @@
+# Walkthrough: The V1 Inventory Pipeline
+
+This journey follows a product from its initial definition in a JSON source to its final high-fidelity rendering in the KoColor mobile app.
+
+---
+
+## 🏗️ Step 1: Definition
+You define your products in `starter_pack_source.json`. 
+*   Every item belongs to a `macro_category` (e.g., `LIPS`, `COMPLEXION`).
+*   Every item has high-fidelity metadata like `formulation`, `finish`, and `ingredients`.
+
+## ⚙️ Step 2: Compilation
+Run the Rust compiler to transform your JSON into a secure distribution package:
+```bash
+cd server/package/KoColor
+cargo run --bin kocolor-compiler -- build starter-pack ./starter_pack_source.json
+```
+**The Result**: A compressed `.kpkg` file and a new `manifest.json` entry with a valid ECDSA signature and SHA-256 hash.
+
+## 📱 Step 3: Mobile Sync
+Open the KoColor app and navigate to **Settings > Glow Archive Sync**.
+1.  **Manifest Fetch**: The app pings the manifest and displays your packs.
+2.  **Security Check**: The app verifies the signature of the manifest using its native ECDSA engine.
+3.  **Discovery**: You see the "Core Collection" listed with its exact item count (9 items).
+
+## 🛍️ Step 4: Boutique Selection
+Tap on a pack to enter the **Select Items** screen.
+1.  **Categorization**: Products are grouped into "Prep," "Complexion," etc.
+2.  **Granular Choice**: You can "Select All" in the Prep category but choose only specific Lip shades.
+3.  **Visual Proof**: Note that category titles stay at the top as you scroll (Sticky Headers) and background text never bleeds through.
+
+## 💾 Step 5: Ingestion & "Make it Mine"
+Once you hit **Import Selected**:
+1.  **Database Write**: Items are saved to Room with their source tagged (e.g., `sourcePackId = 'starter_pack_v1'`).
+2.  **Personalization**: Go to the product detail screen. Tap **"MAKE IT MINE"**.
+3.  **Safe Clone**: The app creates a personal copy. If you later decide to "Wipe Starter Pack," your cloned version is safe because the app automatically detached its `sourcePackId` during the clone process.
+
+---
+
+**Summary**: You now have a complete, secure, and professional cycle for distributing products to your users with zero manual data entry.


### PR DESCRIPTION
This commit introduces technical documentation for the Version 1 (V1) inventory ingestion pipeline, encompassing the data contract, the Rust package compiler logic, and the high-fidelity Android "Boutique" UI implementation.

- **Data Contract & Protocol (KCPS v1)**:
    - Standardized the KoColor Canonical Product Schema (KCPS) using a sealed interface (`PackItemDto`) for polymorphic handling of cosmetics and clothing.
    - Established a global reset policy: locked schema to `version = 1`, favoring database recreation over migrations during pre-release development.
- **Compiler Architecture**:
    - Defined the `kocolor-compiler` logic, moving from simple generation to a strict validation model.
    - Implemented deterministic serialization by converting Rust structs to byte vectors for consistent SHA-256 hashing.
    - Standardized package naming conventions as `com.kocolor.pack.{id}-{sha256}.kpkg`.
- **Boutique UI Specifications**:
    - Detailed rendering constraints for the `SelectItemsScreen`, including opaque sticky headers to prevent text bleedthrough.
    - Integrated safe drawing insets and reactive selection states for the Android Hub.
    - Documented the "Make it Mine" ingestion flow, which detaches items from source packs via cloning to prevent accidental data loss during pack wipes.
- **Workflow Walkthrough**:
    - Created a step-by-step guide for the V1 pipeline: JSON definition, Rust compilation, ECDSA-verified mobile sync, and granular item selection.