### PR TITLE
feat: relocate collection wipe action to pack preview bottom bar

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewBottomBar.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewBottomBar.kt
@@ -2,8 +2,11 @@ package com.zoewave.probase.kocolor.features.starterpack.ui.packpreview
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -14,23 +17,49 @@ import androidx.compose.ui.unit.dp
 fun PackPreviewBottomBar(
     selectedCount: Int,
     isLoading: Boolean,
-    onImportSelected: () -> Unit
+    onImportSelected: () -> Unit,
+    onWipe: () -> Unit,
+    isWipeVisible: Boolean = false
 ) {
     Surface(
         tonalElevation = 8.dp,
         shadowElevation = 8.dp
     ) {
-        Box(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp)
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
+            if (isWipeVisible) {
+                Button(
+                    onClick = onWipe,
+                    modifier = Modifier
+                        .size(height = 56.dp, width = 64.dp),
+                    shape = RoundedCornerShape(20.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.2f),
+                        contentColor = MaterialTheme.colorScheme.error
+                    ),
+                    contentPadding = PaddingValues(0.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Wipe Collection",
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
+
             Button(
                 onClick = onImportSelected,
-                modifier = Modifier.fillMaxWidth().height(56.dp),
+                modifier = Modifier
+                    .weight(1f)
+                    .height(56.dp),
                 enabled = selectedCount > 0 && !isLoading,
-                shape = RoundedCornerShape(28.dp), // Pill shape like in mockup
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF745E7A).copy(alpha = 0.6f)) // Subdued luxury plum
+                shape = RoundedCornerShape(28.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF745E7A).copy(alpha = 0.8f))
             ) {
                 if (isLoading) {
                     CircularProgressIndicator(modifier = Modifier.size(24.dp), color = Color.White)
@@ -54,7 +83,9 @@ private fun PackPreviewBottomBarPreview() {
         PackPreviewBottomBar(
             selectedCount = 4,
             isLoading = false,
-            onImportSelected = {}
+            onImportSelected = {},
+            onWipe = {},
+            isWipeVisible = true
         )
     }
 }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
@@ -84,16 +84,16 @@ fun PackPreviewScreen(
             PackPreviewTopAppBar(
                 onBack = onBack,
                 onSelectAll = onSelectAll,
-                onClear = onDeselectAll,
-                onWipe = { showWipeConfirm = true },
-                isWipeVisible = uiState.isInstalled
+                onClear = onDeselectAll
             )
         },
         bottomBar = {
             PackPreviewBottomBar(
                 selectedCount = uiState.selectedIds.size,
                 isLoading = uiState.isLoading,
-                onImportSelected = onImportSelected
+                onImportSelected = onImportSelected,
+                onWipe = { showWipeConfirm = true },
+                isWipeVisible = uiState.isInstalled
             )
         }
     ) { padding ->

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewTopAppBar.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewTopAppBar.kt
@@ -15,9 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 fun PackPreviewTopAppBar(
     onBack: () -> Unit,
     onSelectAll: () -> Unit,
-    onClear: () -> Unit,
-    onWipe: () -> Unit,
-    isWipeVisible: Boolean = false
+    onClear: () -> Unit
 ) {
     val serifFont = FontFamily.Serif
 
@@ -42,15 +40,6 @@ fun PackPreviewTopAppBar(
             }
         },
         actions = {
-            if (isWipeVisible) {
-                IconButton(onClick = onWipe) {
-                    Icon(
-                        imageVector = Icons.Default.Delete,
-                        contentDescription = "Wipe",
-                        tint = MaterialTheme.colorScheme.error
-                    )
-                }
-            }
             TextButton(onClick = onSelectAll) {
                 Text("Select All", style = MaterialTheme.typography.labelMedium)
             }
@@ -68,9 +57,7 @@ private fun PackPreviewTopAppBarPreview() {
         PackPreviewTopAppBar(
             onBack = {},
             onSelectAll = {},
-            onClear = {},
-            onWipe = {},
-            isWipeVisible = true
+            onClear = {}
         )
     }
 }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/CatalogPackageCard.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/CatalogPackageCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -28,7 +27,6 @@ fun CatalogPackageCard(
     pack: PackInfo,
     status: PackStatus,
     onImportClick: () -> Unit,
-    onWipeClick: () -> Unit,
     onInfoClick: () -> Unit,
     isLoading: Boolean,
     modifier: Modifier = Modifier
@@ -110,15 +108,6 @@ fun CatalogPackageCard(
                     ) {
                         Text(if (status == PackStatus.INSTALLED) "PREVIEW" else "IMPORT", fontSize = 12.sp, fontWeight = FontWeight.Bold)
                     }
-                    
-                    if (status == PackStatus.INSTALLED) {
-                        IconButton(
-                            onClick = onWipeClick,
-                            modifier = Modifier.size(36.dp)
-                        ) {
-                            Icon(Icons.Default.Delete, null, modifier = Modifier.size(20.dp), tint = Color.Gray)
-                        }
-                    }
                 }
             }
         }
