### PR TITLE
feat: implement engine enrichment, BlurHash support, and "Make it Min…

### DIFF
--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/ClothingMapper.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/ClothingMapper.kt
@@ -42,6 +42,11 @@ fun ClothingItemEntity.toModel(): ClothingItem = ClothingItem(
     },
     parentItemId = parentItemId,
     isHidden = isHidden,
+    
+    // Engine Enrichment
+    calculatedBlurhash = calculatedBlurhash,
+    searchTokens = searchTokens,
+    
     usageCount = usageCount
 )
 
@@ -82,5 +87,10 @@ fun ClothingItem.toEntity(): ClothingItemEntity = ClothingItemEntity(
     },
     parentItemId = parentItemId,
     isHidden = isHidden,
+    
+    // Engine Enrichment
+    calculatedBlurhash = calculatedBlurhash,
+    searchTokens = searchTokens,
+    
     usageCount = usageCount
 )

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/CosmeticMapper.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/CosmeticMapper.kt
@@ -2,8 +2,8 @@ package com.zoewave.probase.kocolor.data.mapper
 
 import com.zoewave.probase.core.model.ritual.CosmeticItem
 import com.zoewave.probase.kocolor.db.entity.CosmeticItemEntity
-import com.zoewave.probase.kocolor.db.entity.Provenance as DbProvenance
 import com.zoewave.probase.core.model.ritual.Provenance as ModelProvenance
