### PR TITLE
feat: add wipe action to HeroPackageCard in Sync Hub

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/HeroPackageCard.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/HeroPackageCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.*
@@ -28,7 +29,8 @@ fun HeroPackageCard(
     pack: PackInfo,
     status: PackStatus,
     onImportClick: () -> Unit,
-    onInfoClick: () -> Unit
+    onInfoClick: () -> Unit,
+    onWipeClick: () -> Unit
 ) {
     val serifFont = FontFamily.Serif
     val plumColor = Color(0xFF5A3854)
@@ -49,15 +51,30 @@ fun HeroPackageCard(
                 contentScale = ContentScale.Crop
             )
             
-            // Info Button (mockup image_4c0f3c.jpg top right of hero)
-            IconButton(
-                onClick = onInfoClick,
+            // Action Buttons Container (Top End)
+            Row(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(8.dp)
-                    .background(Color.White.copy(alpha = 0.5f), CircleShape)
+                    .padding(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(Icons.Default.Info, contentDescription = "Info", tint = Color.Black)
+                if (status == PackStatus.INSTALLED) {
+                    IconButton(
+                        onClick = onWipeClick,
+                        modifier = Modifier.background(Color.White.copy(alpha = 0.5f), CircleShape)
+                    ) {
+                        Icon(Icons.Default.Delete, contentDescription = "Wipe", tint = MaterialTheme.colorScheme.error.copy(alpha = 0.8f))
+                    }
+                }
+
+                // Info Button
+                IconButton(
+                    onClick = onInfoClick,
+                    modifier = Modifier.background(Color.White.copy(alpha = 0.5f), CircleShape)
+                ) {
+                    Icon(Icons.Default.Info, contentDescription = "Info", tint = Color.Black)
+                }
             }
 
             // Content Card
@@ -151,7 +168,8 @@ private fun HeroPackageCardPreview() {
             ),
             status = PackStatus.AVAILABLE,
             onImportClick = {},
-            onInfoClick = {}
+            onInfoClick = {},
+            onWipeClick = {}
         )
     }
 }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/SyncHubScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/SyncHubScreen.kt
@@ -131,7 +131,8 @@ fun SyncHubScreen(
                         pack = heroPack,
                         status = uiState.installedPacks.find { it.packId == heroPack.id }?.status ?: PackStatus.AVAILABLE,
                         onImportClick = { onNavigateTo(KoColorRoute.PackPreview(packId = heroPack.id, sha256 = heroPack.sha256, publisher = heroPack.publisher)) },
-                        onInfoClick = { selectedInfoPack = heroPack }
+                        onInfoClick = { selectedInfoPack = heroPack },
+                        onWipeClick = { showWipeConfirmByPackId = heroPack.id }
                     )
                 }
             }


### PR DESCRIPTION
This commit introduces the ability to delete installed packages directly from the hero section of the Sync Hub. A new "Wipe" action button is conditionally displayed when a package is marked as installed, allowing users to trigger a removal confirmation.

- **UI Enhancements**:
    - Refactored the top-right action area in `HeroPackageCard` from a single `IconButton` to a `Row` container to support multiple actions.
    - Integrated `Icons.Default.Delete` to represent the wipe action, styled with a semi-transparent background and error-themed tint.
    - Implemented conditional rendering to ensure the Wipe button only appears for packs with `PackStatus.INSTALLED`.
- **Interaction Logic**:
    - Added an `onWipeClick` lambda to the `HeroPackageCard` component signature.
    - Updated `SyncHubScreen` to wire the wipe action, setting `showWipeConfirmByPackId` to the hero pack's ID when clicked.