@@ -154,7 +143,6 @@ private fun CatalogPackageCardPreview() {
             ),
             status = PackStatus.AVAILABLE,
             onImportClick = {},
-            onWipeClick = {},
             onInfoClick = {},
             isLoading = false
         )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/HeroPackageCard.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/HeroPackageCard.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.*
@@ -29,8 +28,7 @@ fun HeroPackageCard(
     pack: PackInfo,
     status: PackStatus,
     onImportClick: () -> Unit,
-    onInfoClick: () -> Unit,
-    onWipeClick: () -> Unit
+    onInfoClick: () -> Unit
 ) {
     val serifFont = FontFamily.Serif
     val plumColor = Color(0xFF5A3854)
@@ -51,30 +49,15 @@ fun HeroPackageCard(
                 contentScale = ContentScale.Crop
             )
             
-            // Action Buttons Container (Top End)
-            Row(
+            // Info Button (mockup image_4c0f3c.jpg top right of hero)
+            IconButton(
+                onClick = onInfoClick,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                    .padding(8.dp)
+                    .background(Color.White.copy(alpha = 0.5f), CircleShape)
             ) {
-                if (status == PackStatus.INSTALLED) {
-                    IconButton(
-                        onClick = onWipeClick,
-                        modifier = Modifier.background(Color.White.copy(alpha = 0.5f), CircleShape)
-                    ) {
-                        Icon(Icons.Default.Delete, contentDescription = "Wipe", tint = MaterialTheme.colorScheme.error.copy(alpha = 0.8f))
-                    }
-                }
-
-                // Info Button
-                IconButton(
-                    onClick = onInfoClick,
-                    modifier = Modifier.background(Color.White.copy(alpha = 0.5f), CircleShape)
-                ) {
-                    Icon(Icons.Default.Info, contentDescription = "Info", tint = Color.Black)
-                }
+                Icon(Icons.Default.Info, contentDescription = "Info", tint = Color.Black)
             }
 
             // Content Card
@@ -168,8 +151,7 @@ private fun HeroPackageCardPreview() {
             ),
             status = PackStatus.AVAILABLE,
             onImportClick = {},
-            onInfoClick = {},
-            onWipeClick = {}
+            onInfoClick = {}
         )
     }
 }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/SyncHubScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/SyncHubScreen.kt
@@ -131,8 +131,7 @@ fun SyncHubScreen(
                         pack = heroPack,
                         status = uiState.installedPacks.find { it.packId == heroPack.id }?.status ?: PackStatus.AVAILABLE,
                         onImportClick = { onNavigateTo(KoColorRoute.PackPreview(packId = heroPack.id, sha256 = heroPack.sha256, publisher = heroPack.publisher)) },
-                        onInfoClick = { selectedInfoPack = heroPack },
-                        onWipeClick = { showWipeConfirmByPackId = heroPack.id }
+                        onInfoClick = { selectedInfoPack = heroPack }
                     )
                 }
             }
@@ -161,7 +160,6 @@ fun SyncHubScreen(
                             pack = pack,
                             status = installed?.status ?: PackStatus.AVAILABLE,
                             onImportClick = { onNavigateTo(KoColorRoute.PackPreview(packId = pack.id, sha256 = pack.sha256, publisher = pack.publisher)) },
-                            onWipeClick = { showWipeConfirmByPackId = pack.id },
                             onInfoClick = { selectedInfoPack = pack },
                             isLoading = uiState.seedingState is SeedingState.Loading,
                             modifier = Modifier.weight(1f)


### PR DESCRIPTION
This commit centralizes the "wipe collection" functionality by moving the delete action from the top app bar and catalog cards into the pack preview screen's bottom bar. This adjustment streamlines the user interface by keeping destructive actions localized within the preview context.

- **Pack Preview UI Refactoring**:
    - Added a dedicated wipe (delete) button to `PackPreviewBottomBar`, styled with the theme's error container color.
    - Updated `PackPreviewBottomBar` to use a `Row` layout, allowing the import button to occupy the remaining space alongside the new wipe action.
    - Increased the background opacity of the primary import button for better visual prominence.
    - Removed the wipe action from `PackPreviewTopAppBar`.
- **Sync Hub Simplification**:
    - Removed the individual wipe/delete icon buttons from `HeroPackageCard` and `CatalogPackageCard`.
    - Simplified the action button container in `HeroPackageCard` to only display the info button.
- **State Management**:
    - Updated `PackPreviewScreen` to pass the `isInstalled` state and wipe callback to the bottom bar instead of the top app bar.