### PR TITLE
chore: update Kocolor API base URL to distribution directory

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/KocolorApiService.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/KocolorApiService.kt
@@ -30,6 +30,6 @@ interface KocolorApiService {
     suspend fun downloadPackageBinary(@Url url: String): ResponseBody
 
     companion object {
-        const val BASE_URL = "https://cdn.kocolor.com/inventory/"
+        const val BASE_URL = "https://cdn.kocolor.com/inventory/dist/"
     }
 }


### PR DESCRIPTION
This commit updates the base URL for the `KocolorApiService` within the starter pack feature. The endpoint is shifted to the `dist/` subdirectory to align with the current distribution structure on the CDN.

- **API Configuration**:
    - Updated `BASE_URL` in `KocolorApiService` from `https://cdn.kocolor.com/inventory/` to `https://cdn.kocolor.com/inventory/dist/`.