### PR TITLE
refactor: synchronize Core Collection metadata across UI and generator

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/SyncHubScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/SyncHubScreen.kt
@@ -195,7 +195,7 @@ private fun SyncHubScreenPreview() {
                 availablePacks = listOf(
                     PackInfo(
                         id = "com.kocolor.pack.core",
-                        name = "Core Collection",
+                        name = "KoColor Core Collection",
                         description = "The foundational high-fidelity product library.",
                         version = 1,
                         publisher = "KoColor",

--- a/server/package/KoColor/src/bin/generate_payload.rs
+++ b/server/package/KoColor/src/bin/generate_payload.rs
@@ -40,10 +40,20 @@ fn main() {
             let file_stem = path_buf.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown_pack");
 
             // 3. Derive Manifest Metadata from the filename
-            // e.g., "winter_2026.json" -> ID: "com.kocolor.pack.winter-2026", Name: "WINTER 2026"
-            let pack_id = format!("com.kocolor.pack.{}", file_stem.replace("_", "-"));
-            let pack_name = file_stem.replace("_", " ").to_uppercase();
-            let description = format!("Automated compilation of {}.json", file_stem);
+            let (pack_id, pack_name) = if file_stem == "core_collection" {
+                ("com.kocolor.pack.core".to_string(), "KoColor Core Collection".to_string())
+            } else {
+                (
+                    format!("com.kocolor.pack.{}", file_stem.replace("_", "-")),
+                    file_stem.replace("_", " ").to_uppercase()
+                )
+            };
+
+            let description = if file_stem == "core_collection" {
+                "The foundational high-fidelity product library for all users.".to_string()
+            } else {
+                format!("Automated compilation of {}.json", file_stem)
+            };
 
             println!("⚙️  Compiling: {}", path_buf.display());
 


### PR DESCRIPTION
This commit standardizes the naming and metadata for the foundational product library across the Android UI and the payload generation tool. These changes ensure consistency between how the package is identified in the codebase and how it is presented to the user.

- **UI Metadata Update**:
    - Updated `SyncHubScreen.kt` to change the hardcoded pack name from "Core Collection" to "KoColor Core Collection" to match the updated branding.
- **Generator Logic Refinement**:
    - Modified `generate_payload.rs` to include special handling for the `core_collection` file stem.
    - Explicitly mapped `core_collection` to the ID `com.kocolor.pack.core` and a specific high-fidelity description, while maintaining the automated derivation logic for other packs.