### PR TITLE
refactor: rename item ID to internalId and enhance cloning logic

### DIFF
--- a/applications/kocolor/apps/mobile/features/color/src/main/java/com/zoewave/probase/kocolor/mobile/features/color/ui/ColorSearchScreen.kt
+++ b/applications/kocolor/apps/mobile/features/color/src/main/java/com/zoewave/probase/kocolor/mobile/features/color/ui/ColorSearchScreen.kt
@@ -3,7 +3,20 @@ package com.zoewave.probase.kocolor.mobile.features.color.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -20,7 +33,16 @@ import androidx.compose.material.icons.filled.Compare
 import androidx.compose.material.icons.filled.FilterVintage
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.SwapHoriz
-import androidx.compose.material3.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -258,7 +280,7 @@ fun ColorSearchScreen(
                         items(uiState.matchedCosmetics) { item ->
                             ResultCard(
                                 uiState = ResultCardUiState(item.name, item.brand, item.imageUrl),
-                                onEvent = { navTo(KoColorRoute.CosmeticDetail(item.id)) },
+                                onEvent = { navTo(KoColorRoute.CosmeticDetail(item.internalId)) },
                                 navTo = navTo
                             )
                         }
@@ -277,7 +299,7 @@ fun ColorSearchScreen(
                         items(uiState.matchedWardrobe) { item ->
                             ResultCard(
                                 uiState = ResultCardUiState(item.name, item.brand ?: "", item.imageUrl),
-                                onEvent = { navTo(KoColorRoute.WardrobeDetail(item.id)) },
+                                onEvent = { navTo(KoColorRoute.WardrobeDetail(item.internalId)) },
                                 navTo = navTo
                             )
                         }

--- a/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeViewModel.kt
+++ b/applications/kocolor/apps/mobile/features/home/src/main/java/com/zoewave/probase/kocolor/mobile/features/home/ui/HomeViewModel.kt
@@ -322,7 +322,7 @@ class HomeViewModel @Inject constructor(
     )
 
     private fun CosmeticItemEntity.toModel() = CosmeticItem(
-        id = id,
+        internalId = internalId,
         name = name,
         brand = brand,
         macroCategory = macroCategory,
@@ -349,7 +349,7 @@ class HomeViewModel @Inject constructor(
     )
 
     private fun ClothingItemEntity.toModel() = ClothingItem(
-        id = id,
+        internalId = internalId,
         name = name,
         brand = brand,
         category = category,

--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavEntry
 import androidx.xr.projected.ProjectedContext
 import androidx.xr.projected.experimental.ExperimentalProjectedApi
+import com.zoewave.probase.core.model.ritual.ArchiveStatus
+import com.zoewave.probase.features.camera.productcapture.ui.DiscoveryStatusScreen
 import com.zoewave.probase.features.health.nutrition.ui.shared.MealsUiEvent
 import com.zoewave.probase.features.health.nutrition.ui.shared.MealsUiRoute
 import com.zoewave.probase.features.health.nutrition.ui.shared.MealsUiState
@@ -16,7 +18,6 @@ import com.zoewave.probase.features.health.nutrition.ui.shared.MealsViewModel
 import com.zoewave.probase.features.readers.barcode.ui.BarcodeScannerScreen
 import com.zoewave.probase.features.readers.qrscanner.ui.QRCodeScannerScreen
 import com.zoewave.probase.features.weather.ui.WeatherUiRoute
-import com.zoewave.probase.core.model.ritual.ArchiveStatus
 import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulatorScreen
 import com.zoewave.probase.kocolor.features.analyzer.simulator.ui.StyleSimulatorViewModel
 import com.zoewave.probase.kocolor.features.analyzer.ui.AnalyzerUiRoute
@@ -28,7 +29,6 @@ import com.zoewave.probase.kocolor.features.clothingcapture.ui.ClothingCaptureEv
 import com.zoewave.probase.kocolor.features.clothingcapture.ui.ClothingCaptureUiRoute
 import com.zoewave.probase.kocolor.features.clothingcapture.ui.ClothingCaptureViewModel
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticAnalyticsScreen
-import com.zoewave.probase.features.camera.productcapture.ui.DiscoveryStatusScreen
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticCategoryCoverScreen
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticCategoryCoverUiState
 import com.zoewave.probase.kocolor.features.cosmetics.ui.CosmeticDetailScreen
@@ -58,7 +58,9 @@ import com.zoewave.probase.kocolor.features.routines.ui.RoutineEditorScreen
 import com.zoewave.probase.kocolor.features.routines.ui.RoutineEditorUiState
 import com.zoewave.probase.kocolor.features.routines.ui.RoutinesUiRoute
 import com.zoewave.probase.kocolor.features.routines.ui.RoutinesViewModel
-import com.zoewave.probase.kocolor.features.starterpack.ui.StarterPackEvent
+import com.zoewave.probase.kocolor.features.starterpack.ui.PackPreviewViewModel
+import com.zoewave.probase.kocolor.features.starterpack.ui.packpreview.PackPreviewScreen
+import com.zoewave.probase.kocolor.features.starterpack.ui.synchub.SyncHubScreen
 import com.zoewave.probase.kocolor.mobile.core.ui.health.HealthUiRoute
 import com.zoewave.probase.kocolor.mobile.features.color.ui.ColorDetailScreen
 import com.zoewave.probase.kocolor.mobile.features.color.ui.ColorDetailUiState
@@ -73,10 +75,6 @@ import com.zoewave.probase.kocolor.mobile.features.home.ui.CollectionHubScreen
 import com.zoewave.probase.kocolor.mobile.features.home.ui.HomeUiRoute
 import com.zoewave.probase.kocolor.mobile.features.home.ui.HomeViewModel
 import com.zoewave.probase.kocolor.mobile.features.settings.ui.components.SettingsUiRoute
-import com.zoewave.probase.kocolor.features.starterpack.ui.synchub.SyncHubScreen
-import com.zoewave.probase.kocolor.features.starterpack.ui.packpreview.PackPreviewScreen
-import com.zoewave.probase.kocolor.features.starterpack.ui.PackPreviewViewModel
-import com.zoewave.probase.kocolor.features.starterpack.ui.StarterPackViewModel
 import com.zoewave.probase.kocolor.model.KoColorRoute
 import kotlinx.coroutines.flow.collectLatest
 
@@ -455,7 +453,7 @@ fun koColorNavEntryProvider(
         is KoColorRoute.CosmeticDetail -> NavEntry(route) {
             val viewModel: CosmeticsViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
-            val item = state.items.find { it.id == route.itemId }
+            val item = state.items.find { it.internalId == route.itemId }
             val archiveStatus = state.archiveStatuses[route.itemId] ?: ArchiveStatus.IDLE
             
             CosmeticDetailScreen(

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/ClothingMapper.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/ClothingMapper.kt
@@ -6,7 +6,7 @@ import com.zoewave.probase.core.model.ritual.Provenance as ModelProvenance
 import com.zoewave.probase.kocolor.db.entity.Provenance as DbProvenance
 
 fun ClothingItemEntity.toModel(): ClothingItem = ClothingItem(
-    id = id,
+    internalId = internalId,
     name = name,
     brand = brand,
     category = category,
@@ -51,7 +51,7 @@ fun ClothingItemEntity.toModel(): ClothingItem = ClothingItem(
 )
 
 fun ClothingItem.toEntity(): ClothingItemEntity = ClothingItemEntity(
-    id = id,
+    internalId = internalId,
     name = name,
     brand = brand,
     category = category,

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/CosmeticMapper.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/CosmeticMapper.kt
@@ -6,7 +6,7 @@ import com.zoewave.probase.core.model.ritual.Provenance as ModelProvenance
 import com.zoewave.probase.kocolor.db.entity.Provenance as DbProvenance
 
 fun CosmeticItemEntity.toModel(): CosmeticItem = CosmeticItem(
-    id = id,
+    internalId = internalId,
     name = name,
     brand = brand,
     macroCategory = macroCategory,
@@ -89,7 +89,7 @@ fun CosmeticItemEntity.toModel(): CosmeticItem = CosmeticItem(
 )
 
 fun CosmeticItem.toEntity(): CosmeticItemEntity = CosmeticItemEntity(
-    id = id,
+    internalId = internalId,
     name = name,
     brand = brand,
     macroCategory = macroCategory,

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/CosmeticInventoryRepository.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/CosmeticInventoryRepository.kt
@@ -10,5 +10,5 @@ interface CosmeticInventoryRepository {
     suspend fun saveCosmeticItems(items: List<CosmeticItem>)
     suspend fun deleteCosmeticItem(id: Long)
     suspend fun deleteCosmeticsByPack(packId: String): Result<Unit>
-    suspend fun cloneToPersonalArchive(id: Long): Result<Unit>
+    suspend fun cloneToPersonalArchive(internalId: Long): Result<Unit>
 }

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/WardrobeRepository.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/WardrobeRepository.kt
@@ -12,5 +12,5 @@ interface WardrobeRepository {
     suspend fun wearClothingItem(id: Long)
     suspend fun deleteClothing(id: Long)
     suspend fun deleteClothingByPack(packId: String): Result<Unit>
-    suspend fun cloneToPersonalArchive(id: Long): Result<Unit>
+    suspend fun cloneToPersonalArchive(internalId: Long): Result<Unit>
 }

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/ClothingDao.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/ClothingDao.kt
@@ -18,7 +18,7 @@ interface ClothingDao {
     @Query("SELECT * FROM clothing_items WHERE category = :category ORDER BY timestamp DESC")
     fun getClothingByCategory(category: String): Flow<List<ClothingItemEntity>>
 
-    @Query("SELECT * FROM clothing_items WHERE id = :id")
+    @Query("SELECT * FROM clothing_items WHERE internalId = :id")
     fun getClothingById(id: Long): Flow<ClothingItemEntity?>
 
     @Query("SELECT * FROM clothing_items WHERE formality >= :minFormality ORDER BY timestamp DESC")
@@ -34,7 +34,7 @@ interface ClothingDao {
     @Update
     suspend fun updateClothing(item: ClothingItemEntity)
 
-    @Query("DELETE FROM clothing_items WHERE id = :id")
+    @Query("DELETE FROM clothing_items WHERE internalId = :id")
     suspend fun deleteClothing(id: Long)
 
     @Transaction
@@ -61,7 +61,7 @@ interface ClothingDao {
             colorTemperature, seasonalPalette, contrastLevel, koColorGroup, 'USER_SCAN', 
             sourceName, NULL
         FROM clothing_items 
-        WHERE id = :sourceId
+        WHERE internalId = :sourceInternalId
     """)
-    suspend fun cloneToPersonalArchive(sourceId: Long, timestamp: Long = System.currentTimeMillis())
+    suspend fun cloneToPersonalArchive(sourceInternalId: Long, timestamp: Long = System.currentTimeMillis())
 }

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/CosmeticDao.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/CosmeticDao.kt
@@ -25,7 +25,7 @@ interface CosmeticDao {
     @Query("SELECT * FROM cosmetic_items WHERE microCategory = :microCategory ORDER BY timestamp DESC")
     fun getCosmeticsByMicroCategory(microCategory: MicroCategory): Flow<List<CosmeticItemEntity>>
 
-    @Query("SELECT * FROM cosmetic_items WHERE id = :id")
+    @Query("SELECT * FROM cosmetic_items WHERE internalId = :id")
     fun getCosmeticById(id: Long): Flow<CosmeticItemEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -38,7 +38,7 @@ interface CosmeticDao {
     @Update
     suspend fun updateCosmetic(item: CosmeticItemEntity)
 
-    @Query("DELETE FROM cosmetic_items WHERE id = :id")
+    @Query("DELETE FROM cosmetic_items WHERE internalId = :id")
     suspend fun deleteCosmetic(id: Long)
 
     @Transaction
@@ -66,7 +66,7 @@ interface CosmeticDao {
             paoMonths, price, volume, ingredients, allergens, isVegan, isCrueltyFree, fdaDataVerified,
             'USER_SCAN', sourceName, NULL
         FROM cosmetic_items 
-        WHERE id = :sourceId
+        WHERE internalId = :sourceInternalId
     """)
-    suspend fun cloneToPersonalArchive(sourceId: Long, timestamp: Long = System.currentTimeMillis())
+    suspend fun cloneToPersonalArchive(sourceInternalId: Long, timestamp: Long = System.currentTimeMillis())
 }

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/ProductDao.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/ProductDao.kt
@@ -13,7 +13,7 @@ interface ProductDao {
     @Query("SELECT * FROM discovered_products ORDER BY timestamp DESC")
     fun getAllProducts(): Flow<List<ProductEntity>>
 
-    @Query("SELECT * FROM discovered_products WHERE id = :id")
+    @Query("SELECT * FROM discovered_products WHERE internalId = :id")
     suspend fun getProductById(id: Long): ProductEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -22,6 +22,6 @@ interface ProductDao {
     @Update
     suspend fun updateProduct(product: ProductEntity)
 
-    @Query("DELETE FROM discovered_products WHERE id = :id")
+    @Query("DELETE FROM discovered_products WHERE internalId = :id")
     suspend fun deleteProduct(id: Long)
 }

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/ClothingItemEntity.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/ClothingItemEntity.kt
@@ -10,7 +10,7 @@ import com.zoewave.probase.core.model.ritual.InventorySource
 
 @Entity(tableName = "clothing_items")
 data class ClothingItemEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey(autoGenerate = true) val internalId: Long = 0,
     val name: String,
     val brand: String? = null,
     val category: ClothingCategory,

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/CosmeticItemEntity.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/CosmeticItemEntity.kt
@@ -15,7 +15,7 @@ import com.zoewave.probase.core.model.ritual.Temperature
 
 @Entity(tableName = "cosmetic_items")
 data class CosmeticItemEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey(autoGenerate = true) val internalId: Long = 0,
     val name: String,
     val brand: String,
     val macroCategory: MacroCategory,

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/ProductEntity.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/ProductEntity.kt
@@ -15,7 +15,7 @@ enum class EnrichmentStatus {
  */
 @Entity(tableName = "discovered_products")
 data class ProductEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey(autoGenerate = true) val internalId: Long = 0,
     val brand: String,
     val productName: String,
     val category: String? = null,

--- a/applications/kocolor/docs/Walkthrough_Make_It_Mine_HighFidelity.md
+++ b/applications/kocolor/docs/Walkthrough_Make_It_Mine_HighFidelity.md
@@ -11,9 +11,9 @@ We established a "Sovereign Data Model" using Room to ensure user-curated items 
 *   **Ancestry Tracking**: Room entities include a `source_package_id`. When this ID is present, the item is linked to a CDN package.
 *   **The Clone Action**: When a user taps **"MAKE IT MINE"**, the DAO executes a transactional SQL clone:
     ```sql
-    INSERT INTO boutique_inventory (...) 
-    SELECT ..., NULL, ... FROM boutique_inventory 
-    WHERE id = :sourceId
+    INSERT INTO cosmetic_items (...) 
+    SELECT ..., NULL, ... FROM cosmetic_items 
+    WHERE internalId = :sourceInternalId
     ```
 *   **Data Sovereignty**: By setting the `source_package_id` to `NULL` in the clone, the item is automatically excluded from `DELETE` queries targeting the parent package.
 
@@ -27,6 +27,7 @@ To match the "Digital Atelier" aesthetic, we built a specialized high-fidelity i
 *   **Asynchronous States**: Tracks `IDLE`, `ARCHIVING`, `SUCCESS`, and `ERROR` states.
 *   **Graceful Transitions**: Uses Compose `Crossfade` animations to transition between "MAKE IT MINE" and "SAVED TO ARCHIVE".
 *   **Feedback Loops**: Provides immediate tactile feedback via a circular progress indicator during the database transaction.
+*   **Double-Tap Protection**: The ViewModel intercepts the action and immediately evaluates the `ArchiveStatus`. If the state is `ARCHIVING` or `SUCCESS`, subsequent taps are silently ignored, preventing duplicate clones in the database.
 *   **Visual Confirmation**: The button turns a verified green upon success, signaling that the product is now a permanent resident of the user's archive.
 
 ---

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/data/StyleSimulatorEngine.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/data/StyleSimulatorEngine.kt
@@ -144,14 +144,14 @@ class StyleSimulatorEngine @Inject constructor(
         val anchoredCategories = anchoredWardrobe.map { it.category }.toSet()
         val prunedWardrobe = wardrobe.filter { item ->
             if (anchoredCategories.contains(item.category)) {
-                anchoredWardrobe.any { it.id == item.id }
+                anchoredWardrobe.any { it.internalId == item.internalId }
             } else true
         }
 
         val anchoredCosmeticMacros = anchoredCosmetics.map { it.macroCategory }.toSet()
         val prunedCosmetics = cosmetics.filter { item ->
             if (anchoredCosmeticMacros.contains(item.macroCategory)) {
-                anchoredCosmetics.any { it.id == item.id }
+                anchoredCosmetics.any { it.internalId == item.internalId }
             } else true
         }
 
@@ -159,13 +159,13 @@ class StyleSimulatorEngine @Inject constructor(
         val minWardrobe = prunedWardrobe.groupBy { it.category.name.lowercase() }
             .mapValues { (_, items) ->
                 items.distinctBy { "${it.category}_${it.colorFamily}" }
-                    .map { listOf("w_${it.id}", it.name.lowercase(), it.colorHex ?: "#000000", it.formality.toKey()) }
+                    .map { listOf("w_${it.internalId}", it.name.lowercase(), it.colorHex ?: "#000000", it.formality.toKey()) }
             }
 
         val minCosmetics = prunedCosmetics.groupBy { it.macroCategory.name.lowercase() }
             .mapValues { (_, items) ->
                 items.distinctBy { "${it.microCategory}_${it.colorFamily}" }
-                    .map { listOf("c_${it.id}", it.microCategory.name.lowercase(), it.colorHex ?: "#000000") }
+                    .map { listOf("c_${it.internalId}", it.microCategory.name.lowercase(), it.colorHex ?: "#000000") }
             }
 
         return json.encodeToString(CloudManifest(minWardrobe, minCosmetics))
@@ -287,8 +287,8 @@ class StyleSimulatorEngine @Inject constructor(
 
         return StyleBlueprint(
             rationale = "Local Architect: Selected from your vault based on intent.",
-            selectedClothingIds = selectedItems.map { "w_${it.id}" },
-            selectedCosmeticIds = selectedCosmetics.map { "c_${it.id}" },
+            selectedClothingIds = selectedItems.map { "w_${it.internalId}" },
+            selectedCosmeticIds = selectedCosmetics.map { "c_${it.internalId}" },
             recommendedPalette = finalPalette
         )
     }

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/StyleSimulatorViewModel.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/StyleSimulatorViewModel.kt
@@ -135,10 +135,10 @@ class StyleSimulatorViewModel @Inject constructor(
             .groupBy { it.colorFamily }
 
         val recommendedClothing = allClothing.filter { item ->
-            "w_${item.id}" in (result?.selectedClothingIds ?: emptyList())
+            "w_${item.internalId}" in (result?.selectedClothingIds ?: emptyList())
         }
         val recommendedCosmetics = allCosmetics.filter { item ->
-            "c_${item.id}" in (result?.selectedCosmeticIds ?: emptyList())
+            "c_${item.internalId}" in (result?.selectedCosmeticIds ?: emptyList())
         }
 
         StyleSimulatorUiState(
@@ -338,11 +338,11 @@ class StyleSimulatorViewModel @Inject constructor(
             val id = match.groupValues[2].toLongOrNull() ?: return@forEach
             
             val richName = if (domain == "w") {
-                clothing.find { it.id == id }?.let { 
+                clothing.find { it.internalId == id }?.let { 
                     "${it.brand ?: ""} ${it.name.removePrefix(it.brand ?: "")}".trim()
                 }
             } else {
-                cosmetics.find { it.id == id }?.let {
+                cosmetics.find { it.internalId == id }?.let {
                     "${it.brand} ${it.name.removePrefix(it.brand)}".trim()
                 }
             }
@@ -370,7 +370,7 @@ class StyleSimulatorViewModel @Inject constructor(
                 advice = state.rationale ?: "",
                 keyPieces = state.recommendedClothing.map { it.name },
                 colorCombinations = state.recommendedPalette,
-                wardrobeItemIds = state.recommendedClothing.map { it.id                },
+                wardrobeItemIds = state.recommendedClothing.map { it.internalId },
                 suggestedItems = state.recommendedClothing.map { item ->
                     SuggestedPiece(
                         name = item.name,
@@ -399,7 +399,7 @@ class StyleSimulatorViewModel @Inject constructor(
                     recommendedColors = cosmetic.colorHex?.let { listOf(it) } ?: emptyList(),
                     suggestedProductName = cosmetic.name,
                     suggestedProductImageUrl = cosmetic.imageUrl,
-                    productId = cosmetic.id
+                    productId = cosmetic.internalId
                 )
             }
 

--- a/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/VisualBlueprintModels.kt
+++ b/applications/kocolor/features/analyzer/src/main/java/com/zoewave/probase/kocolor/features/analyzer/simulator/ui/components/graphics/VisualBlueprintModels.kt
@@ -86,14 +86,14 @@ fun mapToVisualBlueprintData(
 }
 
 private fun CosmeticItem.toBlueprintItem() = BlueprintItem(
-    id = id,
+    id = internalId,
     name = name,
     colorHex = colorHex,
     imageUrl = imageUrl
 )
 
 private fun ClothingItem.toBlueprintItem() = BlueprintItem(
-    id = id,
+    id = internalId,
     name = name,
     colorHex = colorHex,
     imageUrl = imageUrl

--- a/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
+++ b/applications/kocolor/features/boxcapture/src/main/java/com/zoewave/probase/kocolor/features/boxcapture/ui/BoxCaptureViewModel.kt
@@ -284,7 +284,7 @@ class BoxCaptureViewModel @Inject constructor(
         queueEnrichment(productId)
         
         _discoveryState.value = DiscoveryState.LocalSuccess(localData)
-        _uiState.value = BoxCaptureUiState.FinalReview(productEntity.copy(id = productId))
+        _uiState.value = BoxCaptureUiState.FinalReview(productEntity.copy(internalId = productId))
     }
 
     private fun queueEnrichment(productId: Long) {

--- a/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/data/repository/ColorIntelligenceRepositoryImpl.kt
+++ b/applications/kocolor/features/colors/src/main/java/com/zoewave/probase/kocolor/features/colors/data/repository/ColorIntelligenceRepositoryImpl.kt
@@ -31,12 +31,12 @@ class ColorIntelligenceRepositoryImpl @Inject constructor(
             val wardrobeColors = wardrobe.mapNotNull { item ->
                 val hex = item.dominantHex ?: item.colorHex
                 if (hex != null) {
-                    ColorSignature(hex, item.id, SourceType.WARDROBE, item.name)
+                    ColorSignature(hex, item.internalId, SourceType.WARDROBE, item.name)
                 } else null
             }
             val cosmeticColors = cosmetics.mapNotNull { item ->
                 if (item.colorHex.isNotBlank()) {
-                    ColorSignature(item.colorHex, item.id, SourceType.VANITY, item.name)
+                    ColorSignature(item.colorHex, item.internalId, SourceType.VANITY, item.name)
                 } else null
             }
             wardrobeColors + cosmeticColors

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticAnalyticsScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticAnalyticsScreen.kt
@@ -271,7 +271,7 @@ fun CosmeticAnalyticsScreen(
                                         Row(
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .clickable { navTo(KoColorRoute.CosmeticDetail(item.id)) }
+                                                .clickable { navTo(KoColorRoute.CosmeticDetail(item.internalId)) }
                                                 .padding(vertical = 4.dp),
                                             horizontalArrangement = Arrangement.SpaceBetween,
                                             verticalAlignment = Alignment.CenterVertically
@@ -331,7 +331,7 @@ private fun CosmeticAnalyticsScreenPreview() {
             uiState = CosmeticsUiState(
                 items = listOf(
                     CosmeticItem(
-                        id = 1, 
+                        internalId = 1, 
                         name = "Silk Primer", 
                         brand = "KoColor", 
                         macroCategory = MacroCategory.PREP,
@@ -341,7 +341,7 @@ private fun CosmeticAnalyticsScreenPreview() {
                         price = 28.0
                     ),
                     CosmeticItem(
-                        id = 2, 
+                        internalId = 2, 
                         name = "Cool Ivory", 
                         brand = "KoColor", 
                         macroCategory = MacroCategory.COMPLEXION,

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticCategoryCoverScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticCategoryCoverScreen.kt
@@ -42,9 +42,9 @@ private fun CosmeticCategoryCoverScreenPreview() {
                 categoryName = "Face",
                 cosmeticsUiState = CosmeticsUiState(
                     items = listOf(
-                        CosmeticItem(id = 1, name = "Silk Primer", brand = "KoColor", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.PRIMER, usageCount = 45, price = 28.0, colorHex = "#F8F0E3"),
-                        CosmeticItem(id = 2, name = "Cool Ivory", brand = "KoColor", macroCategory = MacroCategory.COMPLEXION, microCategory = MicroCategory.FOUNDATION, usageCount = 120, price = 42.0, colorHex = "#FAD4D4"),
-                        CosmeticItem(id = 3, name = "Neutral Beige", brand = "KoColor", macroCategory = MacroCategory.COMPLEXION, microCategory = MicroCategory.FOUNDATION, usageCount = 5, price = 38.0, colorHex = "#EAD4B4")
+                        CosmeticItem(internalId = 1, name = "Silk Primer", brand = "KoColor", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.PRIMER, usageCount = 45, price = 28.0, colorHex = "#F8F0E3"),
+                        CosmeticItem(internalId = 2, name = "Cool Ivory", brand = "KoColor", macroCategory = MacroCategory.COMPLEXION, microCategory = MicroCategory.FOUNDATION, usageCount = 120, price = 42.0, colorHex = "#FAD4D4"),
+                        CosmeticItem(internalId = 3, name = "Neutral Beige", brand = "KoColor", macroCategory = MacroCategory.COMPLEXION, microCategory = MicroCategory.FOUNDATION, usageCount = 5, price = 38.0, colorHex = "#EAD4B4")
                     )
                 )
             ),

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticDetailScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticDetailScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.VerifiedUser
@@ -63,9 +62,7 @@ import com.zoewave.probase.core.model.ritual.InventorySource
 import com.zoewave.probase.core.model.ritual.MacroCategory
 import com.zoewave.probase.core.model.ritual.MicroCategory
 import com.zoewave.probase.core.ui.components.MakeItMineButton
-import com.zoewave.probase.core.ui.intelligence.CompatibilityBadge
 import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
-import com.zoewave.probase.core.util.ChemistryCompatibilityEngine
 import com.zoewave.probase.kocolor.features.cosmetics.R
 import com.zoewave.probase.kocolor.features.cosmetics.ui.components.ApplicationGuideSection
 import com.zoewave.probase.kocolor.features.cosmetics.ui.components.AtelierExpandableSection
@@ -97,7 +94,7 @@ private fun CosmeticDetailScreenPreview() {
         CosmeticDetailScreen(
             uiState = CosmeticDetailUiState(
                 item = CosmeticItem(
-                    id = 1L,
+                    internalId = 1L,
                     name = "Cool Ivory Foundation",
                     brand = "KoColor",
                     macroCategory = MacroCategory.COMPLEXION,
@@ -154,12 +151,22 @@ fun CosmeticDetailScreen(
                 actions = {
                     IconButton(onClick = { 
                         onEvent(CosmeticsEvent.StartEditing(item))
-                        navTo(KoColorRoute.CosmeticEdit(item.id))
+                        navTo(KoColorRoute.CosmeticEdit(item.internalId))
                     }) {
                         Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_edit), tint = Color.Gray)
                     }
                 }
             )
+        },
+        bottomBar = {
+            if (item.sourceType != InventorySource.USER_SCAN && item.sourceType != InventorySource.CLONED) {
+                Box(modifier = Modifier.padding(16.dp)) {
+                    MakeItMineButton(
+                        status = uiState.archiveStatus,
+                        onClick = { onEvent(CosmeticsEvent.CloneToPersonal(item)) }
+                    )
+                }
+            }
         }
     ) { padding ->
         val expandedStates = remember { 
@@ -457,7 +464,7 @@ fun CosmeticDetailScreen(
                 }
 
                 Button(
-                    onClick = { onEvent(CosmeticsEvent.UseItem(item.id)) },
+                    onClick = { onEvent(CosmeticsEvent.UseItem(item.internalId)) },
                     modifier = Modifier.fillMaxWidth().height(56.dp),
                     shape = RoundedCornerShape(8.dp),
                     colors = ButtonDefaults.buttonColors(containerColor = atelierBrown)

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticEditScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticEditScreen.kt
@@ -62,7 +62,7 @@ private fun CosmeticEditScreenPreview() {
             uiState = CosmeticEditUiState(
                 itemId = 1L,
                 draftItem = CosmeticItem(
-                    id = 1L,
+                    internalId = 1L,
                     name = "Cool Ivory",
                     brand = "KoColor",
                     macroCategory = MacroCategory.COMPLEXION,

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticsViewModel.kt
@@ -1,12 +1,15 @@
 package com.zoewave.probase.kocolor.features.cosmetics.ui
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Log
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.core.data.repository.AiConfigurationSettings
+import com.zoewave.probase.core.model.network.DiscoveryStatus
 import com.zoewave.probase.core.model.network.ServiceStatus
 import com.zoewave.probase.core.model.ritual.ArchiveStatus
 import com.zoewave.probase.core.model.ritual.CosmeticItem
@@ -75,7 +78,7 @@ data class CosmeticsUiState(
     val categoryFilter: String? = null,
     val scanStatus: String? = null,
     val scanState: FashionSessionRepository.ScanStatus = FashionSessionRepository.ScanStatus.IDLE,
-    val discoveryStatus: com.zoewave.probase.core.model.network.DiscoveryStatus = com.zoewave.probase.core.model.network.DiscoveryStatus(),
+    val discoveryStatus: DiscoveryStatus = DiscoveryStatus(),
     val isObfContributionEnabled: Boolean = false,
     val uvIndex: Double = 0.0,
     val archiveStatuses: Map<Long, ArchiveStatus> = emptyMap()
@@ -183,7 +186,7 @@ class CosmeticsViewModel @Inject constructor(
         val aiResult = array[1] as CosmeticItem?
         val draft = array[2] as CosmeticItem
         val scanState = array[3] as FashionSessionRepository.ScanStatus
-        val discStatus = array[4] as com.zoewave.probase.core.model.network.DiscoveryStatus
+        val discStatus = array[4] as DiscoveryStatus
         val query = array[5] as String
         val sort = array[6] as SortOption
         val filter = array[7] as String?
@@ -261,7 +264,7 @@ class CosmeticsViewModel @Inject constructor(
         when (event) {
             is CosmeticsEvent.AddItem -> {
                 val userItem = event.item.copy(
-                    id = 0L,
+                    internalId = 0L,
                     sourceType = InventorySource.USER_SCAN,
                     sourceName = "My Archive",
                     sourcePackId = null
@@ -295,7 +298,7 @@ class CosmeticsViewModel @Inject constructor(
             is CosmeticsEvent.InitializeEdit -> {
                 viewModelScope.launch {
                     cosmeticRepository.getAllCosmetics().map { items -> 
-                        items.find { it.id == event.itemId } 
+                        items.find { it.internalId == event.itemId } 
                     }.filterNotNull().first().let { model ->
                         sessionRepository.setCosmeticDraft(model)
                     }
@@ -309,7 +312,7 @@ class CosmeticsViewModel @Inject constructor(
                              currentDraft.brand.isBlank() && 
                              currentDraft.imageUrl == null && 
                              currentDraft.batchCode == null &&
-                             currentDraft.id == 0L)
+                             currentDraft.internalId == 0L)
                 
                 if (!isEmpty || sessionRepository.scanState.value == FashionSessionRepository.ScanStatus.ANALYZING || sessionRepository.scanState.value == FashionSessionRepository.ScanStatus.SUCCESS) return
                 
@@ -477,7 +480,7 @@ class CosmeticsViewModel @Inject constructor(
 
     private fun useItem(id: Long) {
         viewModelScope.launch {
-            val item = uiState.value.items.find { it.id == id } ?: return@launch
+            val item = uiState.value.items.find { it.internalId == id } ?: return@launch
             val updated = item.copy(
                 usageCount = item.usageCount + 1,
                 isOpened = true,
@@ -543,10 +546,10 @@ class CosmeticsViewModel @Inject constructor(
         }
     }
 
-    private fun loadBitmapFromUri(uri: Uri): android.graphics.Bitmap? {
+    private fun loadBitmapFromUri(uri: Uri): Bitmap? {
         return try {
             val inputStream = context.contentResolver.openInputStream(uri)
-            android.graphics.BitmapFactory.decodeStream(inputStream)
+            BitmapFactory.decodeStream(inputStream)
         } catch (e: Exception) {
             null
         }
@@ -565,21 +568,21 @@ class CosmeticsViewModel @Inject constructor(
     }
 
     private fun cloneToPersonal(item: CosmeticItem) {
-        if (_archiveStatuses.value[item.id] == ArchiveStatus.SUCCESS || 
-            _archiveStatuses.value[item.id] == ArchiveStatus.ARCHIVING) return
+        if (_archiveStatuses.value[item.internalId] == ArchiveStatus.SUCCESS || 
+            _archiveStatuses.value[item.internalId] == ArchiveStatus.ARCHIVING) return
 
         viewModelScope.launch {
-            _archiveStatuses.update { it + (item.id to ArchiveStatus.ARCHIVING) }
+            _archiveStatuses.update { it + (item.internalId to ArchiveStatus.ARCHIVING) }
             
             try {
                 // Use the DAO's optimized SQL cloning logic
-                cosmeticRepository.cloneToPersonalArchive(item.id)
+                cosmeticRepository.cloneToPersonalArchive(item.internalId)
                 
                 // Keep the success state visible for a moment for UX
-                _archiveStatuses.update { it + (item.id to ArchiveStatus.SUCCESS) }
+                _archiveStatuses.update { it + (item.internalId to ArchiveStatus.SUCCESS) }
             } catch (e: Exception) {
                 Log.e("CosmeticsVM", "Cloning failed", e)
-                _archiveStatuses.update { it + (item.id to ArchiveStatus.ERROR) }
+                _archiveStatuses.update { it + (item.internalId to ArchiveStatus.ERROR) }
             }
         }
     }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/InventoryManagementScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/InventoryManagementScreen.kt
@@ -107,7 +107,7 @@ fun InventoryManagementScreen(
             
             InventoryList(
                 uiState = InventoryListUiState(displayItems),
-                onEvent = { item -> navTo(KoColorRoute.CosmeticDetail(item.id)) },
+                onEvent = { item -> navTo(KoColorRoute.CosmeticDetail(item.internalId)) },
                 navTo = navTo
             )
         }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/StitchProductBuilder.kt
@@ -107,7 +107,7 @@ private fun StitchProductBuilderEditPreview() {
         StitchProductBuilder(
             uiState = CosmeticsUiState(
                 draftItem = CosmeticItem(
-                    id = 1L,
+                    internalId = 1L,
                     name = "Luminous Silk Foundation",
                     brand = "Armani",
                     macroCategory = MacroCategory.COMPLEXION,
@@ -132,7 +132,7 @@ fun StitchProductBuilder(
     val draft = uiState.draftItem
     val scrollState = rememberScrollState()
     val atelierBrown = Color(0xFF8B5E3C)
-    val isEditMode = draft.id != 0L
+    val isEditMode = draft.internalId != 0L
 
     var showColorPicker by remember { mutableStateOf(false) }
     var showDatePickerTarget by remember { mutableStateOf<String?>(null) }
@@ -231,7 +231,7 @@ fun StitchProductBuilder(
             confirmButton = {
                 TextButton(
                     onClick = { 
-                        onEvent(CosmeticsEvent.DeleteItem(draft.id))
+                        onEvent(CosmeticsEvent.DeleteItem(draft.internalId))
                         showDeleteConfirmation = false
                         navTo(KoColorRoute.Back)
                     },

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductCard.kt
@@ -38,7 +38,7 @@ fun CosmeticProductCard(
     ElevatedCard(
         modifier = modifier
             .fillMaxWidth()
-            .clickable { navTo(KoColorRoute.CosmeticDetail(uiState.id)) },
+            .clickable { navTo(KoColorRoute.CosmeticDetail(uiState.internalId)) },
         shape = RoundedCornerShape(20.dp),
         colors = CardDefaults.elevatedCardColors(containerColor = cardColor, contentColor = contentColor)
     ) {
@@ -66,7 +66,7 @@ fun CosmeticProductCard(
                     Text(text = uiState.brand, style = MaterialTheme.typography.bodySmall, color = contentColor.copy(alpha = 0.7f))
                 }
                 
-                IconButton(onClick = { onEvent(CosmeticsEvent.DeleteItem(uiState.id)) }) {
+                IconButton(onClick = { onEvent(CosmeticsEvent.DeleteItem(uiState.internalId)) }) {
                     Icon(Icons.Default.Delete, null, tint = contentColor.copy(alpha = 0.6f))
                 }
             }
@@ -79,7 +79,7 @@ fun CosmeticProductCard(
                     Text(text = uiState.costPerUse?.let { "$%.2f".format(it) } ?: stringResource(R.string.applications_kocolor_features_cosmetics_not_available), style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold)
                 }
                 Button(
-                    onClick = { onEvent(CosmeticsEvent.UseItem(uiState.id)) },
+                    onClick = { onEvent(CosmeticsEvent.UseItem(uiState.internalId)) },
                     colors = ButtonDefaults.buttonColors(containerColor = contentColor.copy(alpha = 0.2f), contentColor = contentColor),
                     shape = RoundedCornerShape(8.dp)
                 ) {

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductGridCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductGridCard.kt
@@ -28,7 +28,7 @@ fun CosmeticProductGridCard(
     navTo: (KoColorRoute) -> Unit
 ) {
     val item = uiState
-    val onClick = { navTo(KoColorRoute.CosmeticDetail(item.id)) }
+    val onClick = { navTo(KoColorRoute.CosmeticDetail(item.internalId)) }
     Card(
         modifier = Modifier.fillMaxWidth().aspectRatio(4f / 3f).clickable { onClick() },
         shape = RoundedCornerShape(24.dp)

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/RecentProductCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/RecentProductCard.kt
@@ -33,7 +33,7 @@ fun RecentProductCard(
     navTo: (KoColorRoute) -> Unit
 ) {
     val item = uiState
-    val onClick = { navTo(KoColorRoute.CosmeticDetail(item.id)) }
+    val onClick = { navTo(KoColorRoute.CosmeticDetail(item.internalId)) }
     Card(
         modifier = modifier.width(200.dp).height(260.dp).clickable(onClick = onClick),
         shape = RoundedCornerShape(24.dp)

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/CosmeticInventoryRepositoryImpl.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/CosmeticInventoryRepositoryImpl.kt
@@ -34,11 +34,11 @@ class CosmeticInventoryRepositoryImpl @Inject constructor(
         val bucketedItem = item.copy(
             colorFamily = ColorQuantizer.snapToFamily(item.colorHex)
         )
-        return if (bucketedItem.id == 0L) {
+        return if (bucketedItem.internalId == 0L) {
             cosmeticDao.insertCosmetic(bucketedItem.toEntity())
         } else {
             cosmeticDao.updateCosmetic(bucketedItem.toEntity())
-            bucketedItem.id
+            bucketedItem.internalId
         }
     }
 
@@ -58,8 +58,8 @@ class CosmeticInventoryRepositoryImpl @Inject constructor(
         cosmeticDao.deleteCosmeticsByPackId(packId)
     }
 
-    override suspend fun cloneToPersonalArchive(id: Long): Result<Unit> = runCatching {
-        Log.d("CosmeticRepo", "cloneToPersonalArchive: Cloning item $id")
-        cosmeticDao.cloneToPersonalArchive(id)
+    override suspend fun cloneToPersonalArchive(internalId: Long): Result<Unit> = runCatching {
+        Log.d("CosmeticRepo", "cloneToPersonalArchive: Cloning item $internalId")
+        cosmeticDao.cloneToPersonalArchive(internalId)
     }
 }

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/WardrobeRepositoryImpl.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/data/repository/WardrobeRepositoryImpl.kt
@@ -75,7 +75,7 @@ class WardrobeRepositoryImpl @Inject constructor(
     override suspend fun saveClothingItem(item: ClothingItem) {
         withContext(Dispatchers.IO) {
             try {
-                val existingItem = if (item.id != 0L) clothingDao.getClothingById(item.id).firstOrNull()?.toModel() else null
+                val existingItem = if (item.internalId != 0L) clothingDao.getClothingById(item.internalId).firstOrNull()?.toModel() else null
                 
                 val needsAnalysis = item.imageUrl != null && (
                     item.dominantHex == null || 
@@ -141,10 +141,10 @@ class WardrobeRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun cloneToPersonalArchive(id: Long): Result<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun cloneToPersonalArchive(internalId: Long): Result<Unit> = withContext(Dispatchers.IO) {
         runCatching {
-            Log.d(TAG, "cloneToPersonalArchive: Cloning item $id")
-            clothingDao.cloneToPersonalArchive(id)
+            Log.d(TAG, "cloneToPersonalArchive: Cloning item $internalId")
+            clothingDao.cloneToPersonalArchive(internalId)
         }
     }
 

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeAnalyticsScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeAnalyticsScreen.kt
@@ -260,7 +260,7 @@ fun WardrobeAnalyticsScreen(
                                         Row(
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .clickable { navTo(KoColorRoute.WardrobeDetail(item.id)) }
+                                                .clickable { navTo(KoColorRoute.WardrobeDetail(item.internalId)) }
                                                 .padding(vertical = 4.dp),
                                             horizontalArrangement = Arrangement.SpaceBetween,
                                             verticalAlignment = Alignment.CenterVertically
@@ -319,8 +319,8 @@ private fun WardrobeAnalyticsScreenPreview() {
             uiState = WardrobeUiState(
                 totalInvestment = 2450.0,
                 items = listOf(
-                    ClothingItem(id = 1, name = "Silk Blazer", category = ClothingCategory.TOPS, usageCount = 12, colorHex = "#F5F5DC", price = 350.0),
-                    ClothingItem(id = 2, name = "Denim Jeans", category = ClothingCategory.BOTTOMS, usageCount = 45, colorHex = "#000080", price = 120.0)
+                    ClothingItem(internalId = 1, name = "Silk Blazer", category = ClothingCategory.TOPS, usageCount = 12, colorHex = "#F5F5DC", price = 350.0),
+                    ClothingItem(internalId = 2, name = "Denim Jeans", category = ClothingCategory.BOTTOMS, usageCount = 45, colorHex = "#000080", price = 120.0)
                 )
             ),
             onEvent = {},

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeCategoryCoverScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeCategoryCoverScreen.kt
@@ -65,8 +65,8 @@ private fun WardrobeCategoryCoverScreenPreview() {
                 categoryName = "Tops",
                 wardrobeUiState = WardrobeUiState(
                     items = listOf(
-                        ClothingItem(id = 1, name = "Silk Shirt", brand = "Luxury", category = ClothingCategory.TOPS, price = 85.0, usageCount = 12, colorHex = "#FFFFFF"),
-                        ClothingItem(id = 2, name = "Cashmere Sweater", brand = "Premium", category = ClothingCategory.TOPS, price = 250.0, usageCount = 3, colorHex = "#FFFFFF")
+                        ClothingItem(internalId = 1, name = "Silk Shirt", brand = "Luxury", category = ClothingCategory.TOPS, price = 85.0, usageCount = 12, colorHex = "#FFFFFF"),
+                        ClothingItem(internalId = 2, name = "Cashmere Sweater", brand = "Premium", category = ClothingCategory.TOPS, price = 250.0, usageCount = 3, colorHex = "#FFFFFF")
                     )
                 )
             ),

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeDetailScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeDetailScreen.kt
@@ -57,7 +57,7 @@ private fun WardrobeDetailScreenPreview() {
                 wardrobeUiState = WardrobeUiState(
                     items = listOf(
                         ClothingItem(
-                            id = 1, 
+                            internalId = 1, 
                             name = "Silk Blouse", 
                             brand = "Celine", 
                             category = ClothingCategory.TOPS, 
@@ -82,7 +82,7 @@ fun WardrobeDetailScreen(
     onEvent: (WardrobeEvent) -> Unit,
     navTo: (KoColorRoute) -> Unit
 ) {
-    val item = uiState.wardrobeUiState.items.find { it.id == uiState.itemId } ?: return
+    val item = uiState.wardrobeUiState.items.find { it.internalId == uiState.itemId } ?: return
     val atelierBrown = Color(0xFF8B5E3C)
     val archiveStatus = uiState.archiveStatus
 
@@ -96,7 +96,7 @@ fun WardrobeDetailScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { navTo(KoColorRoute.WardrobeEdit(item.id)) }) {
+                    IconButton(onClick = { navTo(KoColorRoute.WardrobeEdit(item.internalId)) }) {
                         Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.applications_kocolor_features_inventory_edit))
                     }
                 }
@@ -203,7 +203,7 @@ fun WardrobeDetailScreen(
                 Spacer(Modifier.height(32.dp))
 
                 Button(
-                    onClick = { onEvent(WardrobeEvent.WearItem(item.id)) },
+                    onClick = { onEvent(WardrobeEvent.WearItem(item.internalId)) },
                     modifier = Modifier.fillMaxWidth().height(56.dp),
                     shape = RoundedCornerShape(12.dp),
                     colors = ButtonDefaults.buttonColors(containerColor = atelierBrown)

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeEditScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeEditScreen.kt
@@ -46,7 +46,7 @@ private fun WardrobeEditScreenPreview() {
                 itemId = 1L,
                 wardrobeUiState = WardrobeUiState(
                     draftItem = ClothingItem(
-                        id = 1L,
+                        internalId = 1L,
                         name = "Blazer",
                         category = ClothingCategory.TOPS,
                         colorHex = "#000000"

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
@@ -43,7 +43,7 @@ private fun WardrobeLandingScreenPreview() {
                 totalItems = 9,
                 totalInvestment = 1615.0,
                 items = listOf(
-                    ClothingItem(id = 1, name = "Blouse", category = ClothingCategory.TOPS, colorHex = "#FFFFFF")
+                    ClothingItem(internalId = 1, name = "Blouse", category = ClothingCategory.TOPS, colorHex = "#FFFFFF")
                 )
             ),
             onEvent = {},

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeScreen.kt
@@ -134,7 +134,7 @@ fun WardrobeScreen(
                             items.forEach { item ->
                                 WardrobeCard(
                                     uiState = item,
-                                    onEvent = { onEvent(WardrobeEvent.DeleteItem(item.id)) },
+                                    onEvent = { onEvent(WardrobeEvent.DeleteItem(item.internalId)) },
                                     navTo = navTo,
                                     modifier = Modifier.weight(1f).aspectRatio(0.75f)
                                 )

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
@@ -67,7 +67,7 @@ class WardrobeViewModel @Inject constructor(
         itemId?.let { id ->
             if (id != 0L) {
                 viewModelScope.launch {
-                    wardrobeRepository.getClothingById(id).first()?.let { model ->
+                    wardrobeRepository.getClothingById(id).firstOrNull()?.let { model ->
                         _draftItem.update { current ->
                             // If we already have a NEW image in current (captured), keep it
                             if (current.imageUrl != null && current.imageUrl != model.imageUrl) {
@@ -86,7 +86,7 @@ class WardrobeViewModel @Inject constructor(
             .filterNotNull()
             .onEach { uri ->
                 if (uri != lastProcessedUri) {
-                    android.util.Log.d("WardrobeVM", "Processing NEW captured URI: $uri")
+                    Log.d("WardrobeVM", "Processing NEW captured URI: $uri")
                     lastProcessedUri = uri
                     val properUri = if (uri.startsWith("content://") || uri.startsWith("file://")) {
                         uri
@@ -146,9 +146,9 @@ class WardrobeViewModel @Inject constructor(
             is WardrobeEvent.WearItem -> wearItem(event.id)
             is WardrobeEvent.UpdateDraft -> _draftItem.value = event.item
             is WardrobeEvent.InitializeEdit -> {
-                if (_draftItem.value.id != event.itemId) {
+                if (_draftItem.value.internalId != event.itemId) {
                     viewModelScope.launch {
-                        wardrobeRepository.getClothingById(event.itemId).first()?.let { model ->
+                        wardrobeRepository.getClothingById(event.itemId).firstOrNull()?.let { model ->
                             _draftItem.update { current ->
                                 // Prioritize newly captured image in current draft
                                 if (current.imageUrl != null && current.imageUrl != model.imageUrl) {
@@ -167,7 +167,7 @@ class WardrobeViewModel @Inject constructor(
 
     private fun addItem(item: ClothingItem) {
         val userItem = item.copy(
-            id = 0L,
+            internalId = 0L,
             sourceType = InventorySource.USER_SCAN,
             sourceName = "My Wardrobe",
             sourcePackId = null
@@ -181,9 +181,9 @@ class WardrobeViewModel @Inject constructor(
     }
 
     private fun updateItem(item: ClothingItem) {
-        android.util.Log.d("WardrobeVM", "Triggering save for item: ${item.name} (image: ${item.imageUrl})")
+        Log.d("WardrobeVM", "Triggering save for item: ${item.name} (image: ${item.imageUrl})")
         viewModelScope.launch {
-            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO + kotlinx.coroutines.NonCancellable) {
+            withContext(Dispatchers.IO + NonCancellable) {
                 wardrobeRepository.saveClothingItem(item)
             }
         }
@@ -202,18 +202,18 @@ class WardrobeViewModel @Inject constructor(
     }
 
     private fun cloneToPersonal(item: ClothingItem) {
-        if (_archiveStatuses.value[item.id] == ArchiveStatus.SUCCESS || 
-            _archiveStatuses.value[item.id] == ArchiveStatus.ARCHIVING) return
+        if (_archiveStatuses.value[item.internalId] == ArchiveStatus.SUCCESS || 
+            _archiveStatuses.value[item.internalId] == ArchiveStatus.ARCHIVING) return
 
         viewModelScope.launch {
-            _archiveStatuses.update { it + (item.id to ArchiveStatus.ARCHIVING) }
+            _archiveStatuses.update { it + (item.internalId to ArchiveStatus.ARCHIVING) }
             
             try {
-                wardrobeRepository.cloneToPersonalArchive(item.id)
-                _archiveStatuses.update { it + (item.id to ArchiveStatus.SUCCESS) }
+                wardrobeRepository.cloneToPersonalArchive(item.internalId)
+                _archiveStatuses.update { it + (item.internalId to ArchiveStatus.SUCCESS) }
             } catch (e: Exception) {
                 Log.e("WardrobeVM", "Cloning failed", e)
-                _archiveStatuses.update { it + (item.id to ArchiveStatus.ERROR) }
+                _archiveStatuses.update { it + (item.internalId to ArchiveStatus.ERROR) }
             }
         }
     }

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/ClothingProductGridCard.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/ClothingProductGridCard.kt
@@ -25,7 +25,7 @@ import com.zoewave.probase.kocolor.model.KoColorRoute
 @Composable
 fun ClothingProductGridCard(uiState: ClothingItem, navTo: (KoColorRoute) -> Unit) {
     val item = uiState
-    val onClick = { navTo(KoColorRoute.WardrobeDetail(item.id)) }
+    val onClick = { navTo(KoColorRoute.WardrobeDetail(item.internalId)) }
     Card(
         modifier = Modifier.fillMaxWidth().aspectRatio(0.75f).clickable { onClick() },
         shape = RoundedCornerShape(24.dp)

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeCard.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeCard.kt
@@ -45,7 +45,7 @@ fun WardrobeCard(
     val contentColor = if (isDark) Color.White else Color.Black
 
     ElevatedCard(
-        modifier = modifier.clickable { navTo(KoColorRoute.WardrobeDetail(uiState.id)) },
+        modifier = modifier.clickable { navTo(KoColorRoute.WardrobeDetail(uiState.internalId)) },
         shape = RoundedCornerShape(24.dp),
         colors = CardDefaults.elevatedCardColors(containerColor = bgColor)
     ) {

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
@@ -389,7 +389,7 @@ fun AtelierWardrobeCard(
 @Composable
 fun RecentClothingCard(uiState: ClothingItem, modifier: Modifier = Modifier, onEvent: (Unit) -> Unit, navTo: (KoColorRoute) -> Unit) {
     val item = uiState
-    val onClick = { navTo(KoColorRoute.WardrobeDetail(item.id)) }
+    val onClick = { navTo(KoColorRoute.WardrobeDetail(item.internalId)) }
     Card(
         modifier = modifier.width(220.dp).aspectRatio(0.8f).clickable { onClick() },
         shape = RoundedCornerShape(28.dp)

--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutineDetailScreen.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/RoutineDetailScreen.kt
@@ -229,7 +229,7 @@ fun RoutineDetailScreen(
             }
 
             itemsIndexed(routine.steps, key = { _, step -> step.id }) { index, step ->
-                val linkedProduct = state.allProducts.find { step.productIds.contains(it.id) }
+                val linkedProduct = state.allProducts.find { step.productIds.contains(it.internalId) }
                 
                 SplitRitualStep(
                     uiState = SplitRitualStepUiState(

--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/components/EditStepForm.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/components/EditStepForm.kt
@@ -30,7 +30,7 @@ fun EditStepForm(
 ) {
     val step = uiState.step
     val allProducts = uiState.allProducts
-    val linkedProduct = allProducts.find { step.productIds.contains(it.id) }
+    val linkedProduct = allProducts.find { step.productIds.contains(it.internalId) }
     Column(modifier = modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(28.dp)) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(text = stringResource(R.string.applications_kocolor_features_routines_step_title_label), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black, modifier = Modifier.alpha(0.4f), letterSpacing = 1.sp)

--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/components/SelectionPages.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/components/SelectionPages.kt
@@ -62,8 +62,8 @@ private fun ItemSelectionPagePreview() {
         ItemSelectionPage(
             uiState = ItemSelectionUiState(
                 items = listOf(
-                    CosmeticItem(id = 1, name = "Product 1", brand = "Brand A", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.CLEANSER, colorHex = "#FFFFFF"),
-                    CosmeticItem(id = 2, name = "Product 2", brand = "Brand B", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.TONER, colorHex = "#FFFFFF")
+                    CosmeticItem(internalId = 1, name = "Product 1", brand = "Brand A", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.CLEANSER, colorHex = "#FFFFFF"),
+                    CosmeticItem(internalId = 2, name = "Product 2", brand = "Brand B", macroCategory = MacroCategory.PREP, microCategory = MicroCategory.TONER, colorHex = "#FFFFFF")
                 ),
                 selectedIds = listOf(1)
             ),
@@ -158,9 +158,9 @@ fun ItemSelectionPage(
     val selectedIds = uiState.selectedIds
     LazyColumn(modifier = modifier.fillMaxSize(), contentPadding = PaddingValues(24.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
         items(products) { product ->
-            val isSelected = selectedIds.contains(product.id)
+            val isSelected = selectedIds.contains(product.internalId)
             Surface(
-                onClick = { onEvent(product.id) }, 
+                onClick = { onEvent(product.internalId) }, 
                 modifier = Modifier.fillMaxWidth(), 
                 shape = RoundedCornerShape(16.dp), 
                 color = if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.2f) else MaterialTheme.colorScheme.surface, 

--- a/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/components/StepHeroPage.kt
+++ b/applications/kocolor/features/routines/src/main/java/com/zoewave/probase/kocolor/features/routines/ui/components/StepHeroPage.kt
@@ -85,7 +85,7 @@ fun StepHeroPage(
     val routineId = uiState.routineId
     val routineTime = uiState.routineTime
     
-    val linkedProducts = allProducts.filter { step.productIds.contains(it.id) }
+    val linkedProducts = allProducts.filter { step.productIds.contains(it.internalId) }
     
     var showJournalDialog by remember { mutableStateOf(false) }
     var journalDraft by remember { mutableStateOf("") }

--- a/applications/kocolor/features/stitch/src/main/java/com/zoewave/probase/kocolor/features/stitch/ui/StitchViewModel.kt
+++ b/applications/kocolor/features/stitch/src/main/java/com/zoewave/probase/kocolor/features/stitch/ui/StitchViewModel.kt
@@ -123,7 +123,7 @@ class StitchViewModel @Inject constructor(
             val newList = advice.makeupSuggestions.toMutableList()
             if (index < newList.size) {
                 newList[index] = newList[index].copy(
-                    productId = item.id,
+                    productId = item.internalId,
                     suggestedProductName = item.name,
                     suggestedProductImageUrl = item.imageUrl,
                     category = item.microCategory.displayName
@@ -133,7 +133,7 @@ class StitchViewModel @Inject constructor(
                     category = item.microCategory.displayName,
                     advice = "Custom selection.",
                     recommendedColors = item.colorHex?.let { listOf(it) } ?: emptyList(),
-                    productId = item.id,
+                    productId = item.internalId,
                     suggestedProductName = item.name,
                     suggestedProductImageUrl = item.imageUrl
                 ))
@@ -152,7 +152,7 @@ class StitchViewModel @Inject constructor(
                 
                 // For simplicity, we match itemIndex to the lists
                 if (itemIndex < itemIds.size) {
-                    itemIds[itemIndex] = item.id
+                    itemIds[itemIndex] = item.internalId
                     suggestedItems[itemIndex] = SuggestedPiece(
                         name = item.name,
                         category = item.category.name,
@@ -162,7 +162,7 @@ class StitchViewModel @Inject constructor(
                         isOwned = true
                     )
                 } else {
-                    itemIds.add(item.id)
+                    itemIds.add(item.internalId)
                     suggestedItems.add(SuggestedPiece(
                         name = item.name,
                         category = item.category.name,

--- a/core/model/src/main/java/com/zoewave/probase/core/model/ritual/ClothingItem.kt
+++ b/core/model/src/main/java/com/zoewave/probase/core/model/ritual/ClothingItem.kt
@@ -37,7 +37,7 @@ enum class Formality(val rank: Int) {
 
 @Serializable
 data class ClothingItem(
-    val id: Long = 0,
+    val internalId: Long = 0,
     val name: String,
     val brand: String? = null,
     val category: ClothingCategory,

--- a/core/model/src/main/java/com/zoewave/probase/core/model/ritual/CosmeticItem.kt
+++ b/core/model/src/main/java/com/zoewave/probase/core/model/ritual/CosmeticItem.kt
@@ -213,7 +213,7 @@ enum class Temperature {
 
 @Serializable
 data class CosmeticItem(
-    val id: Long = 0,
+    val internalId: Long = 0,
     val name: String,
     val brand: String,
     val macroCategory: MacroCategory,


### PR DESCRIPTION
This commit standardizes the naming of primary key identifiers across the repository by renaming `id` to `internalId` in database entities, domain models, and UI components. It also refines the "Make It Mine" feature with improved state management and visual integration.

- **Schema & Model Standardization**:
    - Renamed the primary key field from `id` to `internalId` in `ClothingItemEntity`, `CosmeticItemEntity`, and `ProductEntity`.
    - Updated the `ClothingItem` and `CosmeticItem` domain models to reflect the change.
- **DAO & Repository Refactoring**:
    - Updated `ClothingDao`, `CosmeticDao`, and `ProductDao` to use `internalId` in SQL queries and method parameters.
    - Adjusted `CosmeticInventoryRepository` and `WardrobeRepository` interfaces and implementations to align with the renamed identifiers.
- **Cloning Logic & UX Enhancements**:
    - Integrated the `MakeItMineButton` into the `CosmeticDetailScreen` bottom bar for items not yet in the user's personal archive.
    - Implemented state-aware protection in `CosmeticsViewModel` to prevent duplicate cloning operations while an archive transaction is active or successful.
    - Updated documentation to reflect the SQL transaction changes and new ViewModel-level double-tap protection.
- **UI & Analytics Updates**:
    - Refactored all UI components, including `CosmeticProductCard`, `WardrobeCard`, and various analytics screens, to use `internalId` for navigation and item selection.
    - Updated the `StyleSimulatorEngine` to generate IDs using the new property.