### PR TITLE
feat: elevate Glow Sync Hub entry point and enhance pack item UI

### DIFF
--- a/applications/kocolor/apps/mobile/features/settings/src/main/java/com/zoewave/probase/kocolor/mobile/features/settings/ui/components/SettingsScreen.kt
+++ b/applications/kocolor/apps/mobile/features/settings/src/main/java/com/zoewave/probase/kocolor/mobile/features/settings/ui/components/SettingsScreen.kt
@@ -147,31 +147,6 @@ fun SettingsScreen(
                 navTo = navTo
             )
 
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = { navTo(KoColorRoute.StarterPack) }
-            ) {
-                Row(
-                    modifier = Modifier.padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.AutoAwesome,
-                        contentDescription = null,
-                        tint = Color(0xFF745E7A)
-                    )
-                    Spacer(modifier = Modifier.width(16.dp))
-                    Column {
-                        Text("Glow Archive Sync", style = MaterialTheme.typography.titleMedium)
-                        Text(
-                            "Manage high-fidelity starter and sample packs",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-            }
-            
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text("About", style = MaterialTheme.typography.titleMedium)

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -129,6 +130,9 @@ fun VanityLandingScreen(
                 actions = {
                     IconButton(onClick = { navTo(KoColorRoute.DiscoveryStatus) }) {
                         Icon(Icons.Default.CloudDone, contentDescription = "Discovery Health")
+                    }
+                    IconButton(onClick = { navTo(KoColorRoute.StarterPack) }) { 
+                        Icon(Icons.Default.Sync, contentDescription = "Glow Sync") 
                     }
                     IconButton(onClick = { navTo(KoColorRoute.BoxCapture()) }) { 
                         Icon(Icons.Default.AutoAwesome, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title)) 
@@ -246,6 +250,79 @@ fun VanityLandingScreen(
                             imageVector = Icons.Default.ChevronRight,
                             contentDescription = null,
                             tint = Color.LightGray.copy(alpha = 0.8f),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
+            }
+
+            // --- PROMINENT GLOW SYNC HUB ENTRY ---
+            item {
+                Surface(
+                    onClick = { navTo(KoColorRoute.StarterPack) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(96.dp),
+                    shape = RoundedCornerShape(32.dp),
+                    color = Color(0xFF5A3854), // Elegant Plum
+                    shadowElevation = 8.dp
+                ) {
+                    val shimmerBrush = Brush.linearGradient(
+                        colors = listOf(
+                            Color.Transparent,
+                            Color.White.copy(alpha = 0.1f),
+                            Color(0xFFD4AF37).copy(alpha = 0.15f), // Gold tint
+                            Color.White.copy(alpha = 0.1f),
+                            Color.Transparent
+                        ),
+                        start = Offset(x = shimmerProgress * 1000f, y = 0f),
+                        end = Offset(x = (shimmerProgress + 0.3f) * 1000f, y = 500f)
+                    )
+
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(shimmerBrush)
+                            .padding(horizontal = 20.dp)
+                    ) {
+                        // Icon with Gold background circle
+                        Box(
+                            modifier = Modifier
+                                .size(56.dp)
+                                .background(Color(0xFFD4AF37), CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.AutoAwesome,
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.size(28.dp)
+                            )
+                        }
+                        
+                        Spacer(Modifier.width(20.dp))
+                        
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Glow Sync Hub",
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = FontFamily.Serif,
+                                color = Color.White
+                            )
+                            Text(
+                                text = "High-fidelity scientific collections",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = Color.White.copy(alpha = 0.7f),
+                                letterSpacing = 0.5.sp
+                            )
+                        }
+                        
+                        Icon(
+                            imageVector = Icons.Default.ChevronRight,
+                            contentDescription = null,
+                            tint = Color.White.copy(alpha = 0.5f),
                             modifier = Modifier.size(20.dp)
                         )
                     }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
@@ -32,6 +32,7 @@ data class PackPreviewUiState(
     val sortByValue: Boolean = false,
     val selectedItemNotes: ProductEditorialNotes? = null,
     val selectedItemThumbnail: String? = null,
+    val selectedItemColor: String? = null,
     val isNotesLoading: Boolean = false
 )
 
@@ -210,9 +211,16 @@ class PackPreviewViewModel @Inject constructor(
     }
 
     fun onItemInfoClick(itemId: String) {
-        val thumbnail = _uiState.value.items.find { it.id == itemId }?.thumbnailUrl
+        val item = _uiState.value.items.find { it.id == itemId }
+        val thumbnail = item?.thumbnailUrl
+        val color = item?.colorHex
         viewModelScope.launch {
-            _uiState.update { it.copy(isNotesLoading = true, selectedItemNotes = null, selectedItemThumbnail = thumbnail) }
+            _uiState.update { it.copy(
+                isNotesLoading = true, 
+                selectedItemNotes = null, 
+                selectedItemThumbnail = thumbnail,
+                selectedItemColor = color
+            ) }
             repository.getProductEditorialNotes(itemId)
                 .onSuccess { notes ->
                     _uiState.update { it.copy(isNotesLoading = false, selectedItemNotes = notes) }
@@ -224,6 +232,6 @@ class PackPreviewViewModel @Inject constructor(
     }
 
     fun onDismissNotes() {
-        _uiState.update { it.copy(selectedItemNotes = null, selectedItemThumbnail = null) }
+        _uiState.update { it.copy(selectedItemNotes = null, selectedItemThumbnail = null, selectedItemColor = null) }
     }
 }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
@@ -2,7 +2,9 @@ package com.zoewave.probase.kocolor.features.starterpack.ui.packpreview
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
@@ -71,12 +73,17 @@ fun PackPreviewItemRow(
                 .padding(vertical = 12.dp, horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Thumbnail with subtle rounded square like in mockup
+            // Thumbnail with colored border
             Box(
                 modifier = Modifier
                     .size(64.dp)
                     .clip(RoundedCornerShape(12.dp))
                     .background(Color(0xFFF5F5F5))
+                    .border(
+                        width = 2.dp,
+                        color = parseHexColor(item.colorHex).copy(alpha = 0.6f),
+                        shape = RoundedCornerShape(12.dp)
+                    )
             ) {
                 val placeholder = rememberBlurHashPainter(blurHash = item.blurhash)
 

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
@@ -86,6 +86,7 @@ fun PackPreviewScreen(
     ProductEditorialNotesDialog(
         notes = uiState.selectedItemNotes,
         thumbnailUrl = uiState.selectedItemThumbnail,
+        colorHex = uiState.selectedItemColor,
         isLoading = uiState.isNotesLoading,
         onDismiss = onDismissNotes
     )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
@@ -1,6 +1,7 @@
 package com.zoewave.probase.kocolor.features.starterpack.ui.packpreview
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
@@ -21,10 +22,13 @@ import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.Produc
 fun ProductEditorialNotesDialog(
     notes: ProductEditorialNotes?,
     thumbnailUrl: String?,
+    colorHex: String?,
     isLoading: Boolean,
     onDismiss: () -> Unit
 ) {
     if (isLoading || notes != null) {
+        val itemColor = colorHex?.let { parseHexColor(it) } ?: Color.Transparent
+
         AlertDialog(
             onDismissRequest = onDismiss,
             title = {
@@ -37,7 +41,8 @@ fun ProductEditorialNotesDialog(
                                 .fillMaxWidth()
                                 .aspectRatio(1f)
                                 .clip(RoundedCornerShape(16.dp))
-                                .background(Color(0xFFF5F5F5)),
+                                .background(Color(0xFFF5F5F5))
+                                .border(4.dp, itemColor.copy(alpha = 0.8f), RoundedCornerShape(16.dp)),
                             contentScale = ContentScale.Crop
                         )
                         Spacer(Modifier.height(24.dp))
@@ -71,6 +76,14 @@ fun ProductEditorialNotesDialog(
             },
             shape = RoundedCornerShape(28.dp)
         )
+    }
+}
+
+private fun parseHexColor(hex: String): Color {
+    return try {
+        Color(android.graphics.Color.parseColor(if (hex.startsWith("#")) hex else "#$hex"))
+    } catch (e: Exception) {
+        Color.Gray
     }
 }
 


### PR DESCRIPTION
This commit relocates the "Glow Sync" feature from the settings menu to a more prominent position on the vanity landing screen and introduces aesthetic improvements to the starter pack item previews.

- **Navigation & Entry Point Relocation**:
    - Removed the "Glow Archive Sync" card from the `SettingsScreen`.
    - Added a prominent "Glow Sync Hub" surface to `VanityLandingScreen` featuring a custom shimmer effect, "Elegant Plum" background, and gold accents.
    - Added a sync icon button to the `VanityLandingScreen` top app bar for quicker access to starter packs.
- **Pack Preview Enhancements**:
    - Updated `PackPreviewItemRow` to include a colored border around thumbnails based on the item's specific hex color.
    - Enhanced `ProductEditorialNotesDialog` to display a thick, color-coded border around the product image, matching the item's brand color.
- **State & Logic Updates**:
    - Updated `PackPreviewViewModel` and `PackPreviewUiState` to capture and propagate `selectedItemColor` when viewing item details.
    - Implemented a `parseHexColor` utility function within the editorial dialog to safely handle hex string conversions to Compose `Color` objects.