### PR TITLE
docs: refine ProductGen specification for build determinism and metad…

### DIFF
--- a/applications/kocolor/Docs/Specification/ProductGen/implementation.md
+++ b/applications/kocolor/Docs/Specification/ProductGen/implementation.md
@@ -30,6 +30,7 @@ The compiler will transition to a two-pass system:
 ### B. Asset Optimization Pipeline (`rayon` integrated)
 *   **Hero Stream**: Process 1:1 PNGs -> Resize to 1024x1024 -> Lossy WebP (85%).
 *   **Thumbnail Stream**: Resize to 256x256 -> Generate 4x4 Base83 BlurHash string.
+*   **Determinism Lock**: Explicitly lock image resizing filters (e.g., `Lanczos3`, `Gaussian`) to a specific implementation version to prevent non-deterministic pixel variations during library updates.
 *   **Parallelism**: Use `rayon` to process all product images concurrently, maximizing build machine throughput.
 
 ### C. Composition Engine (TOML)
@@ -56,11 +57,14 @@ The compiler will perform a "Clean Purge" during the transformation from authori
 - [ ] **Task 1: Workspace Initialization**
     - Create `raw_assets/` and `package_configs/` folders.
     - Setup `Cargo.toml` with `image`, `blurhash`, `rayon`, and `toml`.
+    - **Commit `Cargo.lock`** to ensure deterministic dependency versions across all build machines.
 - [ ] **Task 2: KPSS Indexing & Validation**
-    - Implement directory walker for `raw_assets/`.
+    - Implement directory walker for `raw_assets/` (Discovery Only).
+    - **Enforce Non-Authoritative Folders**: Add validation to hard-error if logic attempts to infer metadata (brand/category) from folder paths.
     - Build the `CanonicalProductIndex` HashMap.
 - [ ] **Task 3: The Asset Stream**
     - Implement the concurrent WebP and BlurHash generation logic.
+    - **Lock Resizing math**: Ensure specific versioning for `Lanczos3` or `Gaussian` filters to maintain byte-identical outputs.
 - [ ] **Task 4: TOML Assortment Logic**
     - Create the composition resolver to build packages by ID.
 - [ ] **Task 5: Final Packaging & Signing**


### PR DESCRIPTION
…ata integrity

This commit updates the implementation documentation for the ProductGen pipeline to ensure reproducible, byte-identical builds and to enforce a strict metadata authority model.

- **Build Determinism**:
    - Mandated locking image resizing filters (e.g., `Lanczos3`, `Gaussian`) to specific implementation versions to prevent non-deterministic pixel variations during library updates.
    - Added a requirement to commit `Cargo.lock` to stabilize dependency versions across all build environments.
- **Metadata Validation**:
    - Refined the directory walking process to be "Discovery Only."
    - Introduced a requirement to hard-error if the logic attempts to infer product metadata (such as brand or category) from folder paths, enforcing the use of authoritative configuration files instead.
- **Pipeline Consistency**:
    - Explicitly defined the need for locked resizing math in the Asset Stream task to maintain consistent, verifiable output hashes.