### PR TITLE
feat: unify garment and usage data streams for rotation tracking

### DIFF
--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/ClothingMapper.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/mapper/ClothingMapper.kt
@@ -48,7 +48,8 @@ fun ClothingItemEntity.toModel(): ClothingItem = ClothingItem(
     blurhash = blurhash,
     searchTokens = searchTokens,
     
-    usageCount = usageCount
+    usageCount = usageCount,
+    lastUsedTimestamp = lastUsedTimestamp
 )
 
 fun ClothingItem.toEntity(): ClothingItemEntity = ClothingItemEntity(
@@ -94,5 +95,6 @@ fun ClothingItem.toEntity(): ClothingItemEntity = ClothingItemEntity(
     blurhash = blurhash,
     searchTokens = searchTokens,
     
-    usageCount = usageCount
+    usageCount = usageCount,
+    lastUsedTimestamp = lastUsedTimestamp
 )

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/model/ClothingWithUsage.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/model/ClothingWithUsage.kt
@@ -1,0 +1,12 @@
+package com.zoewave.probase.kocolor.data.model
+
+import com.zoewave.probase.core.model.ritual.ClothingItem
+import com.zoewave.probase.kocolor.db.entity.ClothingUsageEntity
+
+/**
+ * Domain model combining a canonical garment with its user-specific usage history.
+ */
+data class ClothingWithUsage(
+    val garment: ClothingItem,
+    val usage: ClothingUsageEntity?
+)

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/RotationRepository.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/RotationRepository.kt
@@ -1,5 +1,6 @@
 package com.zoewave.probase.kocolor.data.repository
 
+import com.zoewave.probase.kocolor.data.model.ClothingWithUsage
 import com.zoewave.probase.kocolor.db.entity.ClothingUsageEntity
 import com.zoewave.probase.kocolor.db.entity.GlobalRotationMetricsEntity
 import kotlinx.coroutines.flow.Flow
@@ -7,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 interface RotationRepository {
     fun observeGlobalMetrics(): Flow<GlobalRotationMetricsEntity?>
     fun observeAllUsages(): Flow<List<ClothingUsageEntity>>
+    fun observeAllClothingWithUsage(): Flow<List<ClothingWithUsage>>
     suspend fun getUsageForCategory(categoryId: String): List<ClothingUsageEntity>
     suspend fun commitOutfit(selectedProductIds: List<String>): Result<Unit>
 }

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/RotationRepositoryImpl.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/repository/RotationRepositoryImpl.kt
@@ -1,11 +1,14 @@
 package com.zoewave.probase.kocolor.data.repository
 
+import com.zoewave.probase.kocolor.data.mapper.toModel
+import com.zoewave.probase.kocolor.data.model.ClothingWithUsage
 import com.zoewave.probase.kocolor.db.KoColorDatabase
 import com.zoewave.probase.kocolor.db.dao.GarmentRotationDao
 import com.zoewave.probase.kocolor.db.entity.ClothingUsageEntity
 import com.zoewave.probase.kocolor.db.entity.GlobalRotationMetricsEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,6 +25,17 @@ class RotationRepositoryImpl @Inject constructor(
 
     override fun observeAllUsages(): Flow<List<ClothingUsageEntity>> {
         return rotationDao.observeAllUsages()
+    }
+
+    override fun observeAllClothingWithUsage(): Flow<List<ClothingWithUsage>> {
+        return rotationDao.observeAllClothingWithUsage().map { list ->
+            list.map { wrapper ->
+                ClothingWithUsage(
+                    garment = wrapper.garment.toModel(),
+                    usage = wrapper.usage
+                )
+            }
+        }
     }
 
     override suspend fun getUsageForCategory(categoryId: String): List<ClothingUsageEntity> = withContext(Dispatchers.IO) {

--- a/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/usecase/RotationScoringUseCase.kt
+++ b/applications/kocolor/data/src/main/java/com/zoewave/probase/kocolor/data/usecase/RotationScoringUseCase.kt
@@ -1,6 +1,8 @@
 package com.zoewave.probase.kocolor.data.usecase
 
+import com.zoewave.probase.kocolor.data.model.ClothingWithUsage
 import com.zoewave.probase.kocolor.data.repository.RotationRepository
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -13,6 +15,10 @@ class RotationScoringUseCase @Inject constructor(
     private val minimumOutfitsForPenalty = 5L 
     private val highFrequencyShare = 0.35 // Item used in >35% of category selections
     private val maximumRecencyPenaltyWindowMs = 48 * 60 * 60 * 1000L // 48h
+
+    fun observeAllClothingWithUsage(): Flow<List<ClothingWithUsage>> {
+        return rotationRepository.observeAllClothingWithUsage()
+    }
 
     /**
      * Calculates a normalized rotation penalty [0.0 to 1.0] based on usage frequency

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/GarmentRotationDao.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/dao/GarmentRotationDao.kt
@@ -4,8 +4,10 @@ import androidx.room3.Dao
 import androidx.room3.Insert
 import androidx.room3.OnConflictStrategy
 import androidx.room3.Query
+import androidx.room3.Transaction
 import androidx.room3.Update
 import com.zoewave.probase.kocolor.db.entity.ClothingUsageEntity
+import com.zoewave.probase.kocolor.db.entity.GarmentWithUsage
 import com.zoewave.probase.kocolor.db.entity.GlobalRotationMetricsEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -20,6 +22,10 @@ interface GarmentRotationDao {
 
     @Query("SELECT * FROM clothing_usage")
     fun observeAllUsages(): Flow<List<ClothingUsageEntity>>
+
+    @Transaction
+    @Query("SELECT * FROM clothing_items")
+    fun observeAllClothingWithUsage(): Flow<List<GarmentWithUsage>>
 
     /**
      * Fetches usage statistics by joining [ClothingUsageEntity] with 

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/ClothingItemEntity.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/ClothingItemEntity.kt
@@ -45,5 +45,6 @@ data class ClothingItemEntity(
     val searchTokens: List<String> = emptyList(),
 
     // --- Usage & Performance ---
-    val usageCount: Int = 0
+    val usageCount: Int = 0,
+    val lastUsedTimestamp: Long? = null
 )

--- a/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/GarmentWithUsage.kt
+++ b/applications/kocolor/db/src/main/java/com/zoewave/probase/kocolor/db/entity/GarmentWithUsage.kt
@@ -1,0 +1,17 @@
+package com.zoewave.probase.kocolor.db.entity
+
+import androidx.room3.Embedded
+import androidx.room3.Relation
+
+/**
+ * A data-transfer object (POJO) that joins a canonical garment with its
+ * user-specific usage history.
+ */
+data class GarmentWithUsage(
+    @Embedded val garment: ClothingItemEntity,
+    @Relation(
+        parentColumns = ["remoteId"],
+        entityColumns = ["productId"]
+    )
+    val usage: ClothingUsageEntity?
+)

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeViewModel.kt
@@ -6,7 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zoewave.probase.kocolor.data.repository.WardrobeRepository
 import com.zoewave.probase.kocolor.data.repository.FashionSessionRepository
-import com.zoewave.probase.kocolor.data.repository.RotationRepository
+import com.zoewave.probase.kocolor.data.mapper.toModel
+import com.zoewave.probase.kocolor.data.usecase.RotationScoringUseCase
 import com.zoewave.probase.core.model.ritual.ArchiveStatus
 import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.core.model.ritual.ClothingItem
@@ -53,7 +54,7 @@ sealed class WardrobeEvent {
 @HiltViewModel
 class WardrobeViewModel @Inject constructor(
     private val wardrobeRepository: WardrobeRepository,
-    private val rotationRepository: RotationRepository,
+    private val rotationScoringUseCase: RotationScoringUseCase,
     private val sessionRepository: FashionSessionRepository,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
@@ -102,16 +103,14 @@ class WardrobeViewModel @Inject constructor(
     }
 
     val uiState: StateFlow<WardrobeUiState> = combine(
-        wardrobeRepository.getAllClothing(),
-        rotationRepository.observeAllUsages(),
+        rotationScoringUseCase.observeAllClothingWithUsage(),
         _draftItem,
         _archiveStatuses
-    ) { models, usages, draft, archiveStatuses ->
-        val enrichedModels = models.map { item ->
-            val usage = usages.find { it.productId == item.remoteId }
-            item.copy(
-                usageCount = usage?.useCount?.toInt() ?: 0,
-                lastUsedTimestamp = usage?.lastUsedTimestamp
+    ) { itemsWithUsage, draft, archiveStatuses ->
+        val enrichedModels = itemsWithUsage.map { wrapper ->
+            wrapper.garment.copy(
+                usageCount = wrapper.usage?.useCount?.toInt() ?: 0,
+                lastUsedTimestamp = wrapper.usage?.lastUsedTimestamp
             )
         }
 

--- a/server/docs/Architecture/Rotation/Design/Rotation_UX_Implementation_Plan.md
+++ b/server/docs/Architecture/Rotation/Design/Rotation_UX_Implementation_Plan.md
@@ -1,72 +1,71 @@
-# Implementation Plan: Rotation Visualization & UX (The Glow Score)
+# Architecture Specification: Rotation Visualization & UX (V1 Locked)
 
-This plan outlines the UI/UX enhancements required to showcase the **Clothing Rotation System** to the user. We will transform raw usage data into a premium, "gamified" scientific experience.
+This document outlines the presentation layer for the KoColor Clothing Rotation System, transforming raw database analytics into a premium, responsive user experience.
 
-## 1. Wardrobe "Freshness" Visualization
+## 1. Deterministic Freshness States
 
-### [MOD] Garment Cards (`WardrobeItemCard`)
-Add a dynamic **"Freshness Badge"** to the corner of each garment card.
-*   **Status: FRESH (Cyan/Green)**
-    *   *Logic*: `useCount == 0` OR `lastUsed > 10 days ago`.
-    *   *UI*: Pulsing circular dot.
-*   **Status: IN ROTATION (Yellow/Gold)**
-    *   *Logic*: `useCount > 0` AND `lastUsed` between 3-10 days.
-    *   *UI*: Solid gold border.
-*   **Status: COOLING DOWN (Plum/Red)**
-    *   *Logic*: `lastUsed < 48 hours` OR `CategoryShare > 35%`.
-    *   *UI*: Grayscale overlay or a "Lock" icon indicating the item is "stale" for AI suggestions.
+Garment cards (`WardrobeItemCard`) will display a dynamic status indicator. The system evaluates state in a strict top-down precedence to guarantee no ambiguity:
 
-## 2. The Rotation Dashboard (New Component)
+### 1. RESTING (Plum / Muted Border)
+*   **Logic**: `lastUsed < 48h` OR `CategoryShare > 35%`.
+*   **UX Meaning**: "You've used me recently—consider something else."
+*   **Constraint**: The garment photograph remains fully vibrant and selectable. No grayscale or lock icons.
 
-Place a summary surface at the top of the Wardrobe landing page:
-*   **Glow Score (Total)**: A circular progress gauge showing `Unique Items Worn / Total Items`.
-*   **Diversity Index**: A textual rating (e.g., "Architectural", "Monotonous", "Vibrant") based on the entropy of categories.
-*   **Cooldown Ticker**: A small scrolling list of items currently in the 48h recency window.
+### 2. FRESH (Cyan / Pulsing Dot)
+*   **Logic**: `useCount == 0` OR `lastUsed >= 10 days`.
+*   **UX Meaning**: "Use me."
+*   **Stylist Note**: "You haven't worn this piece recently. It could be a great way to bring more variety to today's look."
 
-## 3. Immersive Outfit Commitment UX
-
-### [MOD] "Save to Palette" Action
-When the user clicks "SAVE", the app must visualize the data loop:
-1.  **Sync Animation**: A "Data Beam" animation moving from the outfit preview into the navigation bar (Collection tab).
-2.  **Haptic Confirmation**: A "Heavy" impact vibration to signify the commitment.
-3.  **Real-time Badge Increment**: The "Wear Count" text on the items should perform a number-scroll animation from `X` to `X+1`.
-
-## 4. AI Insight Integration
-
-### [MOD] `ProductEditorialNotesDialog`
-Update the "Scientific Overview" section to include user-specific rotation facts:
-*   "**Rotation Status**: This item is currently at 12% category share (Fresh)."
-*   "**Last Deployment**: 8 days ago."
-*   "**Stylist Note**: This piece hasn't been worn in a while—deploy it today to maximize your wardrobe ROI."
+### 3. IN ROTATION (Gold / Solid Border)
+*   **Logic**: Default fallback (None of the above apply).
+*   **UX Meaning**: "I'm being used regularly."
 
 ---
 
-## 5. Technical Requirements (Mobile)
+## 2. Dashboard Vanity Metrics
 
-### `RotationRepository` [MODIFY]
-Add a way to observe all personalization data reactively.
+Two independent metrics will reside at the top of the Wardrobe surface:
+
+### The Glow Score (Wardrobe Utilization)
+A percentage measuring how much of the owned wardrobe is actually being worn.
+*   **Formula**: `(Unique garments with useCount > 0) / (Total garments owned)`
+*   **Display**: 0–100% circular progress gauge.
+
+### The Diversity Index (Wardrobe Entropy)
+A textual rating measuring how evenly usage is distributed across categories, preventing a user from hiding a stagnant wardrobe behind a high Glow Score. (Mathematical formula deferred to V1.1; base off simple category variance for V1).
+
+### Cooldown Ticker
+A horizontal scrolling list showing items currently trapped by the 48-hour hard window, making the penalty tangible.
+*   **Format**: `[Item Name] — [Hours Remaining]h` (e.g., *Obsidian Moto Jacket — 31h*).
+
+---
+
+## 3. Domain-Level Architecture Integration
+
+The ViewModel will not map canonical data to personalization data manually. The Repository will expose a joined data class.
+
 ```kotlin
-fun observeAllUsages(): Flow<List<ClothingUsageEntity>>
+// Domain Layer
+data class ClothingWithUsage(
+    val garment: ClothingItem, // Canonical Source of Truth (Domain Model)
+    val usage: ClothingUsageEntity?  // Personalization State
+)
+
+// UI Layer (ViewModel)
+// Observes the unified stream directly
+val uiState: StateFlow<WardrobeUiState> = rotationScoringUseCase
+    .observeAllClothingWithUsage()
+    .map { WardrobeUiState(items = it) }
+    .stateIn(...)
 ```
 
-### `WardrobeViewModel` [MODIFY]
-Combine the canonical catalog flow with the usage flow.
-```kotlin
-val uiState = combine(
-    wardrobeRepository.getAllClothing(),
-    rotationRepository.observeAllUsages()
-) { items, usages ->
-    items.map { item ->
-        val usage = usages.find { it.productId == item.remoteId }
-        item.copy(
-            usageCount = usage?.useCount ?: 0,
-            lastWorn = usage?.lastUsedTimestamp
-        )
-    }
-}
-```
+---
 
-## 6. Verification Plan
-*   **Visual Check**: Verify the "Freshness Badge" changes color immediately after clicking "SAVE" in the simulator.
-*   **Dashboard Accuracy**: Ensure the "Glow Score" increments correctly after committing a multi-garment outfit.
-*   **Cooldown Verification**: Manually set system time forward 48h and verify "Cooling Down" items return to "Fresh/In Rotation" status.
+## 4. The Animation Contract (Truthful UX)
+
+Visual feedback must never lie about database state. The "Data Beam" sync animation and the "Wear Count" badge increments will **only** fire as a callback *after* the Room database transaction completes successfully.
+
+*   **Action**: User taps SAVE.
+*   **Process**: Await `repository.commitOutfit(ids)`.
+*   **Success**: Trigger Data Beam animation + Heavy Haptic impact.
+*   **Failure**: Silently fail (or show a discrete error toast). Do not play success animations.


### PR DESCRIPTION
This commit refactors the data layer to provide a joined stream of garment items and their associated usage metrics. This architecture simplifies the synchronization between canonical catalog data and user-specific usage history, enabling more efficient UI updates for wardrobe "freshness" and rotation scoring.

- **Unified Data Models**:
    - Introduced `GarmentWithUsage` (DB) and `ClothingWithUsage` (Domain) to encapsulate a garment paired with its `ClothingUsageEntity`.
    - Updated `ClothingItemEntity` and mappers to include `lastUsedTimestamp` for precise recency tracking.
- **Database & Repository Enhancements**:
    - Implemented a transactional `@Relation` query in `GarmentRotationDao` to reactively fetch garments with their usage history.
    - Added `observeAllClothingWithUsage` to `RotationRepository` and `RotationScoringUseCase` to expose the unified data stream.
- **ViewModel Refactoring**:
    - Simplified `WardrobeViewModel` by replacing manual flow combination logic with a direct subscription to the unified usage stream.
- **Architecture Documentation**:
    - Revised `Rotation_UX_Implementation_Plan.md` to define deterministic freshness states (Resting, Fresh, In Rotation) and dashboard metrics including "The Glow Score" (utilization) and "Diversity Index" (entropy).