### PR TITLE
feat: enhance editorial notes UI and document visual catalog prompts

### DIFF
--- a/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
+++ b/applications/kocolor/features/starterpack/src/main/java/com/zoewave/probase/kocolor/features/starterpack/ui/packpreview/ProductEditorialNotesDialog.kt
@@ -41,6 +41,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -78,17 +80,35 @@ fun ProductEditorialNotesDialog(
                     .fillMaxWidth()
                     .padding(20.dp),
                 shape = RoundedCornerShape(32.dp),
-                color = backdropColor
+                color = backdropColor,
+                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.5f)),
+                shadowElevation = 12.dp
             ) {
-                Box(modifier = Modifier.fillMaxWidth().heightIn(max = 800.dp)) {
-                    // --- DIALOG CONTENT ---
+                Box(modifier = Modifier.fillMaxWidth().heightIn(max = 850.dp)) {
+                    
+                    // 1. --- IMMERSIVE ATMOSPHERIC BACKGROUND BLUR ---
+                    if (thumbnailUrl != null) {
+                        PremiumProductImage(
+                            imageUrl = thumbnailUrl,
+                            blurHash = blurHash,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .matchParentSize()
+                                .blur(60.dp)
+                                .alpha(0.35f),
+                            contentScale = ContentScale.Crop,
+                            fallbackColor = itemColor.copy(alpha = 0.2f)
+                        )
+                    }
+
+                    // 2. --- DIALOG CONTENT ---
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(24.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        // Product Title
+                        // Header: Title with premium Serif Font
                         Text(
                             text = notes?.editorialTitle ?: "Analyzing Product...",
                             fontFamily = FontFamily.Serif,
@@ -101,7 +121,7 @@ fun ProductEditorialNotesDialog(
                         
                         Spacer(Modifier.height(24.dp))
 
-                        // Scrollable Sections
+                        // Scrollable Modular Card Stack
                         Column(
                             modifier = Modifier
                                 .weight(1f, fill = false)
@@ -113,7 +133,7 @@ fun ProductEditorialNotesDialog(
                                     CircularProgressIndicator(color = Color(0xFF745E7A))
                                 }
                             } else if (notes != null) {
-                                // A. Visual Identity Card
+                                // A. VISUAL IDENTITY CARD (Expanded by Default)
                                 if (thumbnailUrl != null) {
                                     EditorialCard(
                                         label = "Visual Identity",
@@ -136,11 +156,12 @@ fun ProductEditorialNotesDialog(
                                                 fallbackColor = itemColor
                                             )
                                             
-                                            Spacer(Modifier.height(12.dp))
+                                            Spacer(Modifier.height(16.dp))
                                             
+                                            // Product Sub-header & Hex DNA
                                             Text(
                                                 text = notes.editorialTitle.replace("Artist Notes: ", "").replace("Style Notes: ", ""),
-                                                style = MaterialTheme.typography.bodyMedium,
+                                                style = MaterialTheme.typography.bodyLarge,
                                                 fontWeight = FontWeight.Bold,
                                                 color = Color.Black
                                             )
@@ -151,7 +172,7 @@ fun ProductEditorialNotesDialog(
                                                 letterSpacing = 1.sp
                                             )
 
-                                            // SUMMARY under the image (Marketing Copy)
+                                            // Marketing Summary (Hook)
                                             notes.summary?.let { summary ->
                                                 Spacer(Modifier.height(12.dp))
                                                 Text(
@@ -165,7 +186,7 @@ fun ProductEditorialNotesDialog(
                                     }
                                 }
 
-                                // B. DESCRIPTION Card (from description.md) - Between Image and Scientific
+                                // B. BRAND NARRATIVE CARD (Description from description.md)
                                 notes.description?.let { desc ->
                                     EditorialCard(
                                         label = "Description",
@@ -180,7 +201,7 @@ fun ProductEditorialNotesDialog(
                                     }
                                 }
 
-                                // C. SCIENTIFIC OVERVIEW Card (from technical_overview / Product_Description.md)
+                                // C. SCIENTIFIC OVERVIEW CARD (Technical from Product_Description.md)
                                 notes.technicalOverview?.let { tech ->
                                     EditorialCard(
                                         label = "Scientific Overview",
@@ -195,7 +216,7 @@ fun ProductEditorialNotesDialog(
                                     }
                                 }
 
-                                // C. Dynamic Attributes
+                                // D. DYNAMIC ATTRIBUTE CARDS (Usage, Expert Tips, etc.)
                                 notes.attributes.forEach { attribute ->
                                     EditorialCard(
                                         label = attribute.label,

--- a/server/docs/Catalog/visual_backlog_prompts.artifact.md
+++ b/server/docs/Catalog/visual_backlog_prompts.artifact.md
@@ -1,0 +1,70 @@
+# 🎨 KoColor V1.1 Visual Backlog: Grid Generation Prompts
+
+Use the following prompts in the "Create image" tool to generate the missing high-fidelity assets in the required 3x3 format.
+
+---
+
+## 📸 Batch 1: Prep & Foundation Foundation
+**Verticals**: PREP, COMPLEXION
+
+> Generate a single 16:9 image containing a strict 3x3 grid of 9 high-fidelity product photographs. The background for all items must be a clean, uniform light grey studio backdrop with soft, even lighting. Ensure there are thick white horizontal and vertical gutters separating the grid cells, and substantial empty negative space around each product to allow for clean programmatic image slicing. Center each product in its respective grid slot. Below each product, generate two lines of clear, legible black text.
+> **Row 1:**
+> * A premium white frosted glass jar with a silver lid, containing a rich white cream. Text: "kc-moisturizer-901\n'Barrier-Shield Daily Moisturizer'".
+> * A small, elegant tin containing a pink granulated sugar scrub. Text: "kc-lip-care-901\n'Conditioning Lip Scrub'".
+> * A small amber glass jar with a black lid, containing a light yellow eye cream and a small applicator spoon. Text: "kc-eye-care-901\n'Depuffing Caffeine Eye Cream'".
+>
+> **Row 2:**
+> * A tall, clear glass bottle with a silver spray pump, containing a clear blue-tinted liquid. Text: "kc-toner-901\n'Hydra-Lock Balancing Toner'".
+> * A sleek frosted glass dropper bottle containing a clear, viscous liquid with small bubbles. Text: "kc-exfoliant-901\n'Liquid Glow AHA Exfoliant'".
+> * A white squeeze tube with a precision tip, minimalist black text. Text: "kc-primer-901\n'Optical Blur Pore Primer'".
+>
+> **Row 3:**
+> * A wide, grey clay-coated jar with a textured matte finish. Text: "kc-face-mask-901\n'Resurfacing Enzyme Mask'".
+> * A soft beige squeeze tube with a pump dispenser, professional branding. Text: "kc-bb-cc-cream-901\n'Adaptive Radiance BB Cream'".
+> * A tall clear bottle with a fine mist nozzle, showing a slight dewy condensation on the glass. Text: "kc-setting-spray-901\n'All-Day Hydro Lock Mist'".
+
+---
+
+## 📸 Batch 2: Sculpting & Optical Precision
+**Verticals**: COMPLEXION, DIMENSION, EYES
+
+> Generate a single 16:9 image containing a strict 3x3 grid of 9 high-fidelity product photographs. The background for all items must be a clean, uniform light grey studio backdrop with soft, even lighting. Ensure there are thick white horizontal and vertical gutters separating the grid cells, and substantial empty negative space around each product to allow for clean programmatic image slicing. Center each product in its respective grid slot. Below each product, generate two lines of clear, legible black text.
+> **Row 1:**
+> * A premium silver compact case, opened to reveal a smooth, pressed beige powder foundation. Text: "kc-face-powder-901\n'Baked Mineral Foundation'".
+> * A small frosted glass pot with a mint-green gel-cream inside. Text: "kc-color-corrector-901\n'Chroma-Correction Mint Gel'".
+> * A clear acrylic jar with a sifter top, containing ultra-fine translucent white powder and a black velour puff. Text: "kc-setting-powder-901\n'Velvet-Finish Loose Powder'".
+>
+> **Row 2:**
+> * A chunky, matte-black twist-up stick showing a deep, cool-toned brown cream. Text: "kc-contour-901\n'Architectural Sculpting Stick'".
+> * A thin, fine-tipped pen with a wood-grain pattern barrel. Text: "kc-freckle-tint-901\n'Natural-Dot Freckle Pen'".
+> * A frosted glass dropper bottle containing a shimmering champagne-gold liquid. Text: "kc-highlighter-901\n'Starlight Liquid Glow'".
+>
+> **Row 3:**
+> * A large silver palette containing a finely milled, warm golden-brown powder bronzer. Text: "kc-bronzer-901\n'Sun-Kissed Mineral Bronzer'".
+> * A pair of high-density, multi-dimensional black silk false lashes on a clear tray. Text: "kc-false-lashes-901\n'High-Definition Silk Lashes'".
+> * A sleek white mascara tube with a white wand, showing white volumizing fibers. Text: "kc-lash-primer-901\n'Lash-Bonding Fiber Primer'".
+
+---
+
+## 📸 Batch 3: High-Retention Hair & Gloss
+**Verticals**: EYES, LIPS, HAIR
+
+> Generate a single 16:9 image containing a strict 3x3 grid of 9 high-fidelity product photographs. The background for all items must be a clean, uniform light grey studio backdrop with soft, even lighting. Ensure there are thick white horizontal and vertical gutters separating the grid cells, and substantial empty negative space around each product to allow for clean programmatic image slicing. Center each product in its respective grid slot. Below each product, generate two lines of clear, legible black text.
+> **Row 1:**
+> * A small, clear mascara-style tube with a precision spoolie, containing a dark brown fiber-gel. Text: "kc-brow-gel-901\n'Volumizing Tinted Brow Gel'".
+> * A crystal-clear rectangular lip gloss tube with a silver cap and a large doe-foot applicator. Text: "kc-lip-gloss-901\n'Glass-Reflect High Shine Gloss'".
+> * A sleek, high-shine pink tube with a metallic applicator tip. Text: "kc-lip-plumper-901\n'Max-Volume Peptide Plumper'".
+>
+> **Row 2:**
+> * A professional red wooden pencil with a sharp tip and a matching red cap. Text: "kc-lip-liner-901\n'Precision Sculpt Lip Pencil'".
+> * A heavy glass jar with a black lid, containing a thick silver-grey styling pomade and a small comb. Text: "kc-hair-styling-901\n'Architectural Defining Pomade'".
+> * A vibrant purple squeeze bottle with a precision applicator nozzle. Text: "kc-hair-color-901\n'Chromatic Intensity Semi-Perm'".
+>
+> **Row 3:**
+> * A tall, elegant white bottle with a minimalist label and a silver pump. Text: "kc-conditioner-901\n'Cuticle-Seal Moisture Conditioner'".
+> * A wide-mouth gold-tinted jar containing a thick, creamy white hair treatment mask. Text: "kc-hair-mask-901\n'Deep-Bonding Recovery Mask'".
+> * A textured grey puck-style tin containing a gritty, matte-finish hair clay. Text: "kc-hair-501\n'Flexible-Architecture Hair Styling Clay'".
+
+---
+> [!NOTE]
+> Once you have generated and saved these images, place them in `server/utils/ImageSplit/input_images/` and run the slicer to automate production ingestion.


### PR DESCRIPTION
This commit improves the visual fidelity of the product editorial notes dialog and introduces a comprehensive set of AI prompts for generating the missing product assets in the catalog backlog.

- **Editorial Dialog UI Refinement**:
    - Introduced an immersive atmospheric background blur layer derived from the product thumbnail to increase visual depth.
    - Increased maximum dialog height to 850dp and added a semi-transparent white border with 12dp shadow elevation.
    - Upgraded header typography to a premium Serif font and refined spacing/font weights across all modular cards.
    - Reorganized the card stack with clearer section labeling, including "Visual Identity," "Brand Narrative," and "Scientific Overview."
- **Visual Backlog Documentation**:
    - Created `visual_backlog_prompts.artifact.md` to store structured prompts for generating high-fidelity product assets.
    - Standardized 3x3 grid generation requirements (neutral backgrounds, gutters, and negative space) to support automated processing via the `kc-slicer` utility.
    - Defined three thematic batches for AI image generation covering Prep, Complexion, Dimension, Eyes, Lips, and Hair product verticals.