### PR TITLE
feat: implement product editorial notes in starter pack preview

### DIFF
--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -532,7 +532,8 @@ fun koColorNavEntryProvider(
                 onImportSelected = viewModel::onImportSelected,
                 onSearchQueryChanged = viewModel::onSearchQueryChanged,
                 onToggleValueSort = viewModel::onToggleValueSort,
-                onItemInfoClick = { /* TODO */ },
+                onItemInfoClick = viewModel::onItemInfoClick,
+                onDismissNotes = viewModel::onDismissNotes,
                 onBack = onBack
             )
         }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/StarterPackRepository.kt
@@ -24,6 +24,7 @@ import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.KcpsPa
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackInfo
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackItemDto
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackManifest
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.ProductEditorialNotes
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.SignedPayloadEnvelope
 import com.zoewave.probase.kocolor.features.starterpack.domain.security.SignatureVerifier
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -193,6 +194,10 @@ class StarterPackRepository @Inject constructor(
         
         val payload = fetchVerifiedPackage(packInfo)
         return payload.cosmetics + payload.clothing
+    }
+
+    suspend fun getProductEditorialNotes(productId: String): Result<ProductEditorialNotes> = runCatching {
+        apiService.getProductNotes(productId)
     }
 
     private fun isZstdHeader(bytes: ByteArray): Boolean {

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/KocolorApiService.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/KocolorApiService.kt
@@ -1,5 +1,6 @@
 package com.zoewave.probase.kocolor.features.starterpack.data.remote
 
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.ProductEditorialNotes
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.SignedPayloadEnvelope
 import kotlinx.serialization.json.JsonElement
 import okhttp3.ResponseBody
@@ -20,6 +21,9 @@ interface KocolorApiService {
 
     @GET("search_index.json")
     suspend fun getSearchIndex(): Map<String, List<String>>
+
+    @GET("notes/{id}.notes.json")
+    suspend fun getProductNotes(@Path("id") id: String): ProductEditorialNotes
 
     @GET("packs/{packId}.json")
     suspend fun getPackItems(@Path("packId") packId: String): SignedPayloadEnvelope<JsonElement>

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/ProductEditorialNotes.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/ProductEditorialNotes.kt
@@ -1,0 +1,13 @@
+package com.zoewave.probase.kocolor.features.starterpack.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ProductEditorialNotes(
+    val id: String,
+    @SerialName("editorial_title") val editorialTitle: String,
+    @SerialName("usage_notes") val usageNotes: String,
+    @SerialName("expert_tip") val expertTip: String,
+    @SerialName("formulation_insight") val formulationInsight: String? = null
+)

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
@@ -8,6 +8,7 @@ import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.Clothi
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.CosmeticItemDto
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.KcpsPayload
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackItemDto
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.ProductEditorialNotes
 import com.zoewave.probase.kocolor.features.starterpack.data.repository.PackSyncRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,7 +29,9 @@ data class PackPreviewUiState(
     val isInstalled: Boolean = false,
     val targetItemId: String? = null,
     val searchQuery: String = "",
-    val sortByValue: Boolean = false
+    val sortByValue: Boolean = false,
+    val selectedItemNotes: ProductEditorialNotes? = null,
+    val isNotesLoading: Boolean = false
 )
 
 @HiltViewModel
@@ -203,5 +206,22 @@ class PackPreviewViewModel @Inject constructor(
             syncRepository.wipePack(currentPackId)
             _uiState.update { it.copy(isLoading = false) }
         }
+    }
+
+    fun onItemInfoClick(itemId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isNotesLoading = true, selectedItemNotes = null) }
+            repository.getProductEditorialNotes(itemId)
+                .onSuccess { notes ->
+                    _uiState.update { it.copy(isNotesLoading = false, selectedItemNotes = notes) }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(isNotesLoading = false) }
+                }
+        }
+    }
+
+    fun onDismissNotes() {
+        _uiState.update { it.copy(selectedItemNotes = null) }
     }
 }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
@@ -40,6 +40,7 @@ fun PackPreviewScreen(
     onSearchQueryChanged: (String) -> Unit,
     onToggleValueSort: () -> Unit,
     onItemInfoClick: (String) -> Unit,
+    onDismissNotes: () -> Unit,
     onBack: () -> Unit
 ) {
     val listState = rememberLazyListState()
@@ -81,6 +82,12 @@ fun PackPreviewScreen(
             }
         }
     }
+
+    ProductEditorialNotesDialog(
+        notes = uiState.selectedItemNotes,
+        isLoading = uiState.isNotesLoading,
+        onDismiss = onDismissNotes
+    )
 
     Scaffold(
         modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
@@ -275,6 +282,7 @@ private fun PackPreviewScreenPreview() {
             onSearchQueryChanged = {},
             onToggleValueSort = {},
             onItemInfoClick = {},
+            onDismissNotes = {},
             onBack = {}
         )
     }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
@@ -1,0 +1,75 @@
+package com.zoewave.probase.kocolor.features.starterpack.ui.packpreview
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.ProductEditorialNotes
+
+@Composable
+fun ProductEditorialNotesDialog(
+    notes: ProductEditorialNotes?,
+    isLoading: Boolean,
+    onDismiss: () -> Unit
+) {
+    if (isLoading || notes != null) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = {
+                Text(
+                    text = notes?.editorialTitle ?: "Analyzing Product...",
+                    fontFamily = FontFamily.Serif,
+                    fontWeight = FontWeight.Bold
+                )
+            },
+            text = {
+                if (isLoading) {
+                    Box(modifier = Modifier.fillMaxWidth().height(100.dp), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(color = Color(0xFF745E7A))
+                    }
+                } else if (notes != null) {
+                    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                        EditorialSection(label = "Usage Notes", content = notes.usageNotes)
+                        EditorialSection(label = "Expert Tip", content = notes.expertTip)
+                        notes.formulationInsight?.let { insight ->
+                            EditorialSection(label = "Formulation Insight", content = insight)
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = onDismiss) {
+                    Text("CLOSE", fontWeight = FontWeight.Black)
+                }
+            },
+            shape = RoundedCornerShape(28.dp)
+        )
+    }
+}
+
+@Composable
+private fun EditorialSection(label: String, content: String) {
+    Column {
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Black,
+            color = Color.Gray,
+            letterSpacing = 1.sp
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = content,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.DarkGray,
+            lineHeight = 20.sp
+        )
+    }
+}


### PR DESCRIPTION
This update introduces a new feature to view detailed editorial metadata—including usage notes, expert tips, and formulation insights—for products within the starter pack preview screen.

- **API and Data Layer**:
    - Defined the `ProductEditorialNotes` data model to handle serialized editorial content.
    - Added a new GET endpoint to `KocolorApiService` for retrieving product-specific notes.
    - Implemented `getProductEditorialNotes` in `StarterPackRepository` to fetch data via the API service.
- **UI Components**:
    - Created `ProductEditorialNotesDialog`, a Compose-based `AlertDialog` that displays formatted editorial sections with a loading indicator.
    - Integrated the dialog into `PackPreviewScreen` and updated the UI callbacks to handle info clicks and dialog dismissal.
- **State Management**:
    - Updated `PackPreviewViewModel` to track note-loading states and store the currently selected product's editorial data.
    - Implemented asynchronous fetching logic in the ViewModel to retrieve notes when an item's info icon is selected.
    - Connected the new UI actions through `KoColorNavEntryProvider`.