### PR TITLE
feat: update installed pack status upon synchronization

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/repository/PackSyncRepositoryImpl.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/repository/PackSyncRepositoryImpl.kt
@@ -102,7 +102,22 @@ class PackSyncRepositoryImpl @Inject constructor(
             cosmeticDao.insertCosmetics(cosmeticEntities)
             clothingDao.insertClothingList(clothingEntities)
 
-            // 5. Pre-fetch Images (Post-ingestion)
+            // 5. Update Installed Pack status so it appears as "Installed" in Hub/Preview
+            installedPackDao.insertPack(InstalledPackEntity(
+                packId = packInfo.id,
+                name = packInfo.name,
+                description = packInfo.description,
+                version = packInfo.version,
+                status = PackStatus.INSTALLED,
+                itemCount = packInfo.itemCount,
+                sizeBytes = packInfo.compressedSizeBytes,
+                hash = packInfo.sha256,
+                packageHash = packInfo.sha256,
+                heroImageUrl = packInfo.heroImageUrl,
+                expiresAt = packInfo.expiresAt
+            ))
+
+            // 6. Pre-fetch Images (Post-ingestion)
             starterPackRepository.prefetchImages(payload)
         }
     }


### PR DESCRIPTION
This commit integrates a step into the pack synchronization process to record the pack's installation status. By inserting the pack metadata into the local database after data ingestion, the system correctly reflects its "Installed" state in the UI.

- **Sync Process Update**:
    - Updated `PackSyncRepositoryImpl` to insert an `InstalledPackEntity` into `installedPackDao` after successful ingestion of cosmetic and clothing data.
    - Configured the entity with metadata from `packInfo`, including `packId`, `version`, `itemCount`, and `PackStatus.INSTALLED`.
- **UI State Consistency**:
    - Ensures that synchronized packs are immediately recognized as installed by the Hub and Preview components before starting image pre-fetching.