### PR TITLE
feat: include uncompressed size in package manifest and update blurha…

### DIFF
--- a/applications/kocolor/docs/Walkthrough_Mobile_Ingestion_Enrichment.md
+++ b/applications/kocolor/docs/Walkthrough_Mobile_Ingestion_Enrichment.md
@@ -37,7 +37,7 @@ The `CosmeticItem` and `ClothingItem` models have been expanded to include:
 To ensure a "Boutique" experience during high-velocity scrolling, we implemented instant visual placeholders.
 
 *   **BlurHash Decoding**: Created a native Kotlin `BlurHashDecoder` utility.
-*   **UI Integration**: `PackPreviewItemRow` now uses the `calculated_blurhash` as an initial placeholder for Coil's `AsyncImage`.
+*   **UI Integration**: `PackPreviewItemRow` now uses the `blurhash` as an initial placeholder for Coil's `AsyncImage`.
 *   **UX Benefit**: Users see a beautiful, color-accurate blurred version of the product image instantly, eliminating the "empty box" state while high-res assets download.
 
 ---

--- a/server/package/kc-optimizer/src/composer.rs
+++ b/server/package/kc-optimizer/src/composer.rs
@@ -11,6 +11,7 @@ pub struct PackageManifestRecord {
     pub package_id: String,
     pub hash: String,
     pub signature: String,
+    pub uncompressed_size_bytes: u64,
 }
 
 /// Parses TOML manifests, resolves product IDs from the canonical index,
@@ -106,7 +107,7 @@ pub fn assemble_packages(
             let final_json = serde_json::to_string(&package_payloads)
                 .expect("❌ Failed to serialize KCPS payload");
 
-            let (hash_hex, sig_hex) = packager::seal_package(
+            let (hash_hex, sig_hex, uncompressed_size) = packager::seal_package(
                 final_json.as_bytes(),
                 &manifest.package_metadata.id,
                 signing_key,
@@ -117,6 +118,7 @@ pub fn assemble_packages(
                 package_id: manifest.package_metadata.id.clone(),
                 hash: hash_hex,
                 signature: sig_hex,
+                uncompressed_size_bytes: uncompressed_size,
             });
 
             println!("  🔒 Sealed package '{}' (.kpkg generated & signed).", manifest.package_metadata.id);

--- a/server/package/kc-optimizer/src/packager.rs
+++ b/server/package/kc-optimizer/src/packager.rs
@@ -6,12 +6,15 @@ use zstd::stream::encode_all;
 
 /// Compresses the KCPS JSON payload using Zstd, writes the .kpkg binary,
 /// computes its SHA-256 hash, and signs it with an Ed25519 private key.
+/// Returns (hash_hex, signature_hex, uncompressed_size_bytes).
 pub fn seal_package(
     json_bytes: &[u8],
     package_id: &str,
     signing_key: &SigningKey,
     dist_dir: &Path,
-) -> (String, String) {
+) -> (String, String, u64) {
+    let uncompressed_size = json_bytes.len() as u64;
+
     // 1. Zstd Compression
     // We use level 19 (maximum) because we are computing at compile-time.
     // This ruthlessly shrinks the payload for mobile downloads.
@@ -35,5 +38,5 @@ pub fn seal_package(
     let signature: Signature = signing_key.sign(&compressed_bytes);
     let sig_hex = hex::encode(signature.to_bytes());
 
-    (hash_hex, sig_hex)
+    (hash_hex, sig_hex, uncompressed_size)
 }


### PR DESCRIPTION
…sh docs

This commit adds the uncompressed payload size to the package envelope metadata within the Rust optimizer and updates the mobile ingestion documentation to reflect standardized field naming.

- **Package Metadata Enhancement**:
    - Added `uncompressed_size_bytes` to the `PackageEnvelope` struct in `composer.rs` to allow clients to pre-allocate decompression buffers.
    - Updated `seal_package` in `packager.rs` to calculate and return the length of the raw JSON bytes before Zstd compression.
    - Updated the package sealing logic to include this size in the final manifest output.
- **Documentation Refinement**:
    - Updated `Walkthrough_Mobile_Ingestion_Enrichment.md` to use the field name `blurhash` instead of `calculated_blurhash` in the UI integration section, aligning the documentation with the implementation in `PackPreviewItemRow`.