### PR TITLE
refactor: make brand property non-nullable in pack item model

### DIFF
--- a/applications/kocolor/Docs/PackageInvetory/Implementation_V1_Core.md
+++ b/applications/kocolor/Docs/PackageInvetory/Implementation_V1_Core.md
@@ -16,7 +16,7 @@ We use a sealed interface to handle polymorphic collections of cosmetics and clo
 sealed interface PackItemDto {
     val id: String
     val name: String
-    val brand: String?
+    val brand: String
     val macroCategory: String
     val microCategory: String
     val colorHex: String

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackItem.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackItem.kt
@@ -58,7 +58,7 @@ data class CosmeticItemDto(
 data class ClothingItemDto(
     override val id: String,
     override val name: String,
-    override val brand: String?,
+    override val brand: String,
     @SerialName("macro_category") override val macroCategory: String,
     @SerialName("micro_category") override val microCategory: String,
     @SerialName("color_hex") override val colorHex: String,


### PR DESCRIPTION
This commit updates the pack item data structures to treat the `brand` field as a mandatory property. This change ensures consistency between the documentation and the implementation within the starter pack feature.

- **Model Specification Update**:
    - Changed `brand` from nullable (`String?`) to non-nullable (`String`) in the `PackItemDto` definition within `Implementation_V1_Core.md`.
- **Data Model Implementation**:
    - Updated `ClothingItemDto` in `PackItem.kt` to reflect the non-nullable `brand` requirement in the Kotlin implementation.