### PR TITLE
style: increase border thickness in pack preview UI components

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
@@ -80,7 +80,7 @@ fun PackPreviewItemRow(
                     .clip(RoundedCornerShape(12.dp))
                     .background(Color(0xFFF5F5F5))
                     .border(
-                        width = 2.dp,
+                        width = 4.dp,
                         color = parseHexColor(item.colorHex).copy(alpha = 0.6f),
                         shape = RoundedCornerShape(12.dp)
                     )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
@@ -42,7 +42,7 @@ fun ProductEditorialNotesDialog(
                                 .aspectRatio(1f)
                                 .clip(RoundedCornerShape(16.dp))
                                 .background(Color(0xFFF5F5F5))
-                                .border(4.dp, itemColor.copy(alpha = 0.8f), RoundedCornerShape(16.dp)),
+                                .border(8.dp, itemColor.copy(alpha = 0.8f), RoundedCornerShape(16.dp)),
                             contentScale = ContentScale.Crop
                         )
                         Spacer(Modifier.height(24.dp))


### PR DESCRIPTION
This commit adjusts the border widths for item previews within the starter pack feature to enhance visual emphasis and consistency across different UI contexts.

- **UI Style Adjustments**:
    - Increased the item border width from 2.dp to 4.dp in `PackPreviewItemRow`.
    - Increased the item image border width from 4.dp to 8.dp in `ProductEditorialNotesDialog`.