### PR TITLE
ui: redesign vanity landing screen and stat components

### DIFF
--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/VanityLandingScreen.kt
@@ -33,19 +33,22 @@ import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.CloudDone
 import androidx.compose.material.icons.filled.ColorLens
-import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.Kitchen
 import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -58,6 +61,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -121,7 +125,7 @@ fun VanityLandingScreen(
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text(stringResource(R.string.applications_kocolor_features_cosmetics_glow_archive), style = MaterialTheme.typography.titleLarge, fontFamily = FontFamily.Serif) },
+                title = { Text("Glow Archive", style = MaterialTheme.typography.titleLarge, fontFamily = FontFamily.Serif, fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navTo(KoColorRoute.Back) }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_back))
@@ -129,25 +133,30 @@ fun VanityLandingScreen(
                 },
                 actions = {
                     IconButton(onClick = { navTo(KoColorRoute.DiscoveryStatus) }) {
-                        Icon(Icons.Default.CloudDone, contentDescription = "Discovery Health")
+                        Icon(Icons.Default.CloudDone, contentDescription = "Discovery Health", tint = Color.DarkGray)
                     }
                     IconButton(onClick = { navTo(KoColorRoute.StarterPack) }) { 
-                        Icon(Icons.Default.Sync, contentDescription = "Glow Sync") 
+                        Icon(Icons.Default.AutoAwesome, contentDescription = "Glow Sync", tint = Color.DarkGray) 
                     }
-                    IconButton(onClick = { navTo(KoColorRoute.BoxCapture()) }) { 
-                        Icon(Icons.Default.AutoAwesome, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_scan_box_title)) 
+                    IconButton(onClick = { navTo(KoColorRoute.InventoryManagement) }) { 
+                        Icon(Icons.Default.Inventory2, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_inventory_title), tint = Color.DarkGray) 
                     }
