### PR TITLE
feat: implement BlurHash image placeholders across UI and manifest

### DIFF
--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticDetailScreen.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/CosmeticDetailScreen.kt
@@ -63,6 +63,7 @@ import com.zoewave.probase.core.model.ritual.MacroCategory
 import com.zoewave.probase.core.model.ritual.MicroCategory
 import com.zoewave.probase.core.ui.components.MakeItMineButton
 import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
+import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.kocolor.features.cosmetics.R
 import com.zoewave.probase.kocolor.features.cosmetics.ui.components.ApplicationGuideSection
 import com.zoewave.probase.kocolor.features.cosmetics.ui.components.AtelierExpandableSection
@@ -343,7 +344,6 @@ fun CosmeticDetailScreen(
                 )
             }
 
-            // 2. Product Image Section
             Surface(
                 modifier = Modifier
                     .padding(horizontal = 24.dp, vertical = 8.dp)
@@ -355,7 +355,10 @@ fun CosmeticDetailScreen(
             ) {
                 Box(contentAlignment = Alignment.Center, modifier = Modifier.padding(24.dp)) {
                     if (item.imageUrl != null) {
-                        val placeholder = rememberBlurHashPainter(blurHash = item.blurhash)
+                        val placeholder = rememberBlurHashPainter(
+                            blurHash = item.blurhash,
+                            fallbackColor = parseColor(item.colorHex).copy(alpha = 0.1f)
+                        )
                         AsyncImage(
                             model = item.imageUrl,
                             contentDescription = item.name,

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/CosmeticProductCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
 import com.zoewave.probase.features.graphics.colorpicker.util.isColorDark
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.kocolor.features.cosmetics.R
@@ -53,7 +54,14 @@ fun CosmeticProductCard(
                     contentAlignment = Alignment.Center
                 ) {
                     if (uiState.imageUrl != null) {
-                        AsyncImage(model = uiState.imageUrl, contentDescription = null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
+                        val placeholder = rememberBlurHashPainter(blurHash = uiState.blurhash)
+                        AsyncImage(
+                            model = uiState.imageUrl, 
+                            contentDescription = null, 
+                            placeholder = placeholder,
+                            modifier = Modifier.fillMaxSize(), 
+                            contentScale = ContentScale.Crop
+                        )
                     } else {
                         Icon(Icons.Default.AutoAwesome, null, tint = contentColor.copy(alpha = 0.5f))
                     }

--- a/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/RecentProductCard.kt
+++ b/applications/kocolor/features/cosmetics/src/main/java/com/zoewave/probase/kocolor/features/cosmetics/ui/components/RecentProductCard.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
+import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.core.model.ritual.CosmeticItem
 import com.zoewave.probase.core.model.ritual.MacroCategory
 import com.zoewave.probase.core.model.ritual.MicroCategory
@@ -40,7 +42,17 @@ fun RecentProductCard(
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             if (item.imageUrl != null) {
-                AsyncImage(model = item.imageUrl, contentDescription = null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
+                val placeholder = rememberBlurHashPainter(
+                    blurHash = item.blurhash,
+                    fallbackColor = parseColor(item.colorHex).copy(alpha = 0.1f)
+                )
+                AsyncImage(
+                    model = item.imageUrl, 
+                    contentDescription = null, 
+                    placeholder = placeholder,
+                    modifier = Modifier.fillMaxSize(), 
+                    contentScale = ContentScale.Crop
+                )
             }
             
             Surface(modifier = Modifier.padding(16.dp), color = Color.White.copy(alpha = 0.9f), shape = CircleShape) {

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeDetailScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
 import com.zoewave.probase.features.graphics.colorpicker.util.isColorDark
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.kocolor.features.inventory.R
@@ -130,9 +131,11 @@ fun WardrobeDetailScreen(
             ) {
                 Box(modifier = Modifier.fillMaxSize()) {
                     if (item.imageUrl != null) {
+                        val placeholder = rememberBlurHashPainter(blurHash = item.blurhash)
                         AsyncImage(
                             model = item.imageUrl,
                             contentDescription = item.name,
+                            placeholder = placeholder,
                             modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Crop
                         )

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeCard.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
 import com.zoewave.probase.kocolor.features.inventory.R
 import com.zoewave.probase.kocolor.features.inventory.util.toComposeColor
 import com.zoewave.probase.core.model.ritual.ClothingCategory
@@ -51,9 +52,14 @@ fun WardrobeCard(
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             if (uiState.imageUrl != null) {
+                val placeholder = rememberBlurHashPainter(
+                    blurHash = uiState.blurhash,
+                    fallbackColor = bgColor.copy(alpha = 0.1f)
+                )
                 AsyncImage(
                     model = uiState.imageUrl,
                     contentDescription = null,
+                    placeholder = placeholder,
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop
                 )

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
 import com.zoewave.probase.features.graphics.colorpicker.util.parseColor
 import com.zoewave.probase.kocolor.features.inventory.R
 import com.zoewave.probase.kocolor.features.inventory.ui.CategoryMetadata
@@ -396,9 +397,11 @@ fun RecentClothingCard(uiState: ClothingItem, modifier: Modifier = Modifier, onE
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             if (item.imageUrl != null) {
+                val placeholder = rememberBlurHashPainter(blurHash = item.blurhash)
                 AsyncImage(
                     model = item.imageUrl,
                     contentDescription = null,
+                    placeholder = placeholder,
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop
                 )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackManifest.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/data/remote/model/PackManifest.kt
@@ -35,6 +35,7 @@ data class PackInfo(
     @SerialName("schema_version") val schemaVersion: Int,
     val encryption: String,
     @SerialName("hero_image_url") val heroImageUrl: String? = null,
+    @SerialName("hero_blurhash") val heroBlurHash: String? = null,
     @SerialName("expires_at") val expiresAt: Long? = null,
     @SerialName("preview_items") val previewItems: List<PreviewItem> = emptyList()
 )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/PackPreviewViewModel.kt
@@ -32,6 +32,7 @@ data class PackPreviewUiState(
     val sortByValue: Boolean = false,
     val selectedItemNotes: ProductEditorialNotes? = null,
     val selectedItemThumbnail: String? = null,
+    val selectedItemBlurHash: String? = null,
     val selectedItemColor: String? = null,
     val isNotesLoading: Boolean = false
 )
@@ -216,12 +217,14 @@ class PackPreviewViewModel @Inject constructor(
     fun onItemInfoClick(itemId: String) {
         val item = _uiState.value.items.find { it.id == itemId }
         val thumbnail = item?.thumbnailUrl
+        val blurhash = item?.blurhash
         val color = item?.colorHex
         viewModelScope.launch {
             _uiState.update { it.copy(
                 isNotesLoading = true, 
                 selectedItemNotes = null, 
                 selectedItemThumbnail = thumbnail,
+                selectedItemBlurHash = blurhash,
                 selectedItemColor = color
             ) }
             repository.getProductEditorialNotes(itemId)
@@ -235,6 +238,6 @@ class PackPreviewViewModel @Inject constructor(
     }
 
     fun onDismissNotes() {
-        _uiState.update { it.copy(selectedItemNotes = null, selectedItemThumbnail = null, selectedItemColor = null) }
+        _uiState.update { it.copy(selectedItemNotes = null, selectedItemThumbnail = null, selectedItemBlurHash = null, selectedItemColor = null) }
     }
 }

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewItemRow.kt
@@ -104,14 +104,17 @@ fun PackPreviewItemRow(
                     modifier = Modifier
                         .size(80.dp)
                         .clip(RoundedCornerShape(24.dp))
-                        .background(Color.White)
+                        .background(itemColor.copy(alpha = 0.1f)) // Show product tint while loading
                         .border(
                             width = 4.dp,
                             color = itemColor,
                             shape = RoundedCornerShape(24.dp)
                         )
                 ) {
-                    val placeholder = rememberBlurHashPainter(blurHash = item.blurhash)
+                    val placeholder = rememberBlurHashPainter(
+                        blurHash = item.blurhash,
+                        fallbackColor = itemColor.copy(alpha = 0.1f)
+                    )
 
                     AsyncImage(
                         model = item.thumbnailUrl,

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/PackPreviewScreen.kt
@@ -87,6 +87,7 @@ fun PackPreviewScreen(
     ProductEditorialNotesDialog(
         notes = uiState.selectedItemNotes,
         thumbnailUrl = uiState.selectedItemThumbnail,
+        blurHash = uiState.selectedItemBlurHash,
         colorHex = uiState.selectedItemColor,
         isLoading = uiState.isNotesLoading,
         onDismiss = onDismissNotes

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
@@ -16,12 +16,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.ProductEditorialNotes
 
 @Composable
 fun ProductEditorialNotesDialog(
     notes: ProductEditorialNotes?,
     thumbnailUrl: String?,
+    blurHash: String?,
     colorHex: String?,
     isLoading: Boolean,
     onDismiss: () -> Unit
@@ -34,9 +36,15 @@ fun ProductEditorialNotesDialog(
             title = {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     if (thumbnailUrl != null) {
+                        val placeholder = rememberBlurHashPainter(
+                            blurHash = blurHash,
+                            fallbackColor = itemColor.copy(alpha = 0.1f)
+                        )
+
                         AsyncImage(
                             model = thumbnailUrl,
                             contentDescription = null,
+                            placeholder = placeholder,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .aspectRatio(1f)

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/CatalogPackageCard.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/CatalogPackageCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
 import com.zoewave.probase.kocolor.db.entity.PackStatus
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackInfo
 
@@ -45,9 +46,15 @@ fun CatalogPackageCard(
                 .fillMaxWidth()
                 .height(200.dp)
             ) {
+                val placeholder = rememberBlurHashPainter(
+                    blurHash = pack.heroBlurHash,
+                    fallbackColor = Color.LightGray.copy(alpha = 0.1f)
+                )
+
                 AsyncImage(
                     model = pack.heroImageUrl ?: "https://cdn.kocolor.com/inventory/dist/assets/hero/${pack.id}.webp",
                     contentDescription = null,
+                    placeholder = placeholder,
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop
                 )

--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/HeroPackageCard.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/synchub/HeroPackageCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
 import com.zoewave.probase.kocolor.db.entity.PackStatus
 import com.zoewave.probase.kocolor.features.starterpack.data.remote.model.PackInfo
 
@@ -41,10 +42,16 @@ fun HeroPackageCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
-            // Background Image
+            // Background Image with BlurHash placeholder
+            val placeholder = rememberBlurHashPainter(
+                blurHash = pack.heroBlurHash,
+                fallbackColor = Color.LightGray.copy(alpha = 0.1f)
+            )
+
             AsyncImage(
                 model = pack.heroImageUrl ?: "https://cdn.kocolor.com/inventory/dist/assets/hero/kc-prep-01.webp",
                 contentDescription = null,
+                placeholder = placeholder,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop
             )

--- a/core/ui/src/main/java/com/zoewave/probase/core/ui/util/BlurHashPainter.kt
+++ b/core/ui/src/main/java/com/zoewave/probase/core/ui/util/BlurHashPainter.kt
@@ -5,6 +5,8 @@ import android.graphics.drawable.BitmapDrawable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.asImageBitmap
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
@@ -16,21 +18,28 @@ import kotlinx.coroutines.withContext
  * Offloads decoding to Dispatchers.Default to ensure 60fps scrolling.
  */
 @Composable
-fun rememberBlurHashPainter(blurHash: String?, width: Int = 32, height: Int = 32): Painter? {
-    if (blurHash == null) return null
-    
+fun rememberBlurHashPainter(
+    blurHash: String?, 
+    width: Int = 32, 
+    height: Int = 32,
+    fallbackColor: Color? = null
+): Painter? {
     val context = LocalContext.current
     
-    // Produce state runs asynchronously. It starts null and updates when the Bitmap is ready.
+    // Produce state runs asynchronously. It starts with null.
     val bitmapState = produceState<Bitmap?>(initialValue = null, blurHash) {
-        value = withContext(Dispatchers.Default) {
-            BlurHashDecoder.decode(blurHash, width, height)
+        if (blurHash != null) {
+            value = withContext(Dispatchers.Default) {
+                BlurHashDecoder.decode(blurHash, width, height, punch = 1.2f) // Increased punch for vibrancy
+            }
         }
     }
 
-    // Convert the native Bitmap to a Compose-friendly Painter
-    return bitmapState.value?.let { bitmap ->
+    val bitmap = bitmapState.value
+    return if (bitmap != null) {
         val drawable = BitmapDrawable(context.resources, bitmap)
         rememberDrawablePainter(drawable = drawable)
+    } else {
+        fallbackColor?.let { ColorPainter(it) }
     }
 }

--- a/server/package/kc-optimizer/src/composer.rs
+++ b/server/package/kc-optimizer/src/composer.rs
@@ -184,6 +184,10 @@ pub fn assemble_packages(
                 .map(|p| p.thumbnail_url.clone())
                 .or_else(|| package_payload.clothing.first().map(|p| p.thumbnail_url.clone()));
 
+            let hero_blurhash = package_payload.cosmetics.first()
+                .and_then(|p| p.blurhash.clone())
+                .or_else(|| package_payload.clothing.first().and_then(|p| p.blurhash.clone()));
+
             manifest_records.push(PackInfo {
                 id: manifest.package_metadata.id.clone(),
                 name: manifest.package_metadata.name.clone(),
@@ -206,6 +210,7 @@ pub fn assemble_packages(
                 schema_version: 1,
                 encryption: "none".to_string(),
                 hero_image_url,
+                hero_blurhash,
                 expires_at: None,
                 preview_items,
             });

--- a/server/package/kc-optimizer/src/models.rs
+++ b/server/package/kc-optimizer/src/models.rs
@@ -173,6 +173,7 @@ pub struct PackInfo {
     pub schema_version: u32,
     pub encryption: String,
     pub hero_image_url: Option<String>,
+    pub hero_blurhash: Option<String>,
     pub expires_at: Option<u64>,
     pub preview_items: Vec<PreviewItem>,
 }


### PR DESCRIPTION
This commit integrates BlurHash-based placeholders for image loading across the cosmetic and inventory features. This improves the perceived performance and visual quality of the app by showing a blurred version of the image or a tinted fallback color while the full asset loads.

- **UI Enhancements**:
    - Integrated `rememberBlurHashPainter` into `CosmeticProductCard`, `RecentProductCard`, `WardrobeCard`, and various detail screens.
    - Updated `AsyncImage` implementations to use these painters as placeholders.
    - Added support for `fallbackColor` (derived from product tint) in placeholders to maintain visual consistency when a BlurHash is unavailable.
- **Core UI Utility Updates**:
    - Enhanced `rememberBlurHashPainter` to support an optional `fallbackColor` using `ColorPainter`.
    - Increased the decoding "punch" to `1.2f` in `BlurHashDecoder` for more vibrant placeholder generation.
- **Starter Pack & Manifest Updates**:
    - Added `heroBlurHash` to `PackManifest` (Kotlin) and the corresponding Rust models.
    - Updated `PackPreviewViewModel` and `ProductEditorialNotesDialog` to track and display blurhashes for previewed items.
    - Integrated hero image placeholders in `CatalogPackageCard` and `HeroPackageCard`.
- **Backend Optimization**:
    - Updated the `kc-optimizer` Rust tool to automatically extract `hero_blurhash` metadata from the first available product in a package during the composition phase.