### PR TITLE
refactor: update uncompressed size type and calculation for Android c…

### DIFF
--- a/server/package/kc-optimizer/src/composer.rs
+++ b/server/package/kc-optimizer/src/composer.rs
@@ -11,7 +11,7 @@ pub struct PackageManifestRecord {
     pub package_id: String,
     pub hash: String,
     pub signature: String,
-    pub uncompressed_size_bytes: u64,
+    pub uncompressed_size_bytes: usize, // Required for Android bomb prevention
 }
 
 /// Parses TOML manifests, resolves product IDs from the canonical index,
@@ -107,8 +107,12 @@ pub fn assemble_packages(
             let final_json = serde_json::to_string(&package_payloads)
                 .expect("❌ Failed to serialize KCPS payload");
 
-            let (hash_hex, sig_hex, uncompressed_size) = packager::seal_package(
-                final_json.as_bytes(),
+            // Measure the byte length BEFORE compression
+            let uncompressed_bytes = final_json.as_bytes();
+            let size_bytes = uncompressed_bytes.len();
+
+            let (hash_hex, sig_hex, _) = packager::seal_package(
+                uncompressed_bytes,
                 &manifest.package_metadata.id,
                 signing_key,
                 dist_dir
@@ -118,10 +122,10 @@ pub fn assemble_packages(
                 package_id: manifest.package_metadata.id.clone(),
                 hash: hash_hex,
                 signature: sig_hex,
-                uncompressed_size_bytes: uncompressed_size,
+                uncompressed_size_bytes: size_bytes,
             });
 
-            println!("  🔒 Sealed package '{}' (.kpkg generated & signed).", manifest.package_metadata.id);
+            println!("  🔒 Sealed package '{}' (Size: {} bytes).", manifest.package_metadata.id, size_bytes);
         }
     }
 


### PR DESCRIPTION
…ompatibility

This commit changes the `uncompressed_size_bytes` field from `u64` to `usize` and ensures the size is calculated directly from the serialized JSON payload. This change is intended to support memory-safe decompression on Android (bomb prevention) by providing an exact byte count for buffer allocation.

- **Data Model Alignment**:
    - Updated `uncompressed_size_bytes` type in `PackageManifestEntry` to `usize`.
- **Size Calculation Refinement**:
    - Modified `composer.rs` to measure the byte length of the serialized JSON payload immediately before it is passed to the packager.
    - Updated the `seal_package` call to use this locally calculated size instead of the value returned by the packager.
- **Improved Logging**:
    - Enhanced the package sealing console output to include the specific byte size of the sealed package.