### PR TITLE
ui: refine thumbnail layout in ProductEditorialNotesDialog

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
@@ -34,12 +34,13 @@ fun ProductEditorialNotesDialog(
                             model = thumbnailUrl,
                             contentDescription = null,
                             modifier = Modifier
-                                .size(120.dp)
-                                .clip(RoundedCornerShape(12.dp))
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
+                                .clip(RoundedCornerShape(16.dp))
                                 .background(Color(0xFFF5F5F5)),
                             contentScale = ContentScale.Crop
                         )
-                        Spacer(Modifier.height(16.dp))
+                        Spacer(Modifier.height(24.dp))
                     }
                     Text(
                         text = notes?.editorialTitle ?: "Analyzing Product...",


### PR DESCRIPTION
This commit updates the thumbnail image dimensions and spacing within the product editorial notes dialog to improve visual consistency and responsiveness.

- **Thumbnail Styling Updates**:
    - Replaced the fixed `120.dp` size with `fillMaxWidth()` and a 1:1 `aspectRatio` for better scaling.
    - Increased the corner radius from `12.dp` to `16.dp` for the thumbnail image.
- **Layout Adjustments**:
    - Increased the vertical spacing between the thumbnail and the editorial text from `16.dp` to `24.dp`.