### PR TITLE
ui: adjust typography sizes in PackPreviewItemRow

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
@@ -107,7 +107,7 @@ fun PackPreviewItemRow(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
                         text = item.name,
-                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 18.sp),
+                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 16.sp), // Slightly smaller header
                         fontFamily = FontFamily.Serif,
                         fontWeight = FontWeight.Medium,
                         color = Color(0xFF1A1C1E)
@@ -146,7 +146,7 @@ fun PackPreviewItemRow(
                 Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 2.dp)) {
                     Text(
                         text = subtitleText ?: "",
-                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 12.sp),
+                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 15.sp), // Increased size
                         color = Color.Gray,
                         letterSpacing = 0.2.sp
                     )
@@ -165,7 +165,7 @@ fun PackPreviewItemRow(
                     Text(
                         text = "$${"%.2f".format(unitPrice)}/ml",
                         style = MaterialTheme.typography.titleLarge.copy(
-                            fontSize = 16.sp,
+                            fontSize = 13.sp, // Decreased size
                             fontWeight = FontWeight.Light
                         ),
                         color = Color(0xFF7CA682),


### PR DESCRIPTION
This commit updates the font sizes for the subtitle and unit price text within the starter pack preview items to refine the visual hierarchy and readability of the item rows.

- **Typography Adjustments**:
    - Increased the `subtitleText` font size from 12sp to 15sp.
    - Decreased the unit price text size from 16sp to 13sp for the price-per-milliliter display.