+import com.zoewave.probase.kocolor.db.entity.Provenance as DbProvenance
 
 fun CosmeticItemEntity.toModel(): CosmeticItem = CosmeticItem(
     id = id,
@@ -64,6 +64,20 @@ fun CosmeticItemEntity.toModel(): CosmeticItem = CosmeticItem(
     },
     parentItemId = parentItemId,
     isHidden = isHidden,
+    
+    // Engine Enrichment
+    calculatedChemistryPhase = calculatedChemistryPhase,
+    calculatedCielabL = calculatedCielabL,
+    calculatedCielabA = calculatedCielabA,
+    calculatedCielabB = calculatedCielabB,
+    calculatedHueAngle = calculatedHueAngle,
+    calculatedBlurhash = calculatedBlurhash,
+    isSiliconeFree = isSiliconeFree,
+    isParabenFree = isParabenFree,
+    isSulfateFree = isSulfateFree,
+    heroActives = heroActives,
+    calculatedUnitPrice = calculatedUnitPrice,
+    searchTokens = searchTokens,
     
     // FDA Safety
     fdaRecallStatus = fdaRecallStatus,
@@ -133,6 +147,20 @@ fun CosmeticItem.toEntity(): CosmeticItemEntity = CosmeticItemEntity(
     },
     parentItemId = parentItemId,
     isHidden = isHidden,
+    
+    // Engine Enrichment
+    calculatedChemistryPhase = calculatedChemistryPhase,
+    calculatedCielabL = calculatedCielabL,
+    calculatedCielabA = calculatedCielabA,
+    calculatedCielabB = calculatedCielabB,
+    calculatedHueAngle = calculatedHueAngle,
+    calculatedBlurhash = calculatedBlurhash,
+    isSiliconeFree = isSiliconeFree,
+    isParabenFree = isParabenFree,
+    isSulfateFree = isSulfateFree,
+    heroActives = heroActives,
+    calculatedUnitPrice = calculatedUnitPrice,
+    searchTokens = searchTokens,
     
     // FDA Safety
     fdaRecallStatus = fdaRecallStatus,

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/ClothingDao.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/ClothingDao.kt
@@ -43,4 +43,25 @@ interface ClothingDao {
 
     @Query("DELETE FROM clothing_items")
     suspend fun deleteAllClothing()
+
+    /**
+     * "MAKE IT MINE" Action: Clones a clothing item and detaches it from the collection lifecycle.
+     */
+    @Transaction
+    @Query("""
+        INSERT INTO clothing_items (
+            name, brand, category, formality, colorHex, colorFamily, size, material, price, 
+            imageUrl, notes, timestamp, dominantHex, vibrantHex, mutedHex, paletteHexes, 
+            colorTemperature, seasonalPalette, contrastLevel, koColorGroup, sourceType, 
+            sourceName, provenance_packId
+        )
+        SELECT 
+            name, brand, category, formality, colorHex, colorFamily, size, material, price, 
+            imageUrl, notes, :timestamp, dominantHex, vibrantHex, mutedHex, paletteHexes, 
+            colorTemperature, seasonalPalette, contrastLevel, koColorGroup, 'USER_SCAN', 
+            sourceName, NULL
+        FROM clothing_items 
+        WHERE id = :sourceId
+    """)
+    suspend fun cloneToPersonalArchive(sourceId: Long, timestamp: Long = System.currentTimeMillis())
 }

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/CosmeticDao.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/CosmeticDao.kt
@@ -47,4 +47,26 @@ interface CosmeticDao {
 
     @Query("DELETE FROM cosmetic_items")
     suspend fun deleteAllCosmetics()
+
+    /**
+     * "MAKE IT MINE" Action: Clones a product and detaches it from the collection lifecycle.
+     * The new item has no provenance (provenance_packId is NULL), protecting it from collection wipes.
+     */
+    @Transaction
+    @Query("""
+        INSERT INTO cosmetic_items (
+            name, brand, macroCategory, microCategory, formulation, chemistryBase, finish, coverage, 
+            temperature, colorHex, colorFamily, shadeName, imageUrl, notes, instructions, timestamp,
+            paoMonths, price, volume, ingredients, allergens, isVegan, isCrueltyFree, fdaDataVerified,
+            sourceType, sourceName, provenance_packId
+        )
+        SELECT 
+            name, brand, macroCategory, microCategory, formulation, chemistryBase, finish, coverage, 
+            temperature, colorHex, colorFamily, shadeName, imageUrl, notes, instructions, :timestamp,
+            paoMonths, price, volume, ingredients, allergens, isVegan, isCrueltyFree, fdaDataVerified,
+            'USER_SCAN', sourceName, NULL
+        FROM cosmetic_items 
+        WHERE id = :sourceId
+    """)
+    suspend fun cloneToPersonalArchive(sourceId: Long, timestamp: Long = System.currentTimeMillis())
 }

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/ClothingItemEntity.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/ClothingItemEntity.kt
@@ -4,8 +4,8 @@ import androidx.room3.Embedded
 import androidx.room3.Entity
 import androidx.room3.PrimaryKey
 import com.zoewave.probase.core.model.ritual.ClothingCategory
-import com.zoewave.probase.core.model.ritual.Formality
 import com.zoewave.probase.core.model.ritual.ColorFamily
+import com.zoewave.probase.core.model.ritual.Formality
 import com.zoewave.probase.core.model.ritual.InventorySource
 
 @Entity(tableName = "clothing_items")
@@ -38,6 +38,10 @@ data class ClothingItemEntity(
     @Embedded(prefix = "provenance_") val provenance: Provenance? = null,
     val parentItemId: String? = null,
     val isHidden: Boolean = false,
+
+    // --- Engine Enrichment (Calculated at Compile Time) ---
+    val calculatedBlurhash: String? = null,
+    val searchTokens: List<String> = emptyList(),
 
     // --- Usage & Performance ---
     val usageCount: Int = 0

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/CosmeticItemEntity.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/CosmeticItemEntity.kt
@@ -3,8 +3,15 @@ package com.zoewave.probase.kocolor.db.entity
 import androidx.room3.Embedded
 import androidx.room3.Entity
 import androidx.room3.PrimaryKey
-import com.zoewave.probase.core.model.ritual.*
+import com.zoewave.probase.core.model.ritual.ChemistryBase
+import com.zoewave.probase.core.model.ritual.ColorFamily
+import com.zoewave.probase.core.model.ritual.Coverage
+import com.zoewave.probase.core.model.ritual.Finish
+import com.zoewave.probase.core.model.ritual.Formulation
 import com.zoewave.probase.core.model.ritual.InventorySource
+import com.zoewave.probase.core.model.ritual.MacroCategory
+import com.zoewave.probase.core.model.ritual.MicroCategory
+import com.zoewave.probase.core.model.ritual.Temperature
 
 @Entity(tableName = "cosmetic_items")
 data class CosmeticItemEntity(
@@ -66,6 +73,20 @@ data class CosmeticItemEntity(
     @Embedded(prefix = "provenance_") val provenance: Provenance? = null,
     val parentItemId: String? = null,
     val isHidden: Boolean = false,
+
+    // --- Engine Enrichment (Calculated at Compile Time) ---
+    val calculatedChemistryPhase: String? = null,
+    val calculatedCielabL: Double? = null,
+    val calculatedCielabA: Double? = null,
+    val calculatedCielabB: Double? = null,
+    val calculatedHueAngle: Double? = null,
+    val calculatedBlurhash: String? = null,
+    val isSiliconeFree: Boolean? = null,
+    val isParabenFree: Boolean? = null,
+    val isSulfateFree: Boolean? = null,
+    val heroActives: List<String> = emptyList(),
+    val calculatedUnitPrice: Double? = null,
+    val searchTokens: List<String> = emptyList(),
 
     // --- FDA & Clinical Safety ---
     val fdaRecallStatus: String? = null,

--- a/applications/kocolor/docs/Pipeline/Mobile_Ingestion_Implementation.md
+++ b/applications/kocolor/docs/Pipeline/Mobile_Ingestion_Implementation.md
@@ -50,16 +50,16 @@ The UI must utilize the pre-calculated build-time intelligence for a premium use
 
 ## 🛠️ Implementation Checklist
 
-- [ ] **Task 1: Security Integration**
-    - Integrate Ed25519 verification logic and Public Key anchoring.
-- [ ] **Task 2: Zstd Compression Engine**
-    - Setup `zstd-jni` dependency and implement bounded decompression.
-- [ ] **Task 3: Streaming Ingestion Pipeline**
-    - Build the `HashingSink` downloader with early-rejection logic.
-- [ ] **Task 4: Room Persistence & Mapping**
-    - Create the migration-free V1 database and transactional seeding logic.
-- [ ] **Task 5: Boutique UI Construction**
-    - Build the Jetpack Compose selector with BlurHash support.
+- [x] **Task 1: Security Integration**
+    - Integrated **Tink** for Ed25519 verification and Public Key anchoring.
+- [x] **Task 2: Zstd Compression Engine**
+    - Setup `zstd-jni` dependency and implemented **bounded decompression** with safety caps.
+- [x] **Task 3: Streaming Ingestion Pipeline**
+    - Built the `HashingSink` downloader with **Verify-Before-Execute** early-rejection logic.
+- [x] **Task 4: Room Persistence & Mapping**
+    - Created the transactional seeding logic and implemented the **"Make it Mine"** cloning mechanism.
+- [x] **Task 5: Boutique UI Construction**
+    - Built the Jetpack Compose selector with **BlurHash** instant placeholder support.
 
 ---
 **Status**: 🗓️ **PLANNING COMPLETE**

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
@@ -563,6 +563,7 @@ class CosmeticsViewModel @Inject constructor(
                 id = 0L, // New record
                 sourceType = InventorySource.CLONED,
                 sourcePackId = null, // Detach from pack wipe
+                provenance = null,   // Critical: Remove provenance to protect from collection removal
                 parentItemId = item.id.toString(),
                 timestamp = System.currentTimeMillis()
             )

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
@@ -202,6 +202,7 @@ class WardrobeViewModel @Inject constructor(
                 id = 0L,
                 sourceType = InventorySource.CLONED,
                 sourcePackId = null,
+                provenance = null, // Critical: Remove provenance to protect from collection removal
                 parentItemId = item.id.toString(),
                 timestamp = System.currentTimeMillis()
             )

--- a/applications/kocolor/features/starterpack/build.gradle.kts
+++ b/applications/kocolor/features/starterpack/build.gradle.kts
@@ -38,8 +38,10 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.squareup.retrofit)
+    implementation(libs.squareup.okhttp3.logging.interceptor)
     implementation(libs.retrofit.kotlinx.serialization.converter)
     implementation(libs.coil.compose)
+    implementation(libs.tinkAndroid)
 
     implementation("org.bouncycastle:bcprov-jdk18on:1.77")
     implementation("com.github.luben:zstd-jni:1.5.7-12@aar")

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
@@ -5,9 +5,27 @@ import android.util.Log
 import coil.imageLoader
 import coil.request.ImageRequest
 import com.github.luben.zstd.Zstd
-import com.zoewave.probase.core.model.ritual.*
+import com.zoewave.probase.core.model.ritual.ChemistryBase
+import com.zoewave.probase.core.model.ritual.ClothingCategory
+import com.zoewave.probase.core.model.ritual.ClothingItem
+import com.zoewave.probase.core.model.ritual.CosmeticItem
+import com.zoewave.probase.core.model.ritual.Coverage
+import com.zoewave.probase.core.model.ritual.Finish
+import com.zoewave.probase.core.model.ritual.Formality
+import com.zoewave.probase.core.model.ritual.Formulation
+import com.zoewave.probase.core.model.ritual.InventorySource
+import com.zoewave.probase.core.model.ritual.MacroCategory
+import com.zoewave.probase.core.model.ritual.MicroCategory
+import com.zoewave.probase.core.model.ritual.Provenance
+import com.zoewave.probase.core.model.ritual.Temperature
+import com.zoewave.probase.core.model.ritual.VerificationState
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.KocolorApiService
-import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.*
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.KcpsPayload
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackInfo
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackItemDto
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackManifest
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.SearchIndexEntry
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.SignedPayloadEnvelope
 import com.zoewave.probase.kocolor.features.starterpack.domain.security.SignatureVerifier
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -134,6 +152,10 @@ class StarterPackRepository @Inject constructor(
             }
 
             // 9. Decompress (Verify-First Rule enforced: decompression ONLY after successful verification)
+            if (packInfo.uncompressedSizeBytes > MAX_PACKAGE_SIZE) {
+                throw PackException.IntegrityException("Uncompressed payload too large (>32MB). Possible JSON bomb.")
+            }
+
             val decompressedBytes = try {
                 Zstd.decompress(fileBytes, packInfo.uncompressedSizeBytes.toInt())
             } catch (e: Exception) {
@@ -258,7 +280,21 @@ class StarterPackRepository @Inject constructor(
                 fdaDataVerified = dto.fdaDataVerified,
                 sourceType = sourceType,
                 sourceName = packInfo.name,
-                provenance = provenance
+                provenance = provenance,
+                
+                // --- Engine Enrichment (Calculated at Compile Time) ---
+                calculatedChemistryPhase = dto.calculatedChemistryPhase,
+                calculatedCielabL = dto.calculatedCielab?.l,
+                calculatedCielabA = dto.calculatedCielab?.a,
+                calculatedCielabB = dto.calculatedCielab?.b,
+                calculatedHueAngle = dto.calculatedCielab?.hueAngleHab,
+                calculatedBlurhash = dto.calculatedBlurhash,
+                isSiliconeFree = dto.calculatedSafetyFlags?.isSiliconeFree,
+                isParabenFree = dto.calculatedSafetyFlags?.isParabenFree,
+                isSulfateFree = dto.calculatedSafetyFlags?.isSulfateFree,
+                heroActives = dto.calculatedHeroActives,
+                calculatedUnitPrice = dto.calculatedUnitPrice,
+                searchTokens = dto.calculatedSearchTokens
             )
         }
 
@@ -282,7 +318,11 @@ class StarterPackRepository @Inject constructor(
                 koColorGroup = dto.koColorGroup,
                 sourceType = sourceType,
                 sourceName = packInfo.name,
-                provenance = provenance
+                provenance = provenance,
+                
+                // --- Engine Enrichment (Calculated at Compile Time) ---
+                calculatedBlurhash = dto.calculatedBlurhash,
+                searchTokens = dto.calculatedSearchTokens
             )
         }
         

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackItem.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackItem.kt
@@ -21,6 +21,7 @@ sealed interface PackItemDto {
     val shadeName: String?
     val imageUrl: String
     val thumbnailUrl: String
+    val calculatedBlurhash: String?
     val price: Double?
     val notes: String?
 }
@@ -51,8 +52,32 @@ data class CosmeticItemDto(
     val allergens: List<String>,
     @SerialName("is_vegan") val isVegan: Boolean?,
     @SerialName("is_cruelty_free") val isCrueltyFree: Boolean?,
-    @SerialName("fda_data_verified") val fdaDataVerified: Boolean
+    @SerialName("fda_data_verified") val fdaDataVerified: Boolean,
+    
+    // --- Engine Enrichment (Calculated at Compile Time) ---
+    @SerialName("calculated_chemistry_phase") val calculatedChemistryPhase: String? = null,
+    @SerialName("calculated_cielab") val calculatedCielab: CielabData? = null,
+    @SerialName("calculated_blurhash") override val calculatedBlurhash: String? = null,
+    @SerialName("calculated_safety_flags") val calculatedSafetyFlags: SafetyFlags? = null,
+    @SerialName("calculated_hero_actives") val calculatedHeroActives: List<String> = emptyList(),
+    @SerialName("calculated_unit_price") val calculatedUnitPrice: Double? = null,
+    @SerialName("calculated_search_tokens") val calculatedSearchTokens: List<String> = emptyList()
 ) : PackItemDto
+
+@Serializable
+data class CielabData(
+    val l: Double,
+    val a: Double,
+    val b: Double,
+    @SerialName("hue_angle_hab") val hueAngleHab: Double
+)
+
+@Serializable
+data class SafetyFlags(
+    @SerialName("is_silicone_free") val isSiliconeFree: Boolean,
+    @SerialName("is_paraben_free") val isParabenFree: Boolean,
+    @SerialName("is_sulfate_free") val isSulfateFree: Boolean
+)
 
 @Serializable
 data class ClothingItemDto(
@@ -76,5 +101,9 @@ data class ClothingItemDto(
     @SerialName("color_temperature") val colorTemperature: String? = null,
     @SerialName("seasonal_palette") val seasonalPalette: String? = null,
     @SerialName("contrast_level") val contrastLevel: String? = null,
-    @SerialName("ko_color_group") val koColorGroup: String? = null
+    @SerialName("ko_color_group") val koColorGroup: String? = null,
+    
+    // --- Engine Enrichment (Calculated at Compile Time) ---
+    @SerialName("calculated_blurhash") override val calculatedBlurhash: String? = null,
+    @SerialName("calculated_search_tokens") val calculatedSearchTokens: List<String> = emptyList()
 ) : PackItemDto

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/domain/security/SignatureVerifier.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/domain/security/SignatureVerifier.kt
@@ -1,11 +1,10 @@
 package com.zoewave.probase.kocolor.features.starterpack.domain.security
 
-import com.zoewave.probase.kocolor.features.starterpack.data.SecurityConstants
+import com.google.crypto.tink.subtle.Ed25519Verify
 import com.zoewave.probase.core.util.HashUtils
+import com.zoewave.probase.kocolor.features.starterpack.data.SecurityConstants
 import okio.Source
 import okio.buffer
-import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
-import org.bouncycastle.crypto.signers.Ed25519Signer
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -29,11 +28,10 @@ interface SignatureVerifier {
 class KoColorEd25519Verifier @Inject constructor() : SignatureVerifier {
 
     // Hardcoded compiler public key for Zero-Trust verification
-    // This is standard practice for root public keys
     private val publicKeyHex = SecurityConstants.KOCOLOR_ROOT_PUBLIC_KEY 
 
-    private val publicKeyParams by lazy {
-        Ed25519PublicKeyParameters(publicKeyHex.decodeHex(), 0)
+    private val verifier by lazy {
+        Ed25519Verify(publicKeyHex.decodeHex())
     }
 
     override fun verify(payloadBytes: ByteArray, signatureHex: String, expectedSha256: String): Boolean {
@@ -45,43 +43,29 @@ class KoColorEd25519Verifier @Inject constructor() : SignatureVerifier {
             }
         }
 
-        // 2. Cryptographic Authenticity Check (Ed25519)
-        val signer = Ed25519Signer().apply {
-            init(false, publicKeyParams)
-            update(payloadBytes, 0, payloadBytes.size)
-        }
-
+        // 2. Cryptographic Authenticity Check (Ed25519 via Tink)
         return try {
             val signatureBytes = signatureHex.decodeHex()
-            signer.verifySignature(signatureBytes)
+            verifier.verify(signatureBytes, payloadBytes)
+            true
         } catch (e: Exception) {
-            false // Malformed signature string
+            false // Invalid signature or malformed data
         }
     }
 
     override fun verify(source: Source, signatureHex: String): Boolean {
-        val signer = Ed25519Signer().apply {
-            init(false, publicKeyParams)
-        }
-
-        val buffer = ByteArray(8192) // 8KB chunks
-        source.buffer().use { bufferedSource ->
-            while (true) {
-                val bytesRead = bufferedSource.read(buffer)
-                if (bytesRead == -1) break
-                signer.update(buffer, 0, bytesRead)
-            }
-        }
-
+        // Tink's Ed25519Verify requires the full message to verify.
+        // Since .kpkg files are relatively small (<32MB), we read into memory.
         return try {
+            val payloadBytes = source.buffer().readByteArray()
             val signatureBytes = signatureHex.decodeHex()
-            signer.verifySignature(signatureBytes)
+            verifier.verify(signatureBytes, payloadBytes)
+            true
         } catch (e: Exception) {
             false
         }
     }
 
-    // --- Hex Utility Extensions ---
     private fun String.decodeHex(): ByteArray {
         check(length % 2 == 0) { "Must have an even length" }
         return chunked(2)

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
@@ -4,18 +4,33 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.CosmeticItemDto
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackItemDto
+import com.zoewave.probase.kocolor.features.starterpack.ui.util.BlurHashDecoder
 import kotlinx.coroutines.delay
 
 @Composable
@@ -63,9 +79,15 @@ fun PackPreviewItemRow(
                 .clip(RoundedCornerShape(12.dp))
                 .background(Color(0xFFF5F5F5))
         ) {
+            val blurhash = item.calculatedBlurhash
+            val placeholder = remember(blurhash) {
+                BlurHashDecoder.decode(blurhash, 32, 32)?.asImageBitmap()
+            }
+
             AsyncImage(
                 model = item.thumbnailUrl,
                 contentDescription = null,
+                placeholder = placeholder?.let { BitmapPainter(it) },
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop
             )
@@ -140,6 +162,7 @@ private fun PackPreviewItemRowPreview() {
                 colorHex = "#F4F6F0",
                 thumbnailUrl = "",
                 imageUrl = "",
+                calculatedBlurhash = "LEHV6nWB2yk8pyo0adRj00WBof%M",
                 macroCategory = "PREP",
                 microCategory = "CLEANSER",
                 price = 18.0,

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/util/BlurHashDecoder.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/util/BlurHashDecoder.kt
@@ -1,0 +1,106 @@
+package com.zoewave.probase.kocolor.features.starterpack.ui.util
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.withSign
+
+/**
+ * Native Kotlin implementation of the BlurHash decoding algorithm.
+ * Used to instantly render pre-calculated visual placeholders while high-res assets load.
+ */
+object BlurHashDecoder {
+
+    fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f): Bitmap? {
+        if (blurHash == null || blurHash.length < 6) return null
+
+        val numComponents = decode83(blurHash, 0, 1)
+        val nx = (numComponents % 9) + 1
+        val ny = (numComponents / 9) + 1
+
+        if (blurHash.length != 4 + 2 * nx * ny) return null
+
+        val maxAc = (decode83(blurHash, 1, 2) + 1).toFloat() / 166f
+        val colors = Array(nx * ny) { i ->
+            if (i == 0) {
+                val value = decode83(blurHash, 2, 6)
+                decodeDc(value)
+            } else {
+                val value = decode83(blurHash, 4 + i * 2, 4 + i * 2 + 2)
+                decodeAc(value, maxAc * punch)
+            }
+        }
+
+        val pixels = IntArray(width * height)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                var r = 0f
+                var g = 0f
+                var b = 0f
+
+                for (j in 0 until ny) {
+                    for (i in 0 until nx) {
+                        val basis = (cos(Math.PI * x * i / width) * cos(Math.PI * y * j / height)).toFloat()
+                        val color = colors[i + j * nx]
+                        r += color[0] * basis
+                        g += color[1] * basis
+                        b += color[2] * basis
+                    }
+                }
+
+                val red = linearToSrgb(r)
+                val green = linearToSrgb(g)
+                val blue = linearToSrgb(b)
+
+                pixels[y * width + x] = Color.rgb(red, green, blue)
+            }
+        }
+
+        return Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888)
+    }
+
+    private fun decode83(str: String, start: Int, end: Int): Int {
+        var res = 0
+        for (i in start until end) {
+            val c = str[i]
+            val digit = charMap[c] ?: 0
+            res = res * 83 + digit
+        }
+        return res
+    }
+
+    private fun decodeDc(value: Int): FloatArray {
+        val r = (value shr 16) / 255f
+        val g = ((value shr 8) and 255) / 255f
+        val b = (value and 255) / 255f
+        return floatArrayOf(srgbToLinear(r), srgbToLinear(g), srgbToLinear(b))
+    }
+
+    private fun decodeAc(value: Int, maxAc: Float): FloatArray {
+        val r = value / (19 * 19)
+        val g = (value / 19) % 19
+        val b = value % 19
+        return floatArrayOf(
+            signedPow((r - 9f) / 9f, 2f) * maxAc,
+            signedPow((g - 9f) / 9f, 2f) * maxAc,
+            signedPow((b - 9f) / 9f, 2f) * maxAc
+        )
+    }
+
+    private fun srgbToLinear(v: Float): Float {
+        val f = v / 1.0f
+        return if (f <= 0.04045f) f / 12.92f else ((f + 0.055f) / 1.055f).pow(2.4f)
+    }
+
+    private fun linearToSrgb(v: Float): Int {
+        val f = v.coerceIn(0f, 1f)
+        return if (f <= 0.0031308f) (f * 12.92f * 255f + 0.5f).toInt()
+        else (((1.055f * f.pow(1f / 2.4f)) - 0.055f) * 255f + 0.5f).toInt()
+    }
+
+    private fun signedPow(v: Float, e: Float): Float = v.pow(e).withSign(v)
+
+    private val charMap = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~"
+        .withIndex().associate { it.value to it.index }
+}

--- a/core/model/src/main/java/com/zoewave/probase/core/model/ritual/ClothingItem.kt
+++ b/core/model/src/main/java/com/zoewave/probase/core/model/ritual/ClothingItem.kt
@@ -67,6 +67,10 @@ data class ClothingItem(
     val parentItemId: String? = null,
     val isHidden: Boolean = false,
 
+    // --- Engine Enrichment (Calculated at Compile Time) ---
+    val calculatedBlurhash: String? = null,
+    val searchTokens: List<String> = emptyList(),
+
     // --- Usage & Performance ---
     val usageCount: Int = 0
 ) {

--- a/core/model/src/main/java/com/zoewave/probase/core/model/ritual/CosmeticItem.kt
+++ b/core/model/src/main/java/com/zoewave/probase/core/model/ritual/CosmeticItem.kt
@@ -282,6 +282,20 @@ data class CosmeticItem(
     val parentItemId: String? = null,
     val isHidden: Boolean = false,
 
+    // --- Engine Enrichment (Calculated at Compile Time) ---
+    val calculatedChemistryPhase: String? = null,
+    val calculatedCielabL: Double? = null,
+    val calculatedCielabA: Double? = null,
+    val calculatedCielabB: Double? = null,
+    val calculatedHueAngle: Double? = null,
+    val calculatedBlurhash: String? = null,
+    val isSiliconeFree: Boolean? = null,
+    val isParabenFree: Boolean? = null,
+    val isSulfateFree: Boolean? = null,
+    val heroActives: List<String> = emptyList(),
+    val calculatedUnitPrice: Double? = null,
+    val searchTokens: List<String> = emptyList(),
+
     // --- FDA & Clinical Safety ---
     val fdaRecallStatus: String? = null,
     val fdaAdverseEventCount: Int = 0,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ room = "3.0.0"
 datastore = "1.2.1"
 sqlite = "2.7.0"
 androidxSecurity = "1.1.0"
+tink = "1.23.0"
 
 # -- Background --
 work = "2.11.2"
@@ -194,6 +195,7 @@ hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWo
 room-runtime = { group = "androidx.room3", name = "room3-runtime", version.ref = "room" }
 room-compiler = { group = "androidx.room3", name = "room3-compiler", version.ref = "room" }
 sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", version.ref = "sqlite" }
+tinkAndroid = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink" }
 
 # -- DataStore --
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }


### PR DESCRIPTION
…e" cloning

This commit introduces "Engine Enrichment" metadata to the clothing and cosmetic data models, adds a BlurHash-based placeholder system for the UI, and implements the "Make it Mine" feature for detaching items from collection lifecycles. It also hardens security by migrating to Google Tink and enforcing decompression limits.

- **Data Model & Enrichment**:
    - Expanded `ClothingItem` and `CosmeticItem` (entities and models) to include compile-time calculated fields: `calculatedBlurhash`, `searchTokens`, CIELAB color data, and chemical safety flags (silicone/paraben/sulfate-free).
    - Updated `ClothingMapper` and `CosmeticMapper` to handle these enriched engine fields.
- **"Make it Mine" Logic**:
    - Added `cloneToPersonalArchive` to `ClothingDao` and `CosmeticDao` to allow users to clone items into their personal archive.
    - Updated `CosmeticsViewModel` and `WardrobeViewModel` to strip provenance during cloning, protecting items from being deleted during pack updates or wipes.
- **Security & Integrity**:
    - Migrated `SignatureVerifier` from BouncyCastle to `com.google.crypto.tink:tink-android` for Ed25519 verification.
    - Implemented a 32MB safety cap (`MAX_PACKAGE_SIZE`) in `StarterPackRepository` during Zstd decompression to prevent decompression bomb attacks.
- **UI & UX Improvements**:
    - Introduced a native Kotlin `BlurHashDecoder` utility.
    - Updated `PackPreviewItemRow` to use BlurHash Bitmaps as placeholders for `AsyncImage`, providing instant visual feedback while high-resolution assets load.
- **Dependency Management**:
    - Added `com.google.crypto.tink:tink-android:1.23.0` to the project and `starterpack` module.
    - Integrated `okhttp3.logging.interceptor` for improved network debugging.