### PR TITLE
perf: minify search index and improve manifest verification visibility

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
@@ -72,8 +72,12 @@ class StarterPackRepository @Inject constructor(
         val dataPart = extractDataProperty(rawJson)
         val rawDataBytes = dataPart.toByteArray(Charsets.UTF_8)
         
+        Log.d(TAG, "getManifest: Data part for signature: $dataPart")
+        Log.d(TAG, "getManifest: Signature from envelope: ${envelope.signature}")
+
         // Root of Trust Verification
         if (!verifier.verify(rawDataBytes, envelope.signature, "")) {
+            Log.e(TAG, "getManifest: Signature verification failed!")
             throw PackException.SignatureException("Trust Bootstrap Failed: Manifest signature is invalid!")
         }
         

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/KocolorApiService.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/KocolorApiService.kt
@@ -1,6 +1,5 @@
 package com.zoewave.probase.kocolor.features.starterpack.data.remote
 
-import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.SearchIndexEntry
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.SignedPayloadEnvelope
 import kotlinx.serialization.json.JsonElement
 import okhttp3.ResponseBody

--- a/server/package/kc-optimizer/src/main.rs
+++ b/server/package/kc-optimizer/src/main.rs
@@ -108,12 +108,13 @@ fn main() {
         search_index.insert(id.clone(), tokens);
     }
 
-    let search_json = serde_json::to_string_pretty(&search_index)
+    // Use to_string (compact) to match manifest trust style and Retrofit expectations
+    let search_json = serde_json::to_string(&search_index)
         .expect("❌ Failed to generate search index");
 
     let search_path = output_dist_dir.join("search_index.json");
     fs::write(search_path, search_json).expect("❌ Failed to write search_index.json");
-    println!("  🔍 search_index.json written.");
+    println!("  🔍 search_index.json written (Compact Map format).");
 
     println!("\n✅ CCT Build completed in {:.2?}.", start_time.elapsed());
 }


### PR DESCRIPTION
This commit optimizes the search index output format for consistency with manifest serialization and adds diagnostic logging to the manifest verification process.

- **Search Index Minification**:
    - Updated `kc-optimizer` to use `serde_json::to_string` instead of `to_string_pretty` for `search_index.json`. This ensures the output is compact, matching the manifest's trust style and reducing transmission size.
- **Verification Observability**:
    - Added debug logs in `StarterPackRepository` to capture the raw data part and signature used during manifest verification.
    - Introduced an explicit error log when signature verification fails to aid in troubleshooting trust bootstrap issues.
- **Code Cleanup**:
    - Removed an unused import of `SearchIndexEntry` in `KocolorApiService`.