### PR TITLE
feat: add collection wipe functionality to pack preview

### DIFF
--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -522,6 +522,7 @@ fun koColorNavEntryProvider(
                 onClearCategory = viewModel::onClearCategory,
                 onSelectAll = viewModel::onSelectAll,
                 onDeselectAll = viewModel::onDeselectAll,
+                onWipeCollection = viewModel::onWipeCollection,
                 onImportSelected = viewModel::onImportSelected,
                 onBack = onBack
             )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
@@ -2,6 +2,7 @@ package com.zoewave.probase.kocolor.features.starterpack.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zoewave.probase.kocolor.db.entity.PackStatus
 import com.zoewave.probase.kocolor.features.starterpack.data.StarterPackRepository
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.ClothingItemDto
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.CosmeticItemDto
@@ -12,6 +13,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -22,6 +24,7 @@ data class PackPreviewUiState(
     val selectedIds: Set<String> = emptySet(),
     val collapsedCategories: Set<String> = emptySet(),
     val isLoading: Boolean = false,
+    val isInstalled: Boolean = false,
     val targetItemId: String? = null
 )
 
@@ -42,6 +45,15 @@ class PackPreviewViewModel @Inject constructor(
         this.packId = packId
         
         _uiState.update { it.copy(targetItemId = targetItemId) }
+        
+        // Check if pack is installed to show Wipe button
+        viewModelScope.launch {
+            syncRepository.getInstalledPacks().collectLatest { installedPacks ->
+                val isInstalled = installedPacks.any { it.packId == packId && it.status == PackStatus.INSTALLED }
+                _uiState.update { it.copy(isInstalled = isInstalled) }
+            }
+        }
+        
         loadPackItems()
     }
 
@@ -131,6 +143,15 @@ class PackPreviewViewModel @Inject constructor(
                 syncRepository.importSelectedItems(currentPackId, payload)
                 _uiState.update { it.copy(isLoading = false) }
             }
+        }
+    }
+
+    fun onWipeCollection() {
+        val currentPackId = packId ?: return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            syncRepository.wipePack(currentPackId)
+            _uiState.update { it.copy(isLoading = false) }
         }
     }
 }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
@@ -8,12 +8,15 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.CosmeticItemDto
@@ -30,10 +33,37 @@ fun PackPreviewScreen(
     onClearCategory: (String) -> Unit,
     onSelectAll: () -> Unit,
     onDeselectAll: () -> Unit,
+    onWipeCollection: () -> Unit,
     onImportSelected: () -> Unit,
     onBack: () -> Unit
 ) {
     val listState = rememberLazyListState()
+    var showWipeConfirm by remember { mutableStateOf(false) }
+
+    if (showWipeConfirm) {
+        AlertDialog(
+            onDismissRequest = { showWipeConfirm = false },
+            title = { Text("Wipe this Collection?", fontFamily = FontFamily.Serif, fontWeight = FontWeight.Bold) },
+            text = { Text("This will permanently remove all items from this collection. Your personal 'Make it Mine' items are safe.") },
+            confirmButton = {
+                TextButton(
+                    onClick = { 
+                        onWipeCollection()
+                        showWipeConfirm = false
+                    },
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                ) {
+                    Text("WIPE DATA", fontWeight = FontWeight.Black)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showWipeConfirm = false }) {
+                    Text("CANCEL")
+                }
+            },
+            shape = RoundedCornerShape(28.dp)
+        )
+    }
 
     LaunchedEffect(uiState.targetItemId) {
         val targetId = uiState.targetItemId
@@ -54,7 +84,9 @@ fun PackPreviewScreen(
             PackPreviewTopAppBar(
                 onBack = onBack,
                 onSelectAll = onSelectAll,
-                onClear = onDeselectAll
+                onClear = onDeselectAll,
+                onWipe = { showWipeConfirm = true },
+                isWipeVisible = uiState.isInstalled
             )
         },
         bottomBar = {
@@ -191,6 +223,7 @@ private fun PackPreviewScreenPreview() {
             onClearCategory = {},
             onSelectAll = {},
             onDeselectAll = {},
+            onWipeCollection = {},
             onImportSelected = {},
             onBack = {}
         )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewTopAppBar.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewTopAppBar.kt
@@ -3,6 +3,7 @@ package com.zoewave.probase.kocolor.features.starterpack.ui.packpreview
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontFamily
@@ -14,7 +15,9 @@ import androidx.compose.ui.tooling.preview.Preview
 fun PackPreviewTopAppBar(
     onBack: () -> Unit,
     onSelectAll: () -> Unit,
-    onClear: () -> Unit
+    onClear: () -> Unit,
+    onWipe: () -> Unit,
+    isWipeVisible: Boolean = false
 ) {
     val serifFont = FontFamily.Serif
 
@@ -39,6 +42,15 @@ fun PackPreviewTopAppBar(
             }
         },
         actions = {
+            if (isWipeVisible) {
+                IconButton(onClick = onWipe) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Wipe",
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
             TextButton(onClick = onSelectAll) {
                 Text("Select All", style = MaterialTheme.typography.labelMedium)
             }
@@ -56,7 +68,9 @@ private fun PackPreviewTopAppBarPreview() {
         PackPreviewTopAppBar(
             onBack = {},
             onSelectAll = {},
-            onClear = {}
+            onClear = {},
+            onWipe = {},
+            isWipeVisible = true
         )
     }
 }


### PR DESCRIPTION
This commit introduces the ability for users to wipe an installed collection directly from the pack preview screen. It includes a confirmation workflow to prevent accidental data loss and updates the UI to dynamically show the wipe action based on the pack's installation status.

- **UI Enhancements**:
    - Added a `Delete` icon button to the `PackPreviewTopAppBar` that appears only when the pack is currently installed.
    - Implemented a confirmation `AlertDialog` in `PackPreviewScreen` that warns users about permanent removal before proceeding with the wipe.
- **ViewModel & State Logic**:
    - Updated `PackPreviewUiState` to include an `isInstalled` flag.
    - Modified `PackPreviewViewModel` to observe the installation status of the current pack using `syncRepository.getInstalledPacks()`.
    - Added `onWipeCollection` to the ViewModel to handle the asynchronous removal process via the repository.
- **Navigation Integration**:
    - Updated `KoColorNavEntryProvider` to wire the new `onWipeCollection` action from the ViewModel to the `PackPreviewScreen`.