### PR TITLE
docs: standardize versioning to V1.0 across catalog and product metadata

### DIFF
--- a/server/docs/Catalog/New_Product_Backlog.md
+++ b/server/docs/Catalog/New_Product_Backlog.md
@@ -1,4 +1,4 @@
-# KoColor V1.1 Inventory Backlog: Synthetic Category Completion
+# KoColor V1.0 Inventory Backlog: Synthetic Category Completion
 
 This document contains full scientific specifications for 55 new products, designed to bridge every remaining gap in the KoColor vertical taxonomy. These items are engineered for "Scientific Beauty" and "Aesthetic DNA" alignment.
 

--- a/server/docs/Catalog/summary.md
+++ b/server/docs/Catalog/summary.md
@@ -243,6 +243,6 @@ Here is the advertising copy designed to sell each product, formatted perfectly 
 * **Synthetic-Bristle Foundation Brush (`kc-tools-101`)**: Flawless chromatic dispersion. A densely packed, ultra-soft brush engineered specifically for liquid and cream architectures.
 * **Micro-Pore Blending Sponge (`kc-tools-201`)**: The ultimate skin-mimic tool. A hydrophilic, latex-free sponge that doubles in size when wet to bounce foundation into a seamless, poreless finish.
 * **Ergonomic Eyelash Curler (`kc-tools-301`)**: Maximum vertical architecture. A heavy-duty, carbon steel curler designed to fit the exact curvature of the human eye without pinching.
-* **Modular Acrylic Organizer (`kc-tools-401`)**: Aesthetic inventory management. A heavy-weight, crystal-clear storage matrix designed to house the exact dimensions of the KoColor V1.1 collection.
+* **Modular Acrylic Organizer (`kc-tools-401`)**: Aesthetic inventory management. A heavy-weight, crystal-clear storage matrix designed to house the exact dimensions of the KoColor V1.0 collection.
 * **Stainless Steel Cosmetic Spatula (`kc-tools-501`)**: Clinical cross-contamination prevention. A surgical-grade mixing tool designed to safely extract creams and mix foundation shades.
 * **Aura No. 7: swiftmonster (`kc-frag-701`)**: Unleash the beast. A high-voltage floral explosion that balances sweet wild orchid with a predatory, metallic Ambroxan base.

--- a/server/docs/Catalog/visual_backlog_prompts.artifact.md
+++ b/server/docs/Catalog/visual_backlog_prompts.artifact.md
@@ -1,4 +1,4 @@
-# 🎨 KoColor V1.1 Visual Backlog: Grid Generation Prompts
+# 🎨 KoColor V1.0 Visual Backlog: Grid Generation Prompts
 
 Use the following prompts in the "Create image" tool to generate the missing high-fidelity assets in the required 3x3 format.
 

--- a/server/package/input/KoColor/TOOLS/Organizers/kc-tools-401.notes.json
+++ b/server/package/input/KoColor/TOOLS/Organizers/kc-tools-401.notes.json
@@ -1,7 +1,7 @@
 {
   "product_id": "kc-tools-401",
   "card_title": "Artist Notes: Modular Acrylic Organizer",
-  "summary": "Aesthetic inventory management. A heavy-weight, crystal-clear storage matrix designed to house the exact dimensions of the KoColor V1.1 collection.",
+  "summary": "Aesthetic inventory management. A heavy-weight, crystal-clear storage matrix designed to house the exact dimensions of the KoColor V1.0 collection.",
   "description": "Structural vanity organization. Cast from shatter-resistant acrylic, this multi-tiered system allows for high-visibility access to your cosmetic arsenal, elevating your daily routine into a streamlined, clinical process.",
   "technical_overview": "Offered at $65.0 for 1 Unit, this KoColor ORGANIZERS is expertly formulated with 100% Cast Acrylic. It delivers a high-fidelity Crystal Clear color profile (`#FFFFFF`) and leverages high-tensile transparent molding.",
   "dynamic_attributes": [


### PR DESCRIPTION
This commit corrects several instances where version "V1.1" was incorrectly referenced instead of "V1.0". These updates ensure consistency across the inventory backlog, visual asset prompts, and product-specific metadata.

- **Documentation Versioning Alignment**:
    - Updated the titles of `New_Product_Backlog.md` and `visual_backlog_prompts.artifact.md` to reflect the KoColor V1.0 release.
    - Adjusted the product summary for the **Modular Acrylic Organizer (`kc-tools-401`)** in `summary.md` to reference the V1.0 collection.
- **Metadata Synchronization**:
    - Updated `kc-tools-401.notes.json` to ensure the internal product summary correctly identifies the target collection version as V1.0.