### PR TITLE
docs: update compiler walkthrough documentation

### DIFF
--- a/applications/kocolor/Docs/Specification/Walkthrough.md
+++ b/applications/kocolor/Docs/Specification/Walkthrough.md
@@ -15,8 +15,6 @@ You no longer modify code to add inventory. Products are defined in **KCPS v1** 
 When you run `./runMe.sh`, the **`kocolor-compiler`** performs expert-level science before the data reaches the user:
 *   **Colorimetry**: Translates sRGB hex codes into the **CIELAB** ($L^*a^*b^*$) 3D color space (D65 Illuminant).
 *   **Thermodynamics**: Maps chemical bases to professional phases (e.g., `SILICONE` → `HYDROPHOBIC_SILOXANE`) to pre-calculate pilling risks.
-*   **Visuals**: Generates **BlurHash** color-accurate placeholders for all product thumbnails.
-*   **Safety**: Tokenizes ingredient lists into binary safety flags (e.g., Silicone-Free, Paraben-Free).
 
 ### 3. Distribution Security (Zero-Trust)
 The compiler transforms the raw JSON into secure binary artifacts:


### PR DESCRIPTION
This commit updates the `kocolor-compiler` walkthrough specification to reflect changes in the processing pipeline by removing deprecated or removed features.

- **Compiler Specification Refinement**:
    - Removed the "Visuals" section describing the generation of BlurHash color-accurate placeholders for product thumbnails.
    - Removed the "Safety" section describing the tokenization of ingredient lists into binary safety flags.