-                    IconButton(onClick = { navTo(KoColorRoute.InventoryManagement) }) { Icon(Icons.Default.Inventory2, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_inventory_title)) }
-                    IconButton(onClick = { navTo(KoColorRoute.ColorSearch) }) { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_filter)) }
-                }
+                    IconButton(onClick = { navTo(KoColorRoute.ColorSearch) }) { 
+                        Icon(Icons.Default.Search, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_filter), tint = Color.DarkGray) 
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = Color(0xFFFCF9F6)
+                )
             )
         },
         floatingActionButton = {
             FloatingActionButton(
                 onClick = { navTo(KoColorRoute.CosmeticAdd()) },
-                containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
-                shape = CircleShape
+                containerColor = Color(0xFF5A3854), // Dark Plum matching image
+                contentColor = Color.White,
+                shape = CircleShape,
+                elevation = FloatingActionButtonDefaults.elevation(8.dp)
             ) {
                 Icon(Icons.Default.Add, contentDescription = stringResource(R.string.applications_kocolor_features_cosmetics_add_item))
             }
@@ -155,22 +164,27 @@ fun VanityLandingScreen(
         modifier = modifier
     ) { padding ->
         LazyColumn(
-            modifier = Modifier.padding(padding).fillMaxSize(),
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .background(Color(0xFFFCF9F6)), // Light cream background
             contentPadding = PaddingValues(24.dp),
             verticalArrangement = Arrangement.spacedBy(32.dp)
         ) {
             item {
                 Column {
                     Text(
-                        text = stringResource(R.string.applications_kocolor_features_cosmetics_welcome_header),
-                        style = MaterialTheme.typography.headlineLarge,
+                        text = "Good morning,\nBeautiful.", // Two-line to match image
+                        style = MaterialTheme.typography.displaySmall,
                         fontFamily = FontFamily.Serif,
-                        fontWeight = FontWeight.Bold
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1C1E)
                     )
+                    Spacer(Modifier.height(8.dp))
                     Text(
-                        text = stringResource(R.string.applications_kocolor_features_cosmetics_welcome_desc),
+                        text = "Here is a glance at the collection today.", // Match image text
                         style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
                     )
                 }
             }
@@ -188,17 +202,17 @@ fun VanityLandingScreen(
                     onClick = { navTo(KoColorRoute.ColorHub) },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(96.dp),
-                    shape = RoundedCornerShape(32.dp),
+                        .height(140.dp), // Taller as per image
+                    shape = RoundedCornerShape(24.dp),
                     color = Color.White,
-                    shadowElevation = 8.dp,
+                    shadowElevation = 4.dp,
                     border = BorderStroke(1.dp, Color.Black.copy(alpha = 0.05f))
                 ) {
                     val shimmerBrush = Brush.linearGradient(
                         colors = listOf(
                             Color.Transparent,
                             Color.White.copy(alpha = 0.3f),
-                            Color(0xFFA0C4FF).copy(alpha = 0.15f), // Subtle blue tint
+                            Color(0xFFA0C4FF).copy(alpha = 0.1f),
                             Color.White.copy(alpha = 0.3f),
                             Color.Transparent
                         ),
@@ -211,33 +225,18 @@ fun VanityLandingScreen(
                         modifier = Modifier
                             .fillMaxSize()
                             .background(shimmerBrush)
-                            .padding(horizontal = 20.dp)
+                            .padding(horizontal = 24.dp)
                     ) {
-                        // Icon with Chromatic background circle
-                        Box(
-                            modifier = Modifier
-                                .size(56.dp)
-                                .background(chromaticBrush, CircleShape),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.ColorLens,
-                                contentDescription = null,
-                                tint = Color.White,
-                                modifier = Modifier.size(28.dp)
-                            )
-                        }
-                        
-                        Spacer(Modifier.width(20.dp))
-                        
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                text = "Color Intelligence Hub",
-                                style = MaterialTheme.typography.titleLarge,
+                                text = "Color Intelligence\nHub", // Forced wrap to match image
+                                style = MaterialTheme.typography.headlineMedium,
                                 fontWeight = FontWeight.Bold,
                                 fontFamily = FontFamily.Serif,
-                                color = Color(0xFF2C2420)
+                                color = Color(0xFF2C2420),
+                                lineHeight = 32.sp
                             )
+                            Spacer(Modifier.height(4.dp))
                             Text(
                                 text = "Spectral blueprint & chromatic DNA",
                                 style = MaterialTheme.typography.labelMedium,
@@ -245,13 +244,21 @@ fun VanityLandingScreen(
                                 letterSpacing = 0.5.sp
                             )
                         }
-                        
-                        Icon(
-                            imageVector = Icons.Default.ChevronRight,
-                            contentDescription = null,
-                            tint = Color.LightGray.copy(alpha = 0.8f),
-                            modifier = Modifier.size(20.dp)
-                        )
+
+                        // Icon with Chromatic background circle on the RIGHT
+                        Box(
+                            modifier = Modifier
+                                .size(72.dp)
+                                .background(chromaticBrush, CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.ColorLens,
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.size(36.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -262,21 +269,21 @@ fun VanityLandingScreen(
                     onClick = { navTo(KoColorRoute.StarterPack) },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(96.dp),
-                    shape = RoundedCornerShape(32.dp),
-                    color = Color(0xFF5A3854), // Elegant Plum
-                    shadowElevation = 8.dp
+                        .height(140.dp), // Taller as per image
+                    shape = RoundedCornerShape(24.dp),
+                    color = Color(0xFF2E1A2C), // Deeper Dark Plum
+                    shadowElevation = 6.dp
                 ) {
                     val shimmerBrush = Brush.linearGradient(
                         colors = listOf(
                             Color.Transparent,
-                            Color.White.copy(alpha = 0.1f),
-                            Color(0xFFD4AF37).copy(alpha = 0.15f), // Gold tint
-                            Color.White.copy(alpha = 0.1f),
+                            Color.White.copy(alpha = 0.05f),
+                            Color(0xFFD4AF37).copy(alpha = 0.1f), 
+                            Color.White.copy(alpha = 0.05f),
                             Color.Transparent
                         ),
-                        start = Offset(x = shimmerProgress * 1000f, y = 0f),
-                        end = Offset(x = (shimmerProgress + 0.3f) * 1000f, y = 500f)
+                        start = Offset(x = shimmerProgress * 1200f, y = 0f),
+                        end = Offset(x = (shimmerProgress + 0.4f) * 1200f, y = 600f)
                     )
 
                     Row(
@@ -284,46 +291,24 @@ fun VanityLandingScreen(
                         modifier = Modifier
                             .fillMaxSize()
                             .background(shimmerBrush)
-                            .padding(horizontal = 20.dp)
+                            .padding(horizontal = 24.dp)
                     ) {
-                        // Icon with Gold background circle
-                        Box(
-                            modifier = Modifier
-                                .size(56.dp)
-                                .background(Color(0xFFD4AF37), CircleShape),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.AutoAwesome,
-                                contentDescription = null,
-                                tint = Color.White,
-                                modifier = Modifier.size(28.dp)
-                            )
-                        }
-                        
-                        Spacer(Modifier.width(20.dp))
-                        
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = "Glow Sync Hub",
-                                style = MaterialTheme.typography.titleLarge,
-                                fontWeight = FontWeight.Bold,
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Medium,
                                 fontFamily = FontFamily.Serif,
                                 color = Color.White
                             )
-                            Text(
-                                text = "High-fidelity scientific collections",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = Color.White.copy(alpha = 0.7f),
-                                letterSpacing = 0.5.sp
-                            )
                         }
                         
+                        // Large Gold Stars Icon on the RIGHT
                         Icon(
-                            imageVector = Icons.Default.ChevronRight,
+                            imageVector = Icons.Default.AutoAwesome,
                             contentDescription = null,
-                            tint = Color.White.copy(alpha = 0.5f),
-                            modifier = Modifier.size(20.dp)
+                            tint = Color(0xFFD4AF37),
+                            modifier = Modifier.size(64.dp)
                         )
                     }
                 }
@@ -336,18 +321,18 @@ fun VanityLandingScreen(
                 ) {
                     SummaryStatCard(
                         uiState = SummaryStatUiState(
-                            label = stringResource(R.string.applications_kocolor_features_cosmetics_total_products),
+                            label = "TOTAL_INVENTORY",
                             value = uiState.totalCosmetics.toString(),
-                            icon = Icons.Default.Inventory2
+                            icon = Icons.Default.Kitchen
                         ),
                         modifier = Modifier.weight(1f),
                         onEvent = { navTo(KoColorRoute.InventoryManagement) }
                     )
                     SummaryStatCard(
                         uiState = SummaryStatUiState(
-                            label = stringResource(R.string.applications_kocolor_features_cosmetics_expiring_soon),
+                            label = "EXPIRING_SOON",
                             value = uiState.expiringCosmeticsCount.toString(),
-                            icon = Icons.Default.ErrorOutline
+                            icon = Icons.Default.Warning
                         ),
                         modifier = Modifier.weight(1f),
                         onEvent = { navTo(KoColorRoute.ExpiringSoon) }
@@ -363,26 +348,27 @@ fun VanityLandingScreen(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = stringResource(R.string.applications_kocolor_features_cosmetics_categories),
+                            text = "CATEGORIES",
                             style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.Bold,
-                            letterSpacing = 1.sp
+                            fontWeight = FontWeight.ExtraBold,
+                            letterSpacing = 1.5.sp
                         )
+                        // Minimalist Info Icon
                         Surface(
                             onClick = { showTaxonomyInfo = true },
                             shape = CircleShape,
-                            color = Color.White,
-                            border = BorderStroke(1.dp, Color(0xFFD4AF37)), 
-                            shadowElevation = 4.dp,
-                            modifier = Modifier.size(36.dp)
+                            color = Color(0xFFF7F2EB),
+                            border = BorderStroke(1.dp, Color(0xFFD4AF37).copy(alpha = 0.5f)),
+                            modifier = Modifier.size(28.dp)
                         ) {
                             Box(contentAlignment = Alignment.Center) {
                                 Text(
-                                    text = stringResource(R.string.applications_kocolor_features_cosmetics_info_icon),
-                                    style = MaterialTheme.typography.titleMedium.copy(
+                                    text = "i",
+                                    style = MaterialTheme.typography.bodySmall.copy(
                                         fontFamily = FontFamily.Serif,
-                                        fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
-                                        fontWeight = FontWeight.Bold
+                                        fontStyle = FontStyle.Italic,
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = 12.sp
                                     ),
                                     color = Color(0xFF2C2420)
                                 )

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/SummaryStatCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/SummaryStatCard.kt
@@ -33,12 +33,12 @@ fun SummaryStatCard(
     modifier: Modifier = Modifier,
     onEvent: () -> Unit
 ) {
-    val isExpiring = uiState.label.contains("EXPIRING")
+    val isExpiring = uiState.label.contains("EXPIRING") || uiState.label.contains("Soon")
     val serifFont = FontFamily.Serif
     val charcoal = Color(0xFF2C2420)
 
-    val chromaticBrush = if (isExpiring) {
-        Brush.verticalGradient(listOf(Color(0xFF4A0000), Color(0xFF8B0000)))
+    val footerBrush = if (isExpiring) {
+        Brush.verticalGradient(listOf(Color(0xFF4A101D), Color(0xFF1A050A))) // Dark Burgundy/Plum
     } else {
         Brush.horizontalGradient(listOf(
             Color(0xFFA0C4FF), Color(0xFFBDB2FF), Color(0xFFFFADAD), 
@@ -54,94 +54,81 @@ fun SummaryStatCard(
 
     Surface(
         onClick = onEvent,
-        modifier = modifier.height(80.dp), // Half-height pill
-        shape = RoundedCornerShape(20.dp),
+        modifier = modifier.height(180.dp), // Taller card as per image
+        shape = RoundedCornerShape(24.dp),
         color = Color.White,
-        shadowElevation = 8.dp,
+        shadowElevation = 4.dp,
         border = BorderStroke(1.dp, Color.Black.copy(alpha = 0.05f))
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
-            // 1. Top Section
-            Box(
+            // 1. Icon and Value Section
+            Column(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .padding(horizontal = 10.dp, vertical = 4.dp)
+                    .padding(top = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
             ) {
-                // High-Visibility Icon (Top Left)
-                Box(
-                    modifier = Modifier
-                        .size(40.dp)
-                        .clip(CircleShape)
-                        .background(Color.Gray.copy(alpha = 0.12f))
-                        .align(Alignment.TopStart),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = uiState.icon,
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp),
-                        tint = Color.Gray.copy(alpha = 0.7f)
-                    )
-                }
+                // High-Visibility Icon
+                Icon(
+                    imageVector = uiState.icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(32.dp),
+                    tint = if (isExpiring) Color(0xFFB76E79) else charcoal
+                )
+
+                Spacer(Modifier.height(8.dp))
 
                 // Centered Number
                 if (valueBrush != null) {
                     Text(
                         text = uiState.value,
-                        style = MaterialTheme.typography.displaySmall.copy(
+                        style = MaterialTheme.typography.displayMedium.copy(
                             fontFamily = serifFont,
                             brush = valueBrush,
-                            fontSize = 32.sp
+                            fontSize = 48.sp
                         ),
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.align(Alignment.Center)
+                        fontWeight = FontWeight.Bold
                     )
                 } else {
                     Text(
                         text = uiState.value,
-                        style = MaterialTheme.typography.displaySmall.copy(
+                        style = MaterialTheme.typography.displayMedium.copy(
                             fontFamily = serifFont,
-                            fontSize = 32.sp
+                            fontSize = 48.sp
                         ),
                         fontWeight = FontWeight.Bold,
-                        color = charcoal,
-                        modifier = Modifier.align(Alignment.Center)
+                        color = charcoal
                     )
                 }
             }
 
-            // 2. Bottom Colored Footer
+            // 2. Bottom Colored Footer Button
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(28.dp)
-                    .background(chromaticBrush),
+                    .height(48.dp)
+                    .background(footerBrush),
                 contentAlignment = Alignment.Center
             ) {
-                Surface(
-                    color = Color.White.copy(alpha = if (isExpiring) 0.12f else 0.45f), 
-                    shape = RoundedCornerShape(4.dp)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = if (isExpiring) "VIEW ITEMS" else "VIEW INVENTORY",
-                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 7.sp),
-                            fontWeight = FontWeight.Black,
-                            color = if (isExpiring) Color.White else charcoal.copy(alpha = 0.8f),
-                            letterSpacing = 0.5.sp
-                        )
-                        Spacer(Modifier.width(4.dp))
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                            contentDescription = null,
-                            modifier = Modifier.size(8.dp),
-                            tint = if (isExpiring) Color.White else charcoal.copy(alpha = 0.4f)
-                        )
-                    }
+                    Text(
+                        text = if (isExpiring) "VIEW ITEMS" else "VIEW INVENTORY",
+                        style = MaterialTheme.typography.labelLarge.copy(fontSize = 12.sp),
+                        fontWeight = FontWeight.Black,
+                        color = if (isExpiring) Color.White else charcoal.copy(alpha = 0.8f),
+                        letterSpacing = 1.sp
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                        contentDescription = null,
+                        modifier = Modifier.size(12.dp),
+                        tint = if (isExpiring) Color.White else charcoal.copy(alpha = 0.6f)
+                    )
                 }
             }
         }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/VanityCategoryCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -41,6 +42,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -206,16 +208,25 @@ fun VanityCategoryCard(
                                 fontFamily = FontFamily.Serif,
                                 color = Color.Black
                             )
-                            IconButton(
+                            Spacer(Modifier.width(8.dp))
+                            Surface(
                                 onClick = { showExplanation = true },
-                                modifier = Modifier.size(32.dp)
+                                shape = CircleShape,
+                                color = Color.Black.copy(alpha = 0.05f),
+                                modifier = Modifier.size(20.dp)
                             ) {
-                                Icon(
-                                    imageVector = Icons.Default.Info,
-                                    contentDescription = "Category Info",
-                                    modifier = Modifier.size(16.dp),
-                                    tint = Color.Black.copy(alpha = 0.2f)
-                                )
+                                Box(contentAlignment = Alignment.Center) {
+                                    Text(
+                                        text = "i",
+                                        style = MaterialTheme.typography.labelSmall.copy(
+                                            fontFamily = FontFamily.Serif,
+                                            fontStyle = FontStyle.Italic,
+                                            fontWeight = FontWeight.Bold,
+                                            fontSize = 10.sp
+                                        ),
+                                        color = Color.Black.copy(alpha = 0.4f)
+                                    )
+                                }
                             }
                         }
                         Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
This commit updates the visual layout and styling of the Cosmetics feature to a more elegant aesthetic, focusing on typography, spacing, and color palette refinements.

- **VanityLandingScreen Updates**:
    - Replaced the welcome header with a stylized "Good morning, Beautiful" greeting and updated text styles.
    - Redesigned feature cards (Color Hub, Glow Sync) with increased height (140.dp), updated shimmer gradients, and right-aligned prominent icons.
    - Applied a light cream background (`0xFFFCF9F6`) to the main container and styled the top app bar to match.
    - Updated the Floating Action Button with a Dark Plum color scheme and increased elevation.
- **SummaryStatCard Refactoring**:
    - Increased card height to 180.dp and value font size to 48.sp for better visibility.
    - Reorganized layout to center the icon and value vertically.
    - Refined the "Expiring" state logic to include "Soon" labels and updated the footer with a dark burgundy/plum gradient.
- **Component Refinements**:
    - Simplified the information icon in `VanityCategoryCard` to a minimalist, italicized "i" within a circular surface.
    - Standardized stat card icons, utilizing `Kitchen` for total inventory and `Warning` for expiring items.
    - Updated typography across components to use bold serif fonts for a more premium look.