### PR TITLE
feat: implement high-fidelity "Make it Mine" personalization engine

### DIFF
--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -16,6 +16,7 @@ import com.zoewave.probase.features.health.nutrition.ui.shared.MealsViewModel
 import com.zoewave.probase.features.readers.barcode.ui.BarcodeScannerScreen
 import com.zoewave.probase.features.readers.qrscanner.ui.QRCodeScannerScreen
 import com.zoewave.probase.features.weather.ui.WeatherUiRoute
+import com.zoewave.probase.core.model.ritual.ArchiveStatus
 import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulatorScreen
 import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulatorViewModel
 import com.zoewave.probase.kocolor.features.analyzer.ui.AnalyzerUiRoute
@@ -384,8 +385,9 @@ fun koColorNavEntryProvider(
         is KoColorRoute.WardrobeDetail -> NavEntry(route) {
             val viewModel: WardrobeViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
+            val archiveStatus = state.archiveStatuses[route.itemId] ?: ArchiveStatus.IDLE
             WardrobeDetailScreen(
-                uiState = WardrobeDetailUiState(route.itemId, state),
+                uiState = WardrobeDetailUiState(route.itemId, state, archiveStatus),
                 onEvent = viewModel::onEvent,
                 navTo = onNavigateTo
             )
@@ -454,8 +456,14 @@ fun koColorNavEntryProvider(
             val viewModel: CosmeticsViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
             val item = state.items.find { it.id == route.itemId }
+            val archiveStatus = state.archiveStatuses[route.itemId] ?: ArchiveStatus.IDLE
+            
             CosmeticDetailScreen(
-                uiState = CosmeticDetailUiState(item),
+                uiState = CosmeticDetailUiState(
+                    item = item,
+                    archiveStatus = archiveStatus,
+                    uvIndex = state.uvIndex
+                ),
                 onEvent = viewModel::onEvent,
                 navTo = onNavigateTo
             )

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/CosmeticInventoryRepository.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/CosmeticInventoryRepository.kt
@@ -10,4 +10,5 @@ interface CosmeticInventoryRepository {
     suspend fun saveCosmeticItems(items: List<CosmeticItem>)
     suspend fun deleteCosmeticItem(id: Long)
     suspend fun deleteCosmeticsByPack(packId: String): Result<Unit>
+    suspend fun cloneToPersonalArchive(id: Long): Result<Unit>
 }

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/WardrobeRepository.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/WardrobeRepository.kt
@@ -12,4 +12,5 @@ interface WardrobeRepository {
     suspend fun wearClothingItem(id: Long)
     suspend fun deleteClothing(id: Long)
     suspend fun deleteClothingByPack(packId: String): Result<Unit>
+    suspend fun cloneToPersonalArchive(id: Long): Result<Unit>
 }

--- a/applications/kocolor/docs/UI/Intelligence_UI_Implementation.md
+++ b/applications/kocolor/docs/UI/Intelligence_UI_Implementation.md
@@ -77,7 +77,7 @@ Utilizing the compiler-provided index for zero-latency Boutique operations.
 - [x] **Step 4: Intelligence Badging**
     - Updated `CosmeticDetailScreen` to render the Actives and Safety chips.
 - [x] **Step 5: Sovereign Ingestion Wiring**
-    - Hooked up the "Make it Mine" button to the transactional cloning logic.
+    - Hooked up the "Make it Mine" button to the transactional cloning logic and implemented luxury state animations.
 - [x] **Step 6: Value & Search Filtering**
     - Wired the Boutique filters to utilize the `search_tokens` index for instant results and added value-based sorting.
 

--- a/applications/kocolor/docs/Walkthrough_Make_It_Mine_HighFidelity.md
+++ b/applications/kocolor/docs/Walkthrough_Make_It_Mine_HighFidelity.md
@@ -1,0 +1,47 @@
+# Walkthrough: "Make it Mine" High-Fidelity Implementation
+
+This document details the final personalized ingestion feature of the KoColor V1 mobile experience. We have implemented a luxury-grade "Make it Mine" action that permanently detaches curated products from the CDN collection lifecycle.
+
+---
+
+## 🏗️ 1. The Personalization Engine (Cloning & Detachment)
+
+We established a "Sovereign Data Model" using Room to ensure user-curated items are protected during collection wipes or updates.
+
+*   **Ancestry Tracking**: Room entities include a `source_package_id`. When this ID is present, the item is linked to a CDN package.
+*   **The Clone Action**: When a user taps **"MAKE IT MINE"**, the DAO executes a transactional SQL clone:
+    ```sql
+    INSERT INTO boutique_inventory (...) 
+    SELECT ..., NULL, ... FROM boutique_inventory 
+    WHERE id = :sourceId
+    ```
+*   **Data Sovereignty**: By setting the `source_package_id` to `NULL` in the clone, the item is automatically excluded from `DELETE` queries targeting the parent package.
+
+---
+
+## 🎨 2. Luxury UI Interaction (MakeItMineButton)
+
+To match the "Digital Atelier" aesthetic, we built a specialized high-fidelity interaction component.
+
+### The `MakeItMineButton`
+*   **Asynchronous States**: Tracks `IDLE`, `ARCHIVING`, `SUCCESS`, and `ERROR` states.
+*   **Graceful Transitions**: Uses Compose `Crossfade` animations to transition between "MAKE IT MINE" and "SAVED TO ARCHIVE".
+*   **Feedback Loops**: Provides immediate tactile feedback via a circular progress indicator during the database transaction.
+*   **Visual Confirmation**: The button turns a verified green upon success, signaling that the product is now a permanent resident of the user's archive.
+
+---
+
+## ⚙️ 3. Architectural Integration
+
+*   **ViewModel Orchestration**: `CosmeticsViewModel` and `WardrobeViewModel` manage the `ArchiveStatus` StateFlows, ensuring the UI thread remains fluid during the database write.
+*   **Centralized UI**: Moved the `MakeItMineButton` to the `:core:ui` module to ensure consistent branding across both Cosmetics and Wardrobe features.
+*   **Navigation 3 Hook**: The `KoColorNavEntryProvider` seamlessly passes the real-time archive status from the ViewModels to the Detail screens.
+
+---
+
+## ✅ Summary of Achievements
+*   **User Empowerment**: Users can curate and "keep" professional data forever.
+*   **Zero-Maintenance**: Personal archives survive any backend data refreshes.
+*   **High-Fidelity**: Premium animations and state management elevate the action into a luxury experience.
+
+**Status**: 🚀 **PERSONALIZATION ENGINE ACTIVE**

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticDetailScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticDetailScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.model.ritual.ArchiveStatus
 import com.zoewave.probase.core.model.ritual.ChemistryBase
 import com.zoewave.probase.core.model.ritual.ChemistryPhase
 import com.zoewave.probase.core.model.ritual.CosmeticItem
@@ -61,6 +62,7 @@ import com.zoewave.probase.core.model.ritual.Formulation
 import com.zoewave.probase.core.model.ritual.InventorySource
 import com.zoewave.probase.core.model.ritual.MacroCategory
 import com.zoewave.probase.core.model.ritual.MicroCategory
+import com.zoewave.probase.core.ui.components.MakeItMineButton
 import com.zoewave.probase.core.ui.intelligence.CompatibilityBadge
 import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
 import com.zoewave.probase.core.util.ChemistryCompatibilityEngine
@@ -84,7 +86,8 @@ data class CosmeticDetailUiState(
     val estimatedDaysRemaining: Int? = 45,
     val colorCompatibility: List<String> = listOf("#FBF8F5", "#E6A68A", "#2C2420"), 
     val bioSyncMessage: String? = "✨ High Synergy Today: Your hydration markers are low (0.0L); this Hyaluronic Acid will compensate.",
-    val uvIndex: Double = 0.0
+    val uvIndex: Double = 0.0,
+    val archiveStatus: ArchiveStatus = ArchiveStatus.IDLE
 )
 
 @Preview(showBackground = true, name = "Populated")
@@ -447,16 +450,10 @@ fun CosmeticDetailScreen(
             // Action Buttons
             Column(modifier = Modifier.padding(horizontal = 24.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 if (item.sourceType != InventorySource.USER_SCAN && item.sourceType != InventorySource.CLONED) {
-                    Button(
-                        onClick = { onEvent(CosmeticsEvent.CloneToPersonal(item)) },
-                        modifier = Modifier.fillMaxWidth().height(56.dp),
-                        shape = RoundedCornerShape(8.dp),
-                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF745E7A)) // Luxury Purple
-                    ) {
-                        Icon(Icons.Default.ContentCopy, null, modifier = Modifier.size(18.dp))
-                        Spacer(Modifier.width(8.dp))
-                        Text("MAKE IT MINE", fontWeight = FontWeight.Bold)
-                    }
+                    MakeItMineButton(
+                        status = uiState.archiveStatus,
+                        onClick = { onEvent(CosmeticsEvent.CloneToPersonal(item)) }
+                    )
                 }
 
                 Button(

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.core.data.repository.AiConfigurationSettings
 import com.zoewave.probase.core.model.network.ServiceStatus
+import com.zoewave.probase.core.model.ritual.ArchiveStatus
 import com.zoewave.probase.core.model.ritual.CosmeticItem
 import com.zoewave.probase.core.model.ritual.Finish
 import com.zoewave.probase.core.model.ritual.Formulation
@@ -34,6 +35,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -75,7 +77,8 @@ data class CosmeticsUiState(
     val scanState: FashionSessionRepository.ScanStatus = FashionSessionRepository.ScanStatus.IDLE,
     val discoveryStatus: com.zoewave.probase.core.model.network.DiscoveryStatus = com.zoewave.probase.core.model.network.DiscoveryStatus(),
     val isObfContributionEnabled: Boolean = false,
-    val uvIndex: Double = 0.0
+    val uvIndex: Double = 0.0,
+    val archiveStatuses: Map<Long, ArchiveStatus> = emptyMap()
 ) {
     val canContributeToObf: Boolean get() = !draftItem.batchCode.isNullOrBlank()
     val isScanSuccessful: Boolean get() = scanState == FashionSessionRepository.ScanStatus.SUCCESS
@@ -126,6 +129,7 @@ class CosmeticsViewModel @Inject constructor(
     private val _scanStatus = MutableStateFlow<String?>(null)
     private val _isObfContributionEnabled = MutableStateFlow(false)
     private val _uvIndex = MutableStateFlow(0.0)
+    private val _archiveStatuses = MutableStateFlow<Map<Long, ArchiveStatus>>(emptyMap())
 
     init {
         fetchWeather()
@@ -172,7 +176,8 @@ class CosmeticsViewModel @Inject constructor(
         _categoryFilter,
         _scanStatus,
         _isObfContributionEnabled,
-        _uvIndex
+        _uvIndex,
+        _archiveStatuses
     ) { array ->
         val models = array[0] as List<CosmeticItem>
         val aiResult = array[1] as CosmeticItem?
@@ -185,6 +190,7 @@ class CosmeticsViewModel @Inject constructor(
         val scanStatus = array[8] as String?
         val contributionEnabled = array[9] as Boolean
         val uvVal = array[10] as Double
+        val archiveStatuses = array[11] as Map<Long, ArchiveStatus>
 
         val groupStats = models.groupBy { it.macroCategory.displayName }.mapValues { it.value.size }
         
@@ -246,7 +252,8 @@ class CosmeticsViewModel @Inject constructor(
             scanState = scanState,
             discoveryStatus = discStatus,
             isObfContributionEnabled = contributionEnabled,
-            uvIndex = uvVal
+            uvIndex = uvVal,
+            archiveStatuses = archiveStatuses
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, CosmeticsUiState())
 
@@ -558,17 +565,22 @@ class CosmeticsViewModel @Inject constructor(
     }
 
     private fun cloneToPersonal(item: CosmeticItem) {
+        if (_archiveStatuses.value[item.id] == ArchiveStatus.SUCCESS || 
+            _archiveStatuses.value[item.id] == ArchiveStatus.ARCHIVING) return
+
         viewModelScope.launch {
-            val cloned = item.copy(
-                id = 0L, // New record
-                sourceType = InventorySource.CLONED,
-                sourcePackId = null, // Detach from pack wipe
-                provenance = null,   // Critical: Remove provenance to protect from collection removal
-                parentItemId = item.id.toString(),
-                timestamp = System.currentTimeMillis()
-            )
-            cosmeticRepository.saveCosmeticItem(cloned)
-            Log.d("CosmeticsVM", "Item cloned to personal archive: ${cloned.name}")
+            _archiveStatuses.update { it + (item.id to ArchiveStatus.ARCHIVING) }
+            
+            try {
+                // Use the DAO's optimized SQL cloning logic
+                cosmeticRepository.cloneToPersonalArchive(item.id)
+                
+                // Keep the success state visible for a moment for UX
+                _archiveStatuses.update { it + (item.id to ArchiveStatus.SUCCESS) }
+            } catch (e: Exception) {
+                Log.e("CosmeticsVM", "Cloning failed", e)
+                _archiveStatuses.update { it + (item.id to ArchiveStatus.ERROR) }
+            }
         }
     }
 

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/CosmeticInventoryRepositoryImpl.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/CosmeticInventoryRepositoryImpl.kt
@@ -57,4 +57,9 @@ class CosmeticInventoryRepositoryImpl @Inject constructor(
         Log.d("CosmeticRepo", "deleteCosmeticsByPack: Deleting items for pack $packId")
         cosmeticDao.deleteCosmeticsByPackId(packId)
     }
+
+    override suspend fun cloneToPersonalArchive(id: Long): Result<Unit> = runCatching {
+        Log.d("CosmeticRepo", "cloneToPersonalArchive: Cloning item $id")
+        cosmeticDao.cloneToPersonalArchive(id)
+    }
 }

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/WardrobeRepositoryImpl.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/WardrobeRepositoryImpl.kt
@@ -141,6 +141,13 @@ class WardrobeRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun cloneToPersonalArchive(id: Long): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            Log.d(TAG, "cloneToPersonalArchive: Cloning item $id")
+            clothingDao.cloneToPersonalArchive(id)
+        }
+    }
+
     private suspend fun analyzeGarment(item: ClothingItem): ClothingItem {
         val imagePath = item.imageUrl ?: return item
         return try {

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeDetailScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeDetailScreen.kt
@@ -32,15 +32,19 @@ import com.zoewave.probase.kocolor.features.inventory.ui.components.DetailRow
 import com.zoewave.probase.kocolor.features.inventory.ui.components.MetricItem
 import com.zoewave.probase.kocolor.features.inventory.ui.components.ProInsightCard
 import com.zoewave.probase.kocolor.features.inventory.ui.components.SectionHeader
+import com.zoewave.probase.core.model.ritual.ArchiveStatus
 import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.core.model.ritual.ClothingItem
+import com.zoewave.probase.core.model.ritual.InventorySource
+import com.zoewave.probase.core.ui.components.MakeItMineButton
 import com.zoewave.probase.kocolor.model.KoColorRoute
 import java.text.NumberFormat
 import java.util.*
 
 data class WardrobeDetailUiState(
     val itemId: Long,
-    val wardrobeUiState: WardrobeUiState
+    val wardrobeUiState: WardrobeUiState,
+    val archiveStatus: ArchiveStatus = ArchiveStatus.IDLE
 )
 
 @Preview(showBackground = true)
@@ -80,6 +84,7 @@ fun WardrobeDetailScreen(
 ) {
     val item = uiState.wardrobeUiState.items.find { it.id == uiState.itemId } ?: return
     val atelierBrown = Color(0xFF8B5E3C)
+    val archiveStatus = uiState.archiveStatus
 
     Scaffold(
         topBar = {
@@ -96,6 +101,17 @@ fun WardrobeDetailScreen(
                     }
                 }
             )
+        },
+        bottomBar = {
+            if (item.sourceType != InventorySource.USER_SCAN && item.sourceType != InventorySource.CLONED) {
+                Box(modifier = Modifier.padding(16.dp)) {
+                    MakeItMineButton(
+                        status = archiveStatus,
+                        onClick = { onEvent(WardrobeEvent.CloneToPersonal(item)) },
+                        containerColor = atelierBrown
+                    )
+                }
+            }
         }
     ) { padding ->
         Column(

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.kocolor.data.repository.WardrobeRepository
 import com.zoewave.probase.kocolor.data.repository.FashionSessionRepository
+import com.zoewave.probase.core.model.ritual.ArchiveStatus
 import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.core.model.ritual.ClothingItem
 import com.zoewave.probase.core.model.ritual.InventorySource
@@ -34,7 +35,8 @@ data class WardrobeUiState(
     val totalInvestment: Double = 0.0,
     val totalItems: Int = 0,
     val itemsByCategory: Map<String, Int> = emptyMap(),
-    val categoriesMetadata: Map<String, CategoryMetadata> = emptyMap()
+    val categoriesMetadata: Map<String, CategoryMetadata> = emptyMap(),
+    val archiveStatuses: Map<Long, ArchiveStatus> = emptyMap()
 )
 
 sealed class WardrobeEvent {
@@ -55,6 +57,7 @@ class WardrobeViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _draftItem = MutableStateFlow(ClothingItem(name = "", category = ClothingCategory.TOPS, colorHex = "#FFFFFF"))
+    private val _archiveStatuses = MutableStateFlow<Map<Long, ArchiveStatus>>(emptyMap())
 
     private var lastProcessedUri: String? = null
 
@@ -98,8 +101,9 @@ class WardrobeViewModel @Inject constructor(
 
     val uiState: StateFlow<WardrobeUiState> = combine(
         wardrobeRepository.getAllClothing(),
-        _draftItem
-    ) { models, draft ->
+        _draftItem,
+        _archiveStatuses
+    ) { models, draft, archiveStatuses ->
         val totalInvestment = models.sumOf { it.price ?: 0.0 }
         val itemsByCategory = models.groupBy { it.category.name }.mapValues { it.value.size }
         
@@ -129,7 +133,8 @@ class WardrobeViewModel @Inject constructor(
             totalInvestment = totalInvestment,
             totalItems = models.size,
             itemsByCategory = itemsByCategory,
-            categoriesMetadata = categoryMetadata
+            categoriesMetadata = categoryMetadata,
+            archiveStatuses = archiveStatuses
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), WardrobeUiState())
 
@@ -197,17 +202,19 @@ class WardrobeViewModel @Inject constructor(
     }
 
     private fun cloneToPersonal(item: ClothingItem) {
+        if (_archiveStatuses.value[item.id] == ArchiveStatus.SUCCESS || 
+            _archiveStatuses.value[item.id] == ArchiveStatus.ARCHIVING) return
+
         viewModelScope.launch {
-            val cloned = item.copy(
-                id = 0L,
-                sourceType = InventorySource.CLONED,
-                sourcePackId = null,
-                provenance = null, // Critical: Remove provenance to protect from collection removal
-                parentItemId = item.id.toString(),
-                timestamp = System.currentTimeMillis()
-            )
-            wardrobeRepository.saveClothingItem(cloned)
-            Log.d("WardrobeVM", "Clothing item cloned: ${cloned.name}")
+            _archiveStatuses.update { it + (item.id to ArchiveStatus.ARCHIVING) }
+            
+            try {
+                wardrobeRepository.cloneToPersonalArchive(item.id)
+                _archiveStatuses.update { it + (item.id to ArchiveStatus.SUCCESS) }
+            } catch (e: Exception) {
+                Log.e("WardrobeVM", "Cloning failed", e)
+                _archiveStatuses.update { it + (item.id to ArchiveStatus.ERROR) }
+            }
         }
     }
 }

--- a/core/model/src/main/java/com/zoewave/probase/core/model/ritual/ArchiveStatus.kt
+++ b/core/model/src/main/java/com/zoewave/probase/core/model/ritual/ArchiveStatus.kt
@@ -1,0 +1,5 @@
+package com.zoewave.probase.core.model.ritual
+
+enum class ArchiveStatus {
+    IDLE, ARCHIVING, SUCCESS, ERROR
+}

--- a/core/ui/src/main/java/com/zoewave/probase/core/ui/components/MakeItMineButton.kt
+++ b/core/ui/src/main/java/com/zoewave/probase/core/ui/components/MakeItMineButton.kt
@@ -1,0 +1,69 @@
+package com.zoewave.probase.core.ui.components
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.zoewave.probase.core.model.ritual.ArchiveStatus
+
+@Composable
+fun MakeItMineButton(
+    status: ArchiveStatus,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    containerColor: Color = Color(0xFF745E7A) // Default luxury purple
+) {
+    Button(
+        onClick = onClick,
+        enabled = status == ArchiveStatus.IDLE || status == ArchiveStatus.ERROR,
+        shape = RoundedCornerShape(12.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = containerColor,
+            disabledContainerColor = if (status == ArchiveStatus.SUCCESS) Color(0xFF4CAF50) else Color.LightGray,
+            contentColor = Color.White,
+            disabledContentColor = Color.White
+        ),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+    ) {
+        Crossfade(targetState = status, label = "Button State Animation") { currentState ->
+            when (currentState) {
+                ArchiveStatus.IDLE -> {
+                    Text(
+                        text = "MAKE IT MINE",
+                        style = MaterialTheme.typography.labelLarge.copy(
+                            letterSpacing = 2.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    )
+                }
+                ArchiveStatus.ARCHIVING -> {
+                    CircularProgressIndicator(
+                        color = Color.White,
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+                ArchiveStatus.SUCCESS -> {
+                    Text(
+                        text = "SAVED TO ARCHIVE",
+                        style = MaterialTheme.typography.labelLarge.copy(
+                            letterSpacing = 2.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    )
+                }
+                ArchiveStatus.ERROR -> {
+                    Text("ERROR - TRY AGAIN", style = MaterialTheme.typography.labelLarge)
+                }
+            }
+        }
+    }
+}

--- a/server/docs/Specification/DOCUMENTATION_TOC.md
+++ b/server/docs/Specification/DOCUMENTATION_TOC.md
@@ -37,8 +37,9 @@ This index provides a centralized Table of Contents for all architectural bluepr
 *Implementation details for the primary verification and ingestion gateway.*
 
 *   **[Mobile Ingestion Implementation](../../applications/kocolor/docs/Pipeline/Mobile_Ingestion_Implementation.md)**: Blueprint for verified streaming, Zstd, and Room sync.
-*   **[Ingestion & Security Walkthrough](../../applications/kocolor/docs/Walkthrough_Mobile_Ingestion_Enrichment.md)**: Technical guide for scientific enrichment, BlurHash, and "Make it Mine" cloning.
-*   **[Boutique UI Specification](../../applications/kocolor/docs/UI/Implementation_V1_Core.md)**: High-fidelity selection UI and sticky header constraints.
+*   [**Ingestion & Security Walkthrough**](../../applications/kocolor/docs/Walkthrough_Mobile_Ingestion_Enrichment.md): Technical guide for scientific enrichment and BlurHash.
+*   [**"Make it Mine" Personalization**](../../applications/kocolor/docs/Walkthrough_Make_It_Mine_HighFidelity.md): Luxury cloning engine and data sovereignty model.
+*   [**Boutique UI Specification**](../../applications/kocolor/docs/UI/Implementation_V1_Core.md): High-fidelity selection UI and sticky header constraints.
 *   **Feature Modules**:
     *   [BoxCapture](../../applications/kocolor/docs/BoxCapture/walkthrough.md)
     *   [GenAI Engine](../../applications/kocolor/docs/GenAI/walkthrough.md)


### PR DESCRIPTION
This commit introduces the "Make it Mine" functionality across the Cosmetics and Wardrobe features, allowing users to clone items from curated collections into a personal archive. This implementation establishes a sovereign data model that detaches user-selected items from the CDN package lifecycle, ensuring data permanence and providing a luxury-grade UI experience with state-aware animations.

- **Sovereign Data Model & Repository**:
    - Introduced `ArchiveStatus` enum (IDLE, ARCHIVING, SUCCESS, ERROR) to track the ingestion lifecycle.
    - Added `cloneToPersonalArchive` to `WardrobeRepository` and `CosmeticInventoryRepository` to facilitate transactional SQL cloning of inventory items.
    - Updated repository implementations to delegate cloning operations to their respective DAOs, ensuring items are detached from source package IDs.
- **High-Fidelity UI Components**:
    - Created a reusable `MakeItMineButton` in `:core:ui` that uses `Crossfade` animations to transition between action, progress, and success states.
    - Integrated `MakeItMineButton` into `CosmeticDetailScreen` and `WardrobeDetailScreen`, replacing generic buttons with the luxury-themed interaction.
- **ViewModel & State Management**:
    - Updated `CosmeticsViewModel` and `WardrobeViewModel` to manage a map of `archiveStatuses`, providing real-time feedback during cloning operations.
    - Refactored `KoColorNavEntryProvider` to inject the archive status into detail screen UI states via Hilt-managed ViewModels.
- **Documentation & Walkthroughs**:
    - Added `Walkthrough_Make_It_Mine_HighFidelity.md` to document the technical implementation of the personalization engine and data sovereignty model.
    - Updated `Intelligence_UI_Implementation.md` and the central documentation TOC to reflect the completion of the sovereign ingestion wiring.