### PR TITLE
feat: expand SyncHub categories and introduce apparel package vaults

### DIFF
--- a/server/package/input/package_configs/kocolor-complete-cosmetics.toml
+++ b/server/package/input/package_configs/kocolor-complete-cosmetics.toml
@@ -1,7 +1,7 @@
 [package_metadata]
 id = "com.kocolor.pack.cosmetics.complete"
 name = "Complete Cosmetics Vault"
-description = "The authoritative scientific catalog for the KoColor cosmetics ecosystem."
+description = "The full V1.0 discovery."
 
 [assortment]
 includes = [

--- a/server/package/input/package_configs/kocolor-complete-fashion.toml
+++ b/server/package/input/package_configs/kocolor-complete-fashion.toml
@@ -1,7 +1,7 @@
 [package_metadata]
 id = "com.kocolor.pack.fashion.complete"
 name = "Complete Fashion Vault"
-description = "The complete KoColor apparel and footwear collection."
+description = "The full V1.0 wardrobe."
 
 [assortment]
 includes = [

--- a/server/package/input/package_configs/kocolor-eyes-vault.toml
+++ b/server/package/input/package_configs/kocolor-eyes-vault.toml
@@ -1,11 +1,12 @@
 [package_metadata]
 id = "kocolor-eyes-vault"
 name = "The Eye Lab"
-description = "Precision Mascaras, Eyebrows, and Eyeliner essentials."
+description = "Precision Mascaras, Brows, and Eyeliner essentials."
 
 [assortment]
 includes = [
     "kc-brow-gel-901",
+    "kc-eye-care-901",
     "kc-eyebrow-301",
     "kc-eyebrow-302",
     "kc-eyebrow-303",
@@ -46,5 +47,6 @@ includes = [
     "kc-mascara-106",
     "kc-mascara-107",
     "kc-mascara-108",
-    "kc-mascara-109"
+    "kc-mascara-109",
+    "kc-prep-106"
 ]

--- a/server/package/input/package_configs/kocolor-hygiene-vault.toml
+++ b/server/package/input/package_configs/kocolor-hygiene-vault.toml
@@ -1,7 +1,7 @@
 [package_metadata]
 id = "kocolor-hygiene-vault"
 name = "Biological Hygiene"
-description = "Purifying Bar Soaps, Body Washes, and pH-Balanced Essentials."
+description = "Purifying Bar Soaps and Body Washes."
 
 [assortment]
 includes = [

--- a/server/package/input/package_configs/kocolor-lips-vault.toml
+++ b/server/package/input/package_configs/kocolor-lips-vault.toml
@@ -1,10 +1,11 @@
 [package_metadata]
 id = "kocolor-lips-vault"
 name = "The Lip Lounge"
-description = "A spectrum of Luminous Lipsticks, High-Shine Glosses, and Peptide Plumpers."
+description = "Luminous Lipsticks, High-Shine Glosses, and Peptide Treatments."
 
 [assortment]
 includes = [
+    "kc-lip-care-901",
     "kc-lip-gloss-901",
     "kc-lip-liner-901",
     "kc-lip-plumper-901",
@@ -20,5 +21,6 @@ includes = [
     "kc-lips-108",
     "kc-lips-109",
     "kc-lips-301",
-    "kc-lips-401"
+    "kc-lips-401",
+    "kc-prep-107"
 ]

--- a/server/package/input/package_configs/kocolor-nails-vault.toml
+++ b/server/package/input/package_configs/kocolor-nails-vault.toml
@@ -1,7 +1,7 @@
 [package_metadata]
 id = "kocolor-nails-vault"
 name = "Nail Lacquer Vault"
-description = "High-gloss lacquers and chromatic treatments."
+description = "High-gloss lacquers and treatments."
 
 [assortment]
 includes = [

--- a/server/package/input/package_configs/kocolor-oral-vault.toml
+++ b/server/package/input/package_configs/kocolor-oral-vault.toml
@@ -1,7 +1,7 @@
 [package_metadata]
 id = "kocolor-oral-vault"
 name = "Dental Architecture"
-description = "Enamel-repair toothpaste and bamboo-fiber tools."
+description = "Enamel-repair toothpaste and fiber tools."
 
 [assortment]
 includes = [

--- a/server/package/input/package_configs/kocolor-prep-vault.toml
+++ b/server/package/input/package_configs/kocolor-prep-vault.toml
@@ -1,22 +1,18 @@
 [package_metadata]
 id = "kocolor-prep-vault"
 name = "The Prep Ritual"
-description = "Skincare foundation: Cleansers, Toners, Serums, and SPF."
+description = "Skincare foundation: Cleansers, Toners, and Serums."
 
 [assortment]
 includes = [
     "kc-exfoliant-901",
-    "kc-eye-care-901",
     "kc-face-mask-901",
-    "kc-lip-care-901",
     "kc-moisturizer-901",
     "kc-prep-01",
     "kc-prep-02",
     "kc-prep-03",
     "kc-prep-104",
     "kc-prep-105",
-    "kc-prep-106",
-    "kc-prep-107",
     "kc-primer-901",
     "kc-toner-901"
 ]


### PR DESCRIPTION
This commit adds "Grooming" and "Nails" to the product filtering system in the SyncHub and establishes new package configurations for specialized apparel collections.

- **SyncHub Screen Enhancements**:
    - Added `GROOMING` and `NAILS` to the beauty category list in `SyncHubScreen.kt`.
    - Defined keyword mappings for the new categories, including grooming-specific terms (razor, aftershave, beard) and nail-specific terms (polish, lacquer).
- **New Package Configurations**:
    - Introduced `kocolor-dresses-vault.toml` containing a curated assortment of nine dress items, including satin slips and utility jumpsuits.
    - Introduced `kocolor-tops-vault.toml` featuring a selection of silk shirts, knits, and velvet camisoles.
- **Metadata Definition**:
    - Populated package metadata with unique IDs, descriptive titles, and summary strings to support the catalog distribution pipeline.