### PR TITLE
Kocolor

### DIFF
--- a/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
+++ b/applications/kocolor/apps/mobile/src/main/java/com/zoewave/probase/kocolor/mobile/ui/KoColorNavEntryProvider.kt
@@ -42,6 +42,7 @@ import com.zoewave.probase.kocolor.features.cosmetics.ui.VanityLandingScreen
 import com.zoewave.probase.kocolor.features.inventory.ui.ColorVerificationRoute
 import com.zoewave.probase.kocolor.features.inventory.ui.ColorVerificationUiState
 import com.zoewave.probase.kocolor.features.inventory.ui.WardrobeAnalyticsScreen
+import com.zoewave.probase.kocolor.features.inventory.ui.UsageDistributionScreen
 import com.zoewave.probase.kocolor.features.inventory.ui.WardrobeCategoryCoverScreen
 import com.zoewave.probase.kocolor.features.inventory.ui.WardrobeCategoryCoverUiState
 import com.zoewave.probase.kocolor.features.inventory.ui.WardrobeDetailScreen
@@ -317,6 +318,15 @@ fun koColorNavEntryProvider(
             val viewModel: WardrobeViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
             WardrobeAnalyticsScreen(
+                uiState = state,
+                onEvent = viewModel::onEvent,
+                navTo = onNavigateTo
+            )
+        }
+        is KoColorRoute.UsageDistribution -> NavEntry(route) {
+            val viewModel: WardrobeViewModel = hiltViewModel()
+            val state by viewModel.uiState.collectAsStateWithLifecycle()
+            UsageDistributionScreen(
                 uiState = state,
                 onEvent = viewModel::onEvent,
                 navTo = onNavigateTo

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/UsageDistributionScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/UsageDistributionScreen.kt
@@ -1,0 +1,118 @@
+package com.zoewave.probase.kocolor.features.inventory.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.zoewave.probase.core.model.ritual.ClothingCategory
+import com.zoewave.probase.core.model.ritual.ClothingItem
+import com.zoewave.probase.kocolor.features.inventory.R
+import com.zoewave.probase.kocolor.features.inventory.ui.components.UsageDistributionChart
+import com.zoewave.probase.kocolor.model.KoColorRoute
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UsageDistributionScreen(
+    uiState: WardrobeUiState,
+    modifier: Modifier = Modifier,
+    onEvent: (WardrobeEvent) -> Unit,
+    navTo: (KoColorRoute) -> Unit
+) {
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { 
+                    Text(
+                        stringResource(R.string.applications_kocolor_features_inventory_usage_distribution), 
+                        style = MaterialTheme.typography.labelLarge, 
+                        letterSpacing = 2.sp
+                    ) 
+                },
+                navigationIcon = {
+                    IconButton(onClick = { navTo(KoColorRoute.Back) }) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack, 
+                            contentDescription = stringResource(R.string.applications_kocolor_features_inventory_back)
+                        )
+                    }
+                }
+            )
+        },
+        modifier = modifier
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.padding(padding).fillMaxSize(),
+            contentPadding = PaddingValues(24.dp),
+            verticalArrangement = Arrangement.spacedBy(32.dp)
+        ) {
+            item {
+                Column {
+                    Text(
+                        text = "Usage Metrics.",
+                        style = MaterialTheme.typography.displaySmall,
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = "Analyzing the rotation frequency of your curated items.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+            }
+
+            item {
+                UsageDistributionChart(
+                    items = uiState.items,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            
+            item {
+                // Additional insight or description
+                Text(
+                    text = "A high Glow Score indicates that you are utilizing a significant portion of your wardrobe. The distribution above highlights which items are becoming 'Wardrobe Heroes' and which might be ripe for archival or re-styling.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UsageDistributionScreenPreview() {
+    MaterialTheme {
+        UsageDistributionScreen(
+            uiState = WardrobeUiState(
+                items = listOf(
+                    ClothingItem(name = "Blazer", category = ClothingCategory.OUTERWEAR, usageCount = 12, colorHex = "#000000"),
+                    ClothingItem(name = "T-Shirt", category = ClothingCategory.TOPS, usageCount = 45, colorHex = "#FFFFFF")
+                )
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeAnalyticsScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeAnalyticsScreen.kt
@@ -22,9 +22,19 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.TrendingDown
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.MonetizationOn
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,15 +46,21 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.zoewave.probase.core.ui.util.parseColor
-import com.zoewave.probase.kocolor.features.inventory.R
-import com.zoewave.probase.kocolor.features.inventory.ui.components.*
 import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.core.model.ritual.ClothingItem
+import com.zoewave.probase.core.ui.util.parseColor
+import com.zoewave.probase.kocolor.features.inventory.R
+import com.zoewave.probase.kocolor.features.inventory.ui.components.AnalyticsStatCard
+import com.zoewave.probase.kocolor.features.inventory.ui.components.AnalyticsStatUiState
+import com.zoewave.probase.kocolor.features.inventory.ui.components.WardrobeEfficiencyRow
+import com.zoewave.probase.kocolor.features.inventory.ui.components.WardrobeEfficiencyUiState
+import com.zoewave.probase.kocolor.features.inventory.ui.components.WardrobeTaxonomyDialog
+import com.zoewave.probase.kocolor.features.inventory.ui.components.WearRankingRow
+import com.zoewave.probase.kocolor.features.inventory.ui.components.WearRankingUiState
 import com.zoewave.probase.kocolor.model.KoColorRoute
-import android.graphics.Color as AndroidColor
 import java.text.NumberFormat
-import java.util.*
+import java.util.Locale
+import android.graphics.Color as AndroidColor
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
@@ -1,7 +1,6 @@
 package com.zoewave.probase.kocolor.features.inventory.ui
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,12 +13,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -46,9 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -62,6 +57,7 @@ import com.zoewave.probase.kocolor.features.inventory.R
 import com.zoewave.probase.kocolor.features.inventory.ui.components.AtelierWardrobeCard
 import com.zoewave.probase.kocolor.features.inventory.ui.components.AtelierWardrobeUiState
 import com.zoewave.probase.kocolor.features.inventory.ui.components.RecentClothingCard
+import com.zoewave.probase.kocolor.features.inventory.ui.components.StatIcon
 import com.zoewave.probase.kocolor.features.inventory.ui.components.SummaryStatCard
 import com.zoewave.probase.kocolor.features.inventory.ui.components.SummaryStatUiState
 import com.zoewave.probase.kocolor.features.inventory.ui.components.WardrobeTaxonomyDialog

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
@@ -1,8 +1,20 @@
 package com.zoewave.probase.kocolor.features.inventory.ui
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -17,24 +29,45 @@ import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.MonetizationOn
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.zoewave.probase.core.model.ritual.ClothingCategory
-import com.zoewave.probase.kocolor.features.inventory.R
-import com.zoewave.probase.kocolor.features.inventory.ui.components.*
 import com.zoewave.probase.core.model.ritual.ClothingItem
+import com.zoewave.probase.kocolor.features.inventory.R
+import com.zoewave.probase.kocolor.features.inventory.ui.components.AtelierWardrobeCard
+import com.zoewave.probase.kocolor.features.inventory.ui.components.AtelierWardrobeUiState
+import com.zoewave.probase.kocolor.features.inventory.ui.components.RecentClothingCard
+import com.zoewave.probase.kocolor.features.inventory.ui.components.SummaryStatCard
+import com.zoewave.probase.kocolor.features.inventory.ui.components.SummaryStatUiState
+import com.zoewave.probase.kocolor.features.inventory.ui.components.WardrobeTaxonomyDialog
 import com.zoewave.probase.kocolor.model.KoColorRoute
 import java.text.NumberFormat
-import java.util.*
+import java.util.Locale
 
 @Preview(showBackground = true)
 @Composable
@@ -46,7 +79,9 @@ private fun WardrobeLandingScreenPreview() {
                 totalInvestment = 1615.0,
                 items = listOf(
                     ClothingItem(internalId = 1, name = "Blouse", category = ClothingCategory.TOPS, colorHex = "#FFFFFF")
-                )
+                ),
+                glowScore = 0.84,
+                diversityIndex = "Eclectic"
             ),
             onEvent = {},
             navTo = {}
@@ -65,15 +100,34 @@ fun WardrobeLandingScreen(
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text(stringResource(R.string.applications_kocolor_features_inventory_style_archive_title), style = MaterialTheme.typography.titleLarge, fontFamily = FontFamily.Serif) },
+                title = {
+                    Text(
+                        stringResource(R.string.applications_kocolor_features_inventory_style_archive_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontFamily = FontFamily.Serif
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = { navTo(KoColorRoute.Back) }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.applications_kocolor_features_inventory_back))
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.applications_kocolor_features_inventory_back)
+                        )
                     }
                 },
                 actions = {
-                    IconButton(onClick = { navTo(KoColorRoute.Wardrobe) }) { Icon(Icons.Default.Inventory2, contentDescription = stringResource(R.string.applications_kocolor_features_inventory_inventory)) }
-                    IconButton(onClick = { navTo(KoColorRoute.ColorSearch) }) { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.applications_kocolor_features_inventory_search)) }
+                    IconButton(onClick = { navTo(KoColorRoute.Wardrobe) }) {
+                        Icon(
+                            Icons.Default.Inventory2,
+                            contentDescription = stringResource(R.string.applications_kocolor_features_inventory_inventory)
+                        )
+                    }
+                    IconButton(onClick = { navTo(KoColorRoute.ColorSearch) }) {
+                        Icon(
+                            Icons.Default.Search,
+                            contentDescription = stringResource(R.string.applications_kocolor_features_inventory_search)
+                        )
+                    }
                 }
             )
         },
@@ -92,7 +146,12 @@ fun WardrobeLandingScreen(
     ) { padding ->
         LazyColumn(
             modifier = Modifier.padding(padding).fillMaxSize(),
-            contentPadding = PaddingValues(bottom = 100.dp, start = 24.dp, end = 24.dp, top = 24.dp),
+            contentPadding = PaddingValues(
+                bottom = 100.dp,
+                start = 24.dp,
+                end = 24.dp,
+                top = 24.dp
+            ),
             verticalArrangement = Arrangement.spacedBy(32.dp)
         ) {
             item {
@@ -108,35 +167,30 @@ fun WardrobeLandingScreen(
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                     )
-                }
-            }
 
-            item {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    SummaryStatCard(
-                        uiState = SummaryStatUiState(
-                            label = "GLOW SCORE",
+                    Spacer(Modifier.height(24.dp))
+
+                    // Compact Clickable Icons for Rotation Analytics
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        StatIcon(
+                            icon = Icons.Default.AutoAwesome,
                             value = "${(uiState.glowScore * 100).toInt()}%",
-                            icon = Icons.Default.AutoAwesome
-                        ),
-                        modifier = Modifier.weight(1f),
-                        onEvent = { /* Open detailed rotation analytics */ },
-                        navTo = navTo
-                    )
-                    
-                    SummaryStatCard(
-                        uiState = SummaryStatUiState(
-                            label = "DIVERSITY INDEX",
+                            label = "GLOW SCORE",
+                            onClick = { navTo(KoColorRoute.WardrobeAnalytics) },
+                            modifier = Modifier.weight(1f)
+                        )
+
+                        StatIcon(
+                            icon = Icons.Default.Explore,
                             value = uiState.diversityIndex,
-                            icon = Icons.Default.Explore
-                        ),
-                        modifier = Modifier.weight(1f),
-                        onEvent = { /* Open category breakdown */ },
-                        navTo = navTo
-                    )
+                            label = "DIVERSITY",
+                            onClick = { navTo(KoColorRoute.WardrobeAnalytics) },
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
                 }
             }
 
@@ -155,7 +209,7 @@ fun WardrobeLandingScreen(
                         onEvent = { navTo(KoColorRoute.WardrobeAnalytics) },
                         navTo = navTo
                     )
-                    
+
                     val currencyFormatter = remember { NumberFormat.getCurrencyInstance(Locale.US) }
                     SummaryStatCard(
                         uiState = SummaryStatUiState(
@@ -192,7 +246,7 @@ fun WardrobeLandingScreen(
                             fontWeight = FontWeight.Bold,
                             letterSpacing = 1.sp
                         )
-                        
+
                         Surface(
                             onClick = { showTaxonomyInfo = true },
                             shape = CircleShape,
@@ -206,7 +260,7 @@ fun WardrobeLandingScreen(
                                     text = stringResource(R.string.applications_kocolor_features_inventory_info_icon),
                                     style = MaterialTheme.typography.titleMedium.copy(
                                         fontFamily = FontFamily.Serif,
-                                        fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
+                                        fontStyle = FontStyle.Italic,
                                         fontWeight = FontWeight.Bold
                                     ),
                                     color = Color(0xFF2C2420)
@@ -214,7 +268,7 @@ fun WardrobeLandingScreen(
                             }
                         }
                     }
-                    
+
                     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                         val sections = listOf(
                             "Tops" to (Color(0xFFF7F2EB) to R.drawable.tops),
@@ -225,10 +279,15 @@ fun WardrobeLandingScreen(
                             "Shoes" to (Color(0xFFE8F1FD) to R.drawable.wardrobe_shoes),
                             "Accessories" to (Color(0xFFF3EBFD) to R.drawable.wardrobe_accessories)
                         )
-                        
+
                         sections.forEach { (name, props) ->
                             val (bgColor, imageModel) = props
-                            val metadata = uiState.categoriesMetadata.entries.find { it.key.equals(name, ignoreCase = true) }?.value
+                            val metadata = uiState.categoriesMetadata.entries.find {
+                                it.key.equals(
+                                    name,
+                                    ignoreCase = true
+                                )
+                            }?.value
                             AtelierWardrobeCard(
                                 uiState = AtelierWardrobeUiState(
                                     name = name,
@@ -252,7 +311,12 @@ fun WardrobeLandingScreen(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Text(stringResource(R.string.applications_kocolor_features_inventory_recently_added), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, letterSpacing = 1.sp)
+                        Text(
+                            stringResource(R.string.applications_kocolor_features_inventory_recently_added),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 1.sp
+                        )
                         Text(
                             stringResource(R.string.applications_kocolor_features_inventory_see_all),
                             style = MaterialTheme.typography.labelLarge,
@@ -260,7 +324,7 @@ fun WardrobeLandingScreen(
                             modifier = Modifier.clickable { navTo(KoColorRoute.Wardrobe) }
                         )
                     }
-                    
+
                     LazyRow(
                         horizontalArrangement = Arrangement.spacedBy(16.dp),
                         contentPadding = PaddingValues(horizontal = 4.dp)

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/WardrobeLandingScreen.kt
@@ -175,7 +175,7 @@ fun WardrobeLandingScreen(
                             icon = Icons.Default.AutoAwesome,
                             value = "${(uiState.glowScore * 100).toInt()}%",
                             label = "GLOW SCORE",
-                            onClick = { navTo(KoColorRoute.WardrobeAnalytics) },
+                            onClick = { navTo(KoColorRoute.UsageDistribution) },
                             modifier = Modifier.weight(1f)
                         )
 

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/UsageDistributionChart.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/UsageDistributionChart.kt
@@ -1,0 +1,146 @@
+package com.zoewave.probase.kocolor.features.inventory.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.zoewave.probase.core.model.ritual.ClothingCategory
+import com.zoewave.probase.core.model.ritual.ClothingItem
+import com.zoewave.probase.kocolor.features.inventory.R
+
+@Composable
+fun UsageDistributionChart(
+    items: List<ClothingItem>,
+    modifier: Modifier = Modifier
+) {
+    val distribution = remember(items) {
+        val counts = IntArray(5)
+        items.forEach { item ->
+            when {
+                item.usageCount == 0 -> counts[0]++
+                item.usageCount in 1..5 -> counts[1]++
+                item.usageCount in 6..10 -> counts[2]++
+                item.usageCount in 11..20 -> counts[3]++
+                else -> counts[4]++
+            }
+        }
+        counts.toList()
+    }
+
+    val maxCount = distribution.maxOrNull() ?: 1
+    val labels = listOf(
+        stringResource(R.string.applications_kocolor_features_inventory_never_worn),
+        stringResource(R.string.applications_kocolor_features_inventory_rarely_worn),
+        stringResource(R.string.applications_kocolor_features_inventory_occasionally_worn),
+        stringResource(R.string.applications_kocolor_features_inventory_regularly_worn),
+        stringResource(R.string.applications_kocolor_features_inventory_wardrobe_heroes)
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f), RoundedCornerShape(24.dp))
+            .padding(24.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.applications_kocolor_features_inventory_usage_distribution),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Black,
+            letterSpacing = 1.sp,
+            modifier = Modifier.padding(bottom = 24.dp)
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp),
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            distribution.forEachIndexed { index, count ->
+                val ratio = if (maxCount > 0) count.toFloat() / maxCount else 0f
+                
+                Column(
+                    modifier = Modifier.weight(1f),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Bottom
+                ) {
+                    if (count > 0) {
+                        Text(
+                            text = count.toString(),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(bottom = 4.dp)
+                        )
+                    }
+                    
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .fillMaxHeight(ratio.coerceAtLeast(0.05f))
+                            .background(
+                                color = if (index == 4) Color(0xFFD4AF37) else MaterialTheme.colorScheme.primary.copy(alpha = 0.8f),
+                                shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp)
+                            )
+                    )
+                }
+            }
+        }
+        
+        Spacer(Modifier.height(12.dp))
+        
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            labels.forEach { label ->
+                Text(
+                    text = label,
+                    modifier = Modifier.weight(1f),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    lineHeight = 12.sp
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UsageDistributionChartPreview() {
+    MaterialTheme {
+        UsageDistributionChart(
+            items = listOf(
+                ClothingItem(name = "Item 1", category = ClothingCategory.TOPS, usageCount = 0, colorHex = "#FFFFFF"),
+                ClothingItem(name = "Item 2", category = ClothingCategory.TOPS, usageCount = 3, colorHex = "#FFFFFF"),
+                ClothingItem(name = "Item 3", category = ClothingCategory.TOPS, usageCount = 8, colorHex = "#FFFFFF"),
+                ClothingItem(name = "Item 4", category = ClothingCategory.TOPS, usageCount = 15, colorHex = "#FFFFFF"),
+                ClothingItem(name = "Item 5", category = ClothingCategory.TOPS, usageCount = 25, colorHex = "#FFFFFF"),
+                ClothingItem(name = "Item 6", category = ClothingCategory.TOPS, usageCount = 30, colorHex = "#FFFFFF")
+            ),
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
@@ -659,7 +659,7 @@ fun RecentClothingCard(
 }
 
 @Composable
-private fun StatIcon(
+fun StatIcon(
     icon: ImageVector,
     value: String,
     label: String,

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
@@ -22,6 +22,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Checkroom
+import androidx.compose.material.icons.filled.MonetizationOn
 import androidx.compose.material.icons.filled.NightlightRound
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -46,9 +48,11 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.zoewave.probase.core.model.ritual.ClothingCategory
 import com.zoewave.probase.core.model.ritual.ClothingItem
 import com.zoewave.probase.core.ui.util.parseColor
 import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
@@ -690,6 +694,126 @@ private fun StatIcon(
                 letterSpacing = 0.5.sp
             )
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SummaryStatCardPreview() {
+    MaterialTheme {
+        SummaryStatCard(
+            uiState = SummaryStatUiState(
+                label = "TOTAL PIECES",
+                value = "124",
+                icon = Icons.Default.Checkroom
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SummaryStatCardValuePreview() {
+    MaterialTheme {
+        SummaryStatCard(
+            uiState = SummaryStatUiState(
+                label = "TOTAL VALUE",
+                value = "$12,450",
+                icon = Icons.Default.MonetizationOn
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun WardrobeTaxonomyDialogPreview() {
+    MaterialTheme {
+        WardrobeTaxonomyDialog(
+            uiState = Unit,
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TaxonomySectionPreview() {
+    MaterialTheme {
+        TaxonomySection(
+            uiState = TaxonomySectionUiState(
+                level = "Level 1",
+                title = "Verticals",
+                description = "Primary structural categories of the wardrobe architecture.",
+                items = listOf(
+                    "Tops" to "Blazers, Shirts, Knitwear.",
+                    "Bottoms" to "Trousers, Skirts, Denim.",
+                    "Shoes" to "Heels, Flats, Sneakers."
+                )
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AtelierWardrobeCardPreview() {
+    MaterialTheme {
+        AtelierWardrobeCard(
+            uiState = AtelierWardrobeUiState(
+                name = "Tops",
+                metadata = CategoryMetadata(
+                    itemCount = 42,
+                    totalValue = 2840.0,
+                    leadingBrand = "Toteme",
+                    averageUsage = 18.5,
+                    description = "Strategic upper silhouette pieces."
+                ),
+                baseColor = Color(0xFFE5E4E2),
+                imageModel = ""
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RecentClothingCardPreview() {
+    MaterialTheme {
+        RecentClothingCard(
+            uiState = ClothingItem(
+                internalId = 1,
+                name = "Silk Slip Dress",
+                brand = "La Perla",
+                category = ClothingCategory.DRESSES,
+                colorHex = "#2C2420",
+                dominantHex = "#2C2420"
+            ),
+            onEvent = {},
+            navTo = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun StatIconPreview() {
+    MaterialTheme {
+        StatIcon(
+            icon = Icons.Default.Checkroom,
+            value = "124",
+            label = "TOTAL PIECES",
+            onClick = {}
+        )
     }
 }
 

--- a/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
+++ b/applications/kocolor/features/inventory/src/main/java/com/zoewave/probase/kocolor/features/inventory/ui/components/WardrobeComponents.kt
@@ -4,15 +4,35 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.NightlightRound
-import androidx.compose.material3.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -29,16 +49,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
+import com.zoewave.probase.core.model.ritual.ClothingItem
 import com.zoewave.probase.core.ui.util.parseColor
+import com.zoewave.probase.core.ui.util.rememberBlurHashPainter
 import com.zoewave.probase.kocolor.features.inventory.R
 import com.zoewave.probase.kocolor.features.inventory.ui.CategoryMetadata
 import com.zoewave.probase.kocolor.features.inventory.ui.util.FreshnessState
 import com.zoewave.probase.kocolor.features.inventory.ui.util.getFreshnessState
-import com.zoewave.probase.core.model.ritual.ClothingItem
 import com.zoewave.probase.kocolor.model.KoColorRoute
 import java.text.NumberFormat
-import java.util.*
+import java.util.Locale
 
 data class SummaryStatUiState(
     val label: String,
@@ -56,7 +76,7 @@ fun SummaryStatCard(
 ) {
     val isValue = uiState.label.contains("VALUE")
     val charcoal = Color(0xFF2C2420)
-    
+
     val valueBrush = if (isValue) {
         Brush.linearGradient(listOf(Color(0xFF1B5E20), Color(0xFF4CAF50), Color(0xFF1B5E20)))
     } else {
@@ -66,12 +86,14 @@ fun SummaryStatCard(
     val actionBg = if (isValue) {
         Brush.linearGradient(listOf(Color(0xFF003300), Color(0xFF006600), Color(0xFF003300)))
     } else {
-        Brush.linearGradient(listOf(
-            Color(0xFFA0C4FF), Color(0xFFBDB2FF), Color(0xFFFFADAD), 
-            Color(0xFFFFD6A5), Color(0xFFFDFFB6), Color(0xFFCAFFBF)
-        ))
+        Brush.linearGradient(
+            listOf(
+                Color(0xFFA0C4FF), Color(0xFFBDB2FF), Color(0xFFFFADAD),
+                Color(0xFFFFD6A5), Color(0xFFFDFFB6), Color(0xFFCAFFBF)
+            )
+        )
     }
-    
+
     val actionText = if (isValue) "VIEW INVENTORY" else "VIEW INTELLIGENCE"
     val actionContentColor = if (isValue) Color.White else charcoal.copy(alpha = 0.8f)
 
@@ -89,7 +111,9 @@ fun SummaryStatCard(
         onClick = onEvent,
         elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
     ) {
-        Column(modifier = Modifier.fillMaxSize().background(glassBg)) {
+        Column(modifier = Modifier
+            .fillMaxSize()
+            .background(glassBg)) {
             Column(
                 modifier = Modifier
                     .weight(1f)
@@ -134,7 +158,7 @@ fun SummaryStatCard(
                         color = charcoal
                     )
                 }
-                
+
                 Text(
                     text = uiState.label,
                     style = MaterialTheme.typography.labelSmall.copy(
@@ -154,7 +178,7 @@ fun SummaryStatCard(
                 contentAlignment = Alignment.Center
             ) {
                 Surface(
-                    color = Color.White.copy(alpha = if (isValue) 0.12f else 0.45f), 
+                    color = Color.White.copy(alpha = if (isValue) 0.12f else 0.45f),
                     border = BorderStroke(0.5.dp, actionContentColor.copy(alpha = 0.2f)),
                     shape = RoundedCornerShape(8.dp)
                 ) {
@@ -191,16 +215,31 @@ fun WardrobeTaxonomyDialog(
 ) {
     AlertDialog(
         onDismissRequest = onEvent,
-        title = { Text(stringResource(R.string.applications_kocolor_features_inventory_architecture_title), style = MaterialTheme.typography.headlineMedium, fontFamily = FontFamily.Serif, fontWeight = FontWeight.Bold) },
+        title = {
+            Text(
+                stringResource(R.string.applications_kocolor_features_inventory_architecture_title),
+                style = MaterialTheme.typography.headlineMedium,
+                fontFamily = FontFamily.Serif,
+                fontWeight = FontWeight.Bold
+            )
+        },
         text = {
-            LazyColumn(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(24.dp)) {
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
                 item {
                     TaxonomySection(
                         uiState = TaxonomySectionUiState(
                             level = "Level 1",
                             title = stringResource(R.string.applications_kocolor_features_inventory_verticals_title),
                             description = stringResource(R.string.applications_kocolor_features_inventory_verticals_desc),
-                            items = listOf("Tops" to "Blazers, Shirts, Knitwear.", "Bottoms" to "Trousers, Skirts, Denim.", "Shoes" to "Heels, Flats, Sneakers.", "Accessories" to "Bags, Belts, Jewelry.")
+                            items = listOf(
+                                "Tops" to "Blazers, Shirts, Knitwear.",
+                                "Bottoms" to "Trousers, Skirts, Denim.",
+                                "Shoes" to "Heels, Flats, Sneakers.",
+                                "Accessories" to "Bags, Belts, Jewelry."
+                            )
                         ),
                         onEvent = {},
                         navTo = {}
@@ -208,7 +247,14 @@ fun WardrobeTaxonomyDialog(
                 }
             }
         },
-        confirmButton = { TextButton(onClick = onEvent) { Text("Understand", fontWeight = FontWeight.Bold) } },
+        confirmButton = {
+            TextButton(onClick = onEvent) {
+                Text(
+                    "Understand",
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        },
         shape = RoundedCornerShape(28.dp),
         containerColor = Color(0xFFF9F6F0)
     )
@@ -233,18 +279,55 @@ private fun TaxonomySection(
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Column {
-            Text(text = uiState.level.uppercase(), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Black, letterSpacing = 1.sp)
-            Text(text = uiState.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Text(text = uiState.description, style = MaterialTheme.typography.bodySmall, modifier = Modifier.alpha(0.7f))
+            Text(
+                text = uiState.level.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Black,
+                letterSpacing = 1.sp
+            )
+            Text(
+                text = uiState.title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = uiState.description,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.alpha(0.7f)
+            )
         }
-        Surface(color = Color.White.copy(alpha = 0.5f), shape = RoundedCornerShape(16.dp), border = BorderStroke(1.dp, Color.Black.copy(alpha = 0.05f))) {
-            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Surface(
+            color = Color.White.copy(alpha = 0.5f),
+            shape = RoundedCornerShape(16.dp),
+            border = BorderStroke(1.dp, Color.Black.copy(alpha = 0.05f))
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
                 uiState.items.forEach { (label, detail) ->
-                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Text(text = "•", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = "•",
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary
+                        )
                         Column {
-                            Text(text = label, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
-                            Text(text = detail, style = MaterialTheme.typography.bodySmall, modifier = Modifier.alpha(0.7f))
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = detail,
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.alpha(0.7f)
+                            )
                         }
                     }
                 }
@@ -271,13 +354,13 @@ fun AtelierWardrobeCard(
     val metadata = uiState.metadata
     val baseColor = uiState.baseColor
     val imageModel = uiState.imageModel
-    
+
     val count = metadata?.itemCount ?: 0
     val totalValue = metadata?.totalValue ?: 0.0
     val leadingBrand = metadata?.leadingBrand
     val averageUsage = metadata?.averageUsage ?: 0.0
     val description = metadata?.description ?: "Strategic curated wardrobe collection."
-    
+
     val currencyFormatter = remember { NumberFormat.getCurrencyInstance(Locale.US) }
 
     Card(
@@ -296,7 +379,9 @@ fun AtelierWardrobeCard(
                 model = imageModel,
                 contentDescription = null,
                 placeholder = placeholder,
-                modifier = Modifier.fillMaxSize().alpha(0.4f),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .alpha(0.4f),
                 contentScale = ContentScale.Crop
             )
 
@@ -305,7 +390,11 @@ fun AtelierWardrobeCard(
                     .fillMaxSize()
                     .background(
                         Brush.horizontalGradient(
-                            colors = listOf(baseColor, baseColor.copy(alpha = 0.6f), Color.Transparent),
+                            colors = listOf(
+                                baseColor,
+                                baseColor.copy(alpha = 0.6f),
+                                Color.Transparent
+                            ),
                             startX = 0f,
                             endX = 1000f
                         )
@@ -333,7 +422,10 @@ fun AtelierWardrobeCard(
                         )
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(
-                                text = stringResource(R.string.applications_kocolor_features_inventory_pieces_format, count),
+                                text = stringResource(
+                                    R.string.applications_kocolor_features_inventory_pieces_format,
+                                    count
+                                ),
                                 style = MaterialTheme.typography.bodyLarge,
                                 fontWeight = FontWeight.Bold,
                                 modifier = Modifier.alpha(0.8f)
@@ -360,31 +452,55 @@ fun AtelierWardrobeCard(
                 Text(
                     text = description,
                     style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.alpha(0.6f).padding(top = 2.dp),
+                    modifier = Modifier
+                        .alpha(0.6f)
+                        .padding(top = 2.dp),
                     fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
                 )
 
                 Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                        Text(text = stringResource(R.string.applications_kocolor_features_inventory_average_utility), style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.Bold, modifier = Modifier.alpha(0.8f))
-                        Text(text = stringResource(R.string.applications_kocolor_features_inventory_wears_format_plural, averageUsage.toInt()), style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Black, color = Color(0xFF6B705C))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = stringResource(R.string.applications_kocolor_features_inventory_average_utility),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.alpha(0.8f)
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.applications_kocolor_features_inventory_wears_format_plural,
+                                averageUsage.toInt()
+                            ),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Black,
+                            color = Color(0xFF6B705C)
+                        )
                     }
-                    
-                    val maxWears = 50.0 
+
+                    val maxWears = 50.0
                     val progress = (averageUsage / maxWears).coerceIn(0.0, 1.0)
-                    val statusColor = Color(0xFF6B705C) 
+                    val statusColor = Color(0xFF6B705C)
 
                     LinearProgressIndicator(
                         progress = { progress.toFloat() },
-                        modifier = Modifier.fillMaxWidth().height(6.dp).clip(CircleShape),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(6.dp)
+                            .clip(CircleShape),
                         color = statusColor,
                         trackColor = Color.White.copy(alpha = 0.3f),
                         strokeCap = androidx.compose.ui.graphics.StrokeCap.Round
                     )
-                    
+
                     if (leadingBrand != null) {
                         Text(
-                            text = stringResource(R.string.applications_kocolor_features_inventory_leading_brand_label_format, leadingBrand),
+                            text = stringResource(
+                                R.string.applications_kocolor_features_inventory_leading_brand_label_format,
+                                leadingBrand
+                            ),
                             style = MaterialTheme.typography.bodySmall,
                             fontWeight = FontWeight.Bold,
                             modifier = Modifier.alpha(0.8f)
@@ -397,21 +513,30 @@ fun AtelierWardrobeCard(
 }
 
 @Composable
-fun RecentClothingCard(uiState: ClothingItem, modifier: Modifier = Modifier, onEvent: (Unit) -> Unit, navTo: (KoColorRoute) -> Unit) {
+fun RecentClothingCard(
+    uiState: ClothingItem,
+    modifier: Modifier = Modifier,
+    onEvent: (Unit) -> Unit,
+    navTo: (KoColorRoute) -> Unit
+) {
     val item = uiState
     val onClick = { navTo(KoColorRoute.WardrobeDetail(item.internalId)) }
     val freshness = item.getFreshnessState()
-    
+
     Card(
         modifier = modifier
             .width(220.dp)
             .aspectRatio(0.8f)
             .clickable { onClick() }
             .then(
-                if (freshness == FreshnessState.IN_ROTATION) 
-                    Modifier.border(2.dp, Color(0xFFD4AF37), RoundedCornerShape(28.dp)) 
+                if (freshness == FreshnessState.IN_ROTATION)
+                    Modifier.border(2.dp, Color(0xFFD4AF37), RoundedCornerShape(28.dp))
                 else if (freshness == FreshnessState.RESTING)
-                    Modifier.border(2.dp, Color(0xFF5A3854).copy(alpha = 0.5f), RoundedCornerShape(28.dp))
+                    Modifier.border(
+                        2.dp,
+                        Color(0xFF5A3854).copy(alpha = 0.5f),
+                        RoundedCornerShape(28.dp)
+                    )
                 else Modifier
             ),
         shape = RoundedCornerShape(28.dp)
@@ -444,6 +569,7 @@ fun RecentClothingCard(uiState: ClothingItem, modifier: Modifier = Modifier, onE
                                 shadowElevation = 4.dp
                             ) {}
                         }
+
                         FreshnessState.RESTING -> {
                             Icon(
                                 imageVector = Icons.Default.NightlightRound,
@@ -452,14 +578,15 @@ fun RecentClothingCard(uiState: ClothingItem, modifier: Modifier = Modifier, onE
                                 modifier = Modifier.size(16.dp)
                             )
                         }
+
                         FreshnessState.IN_ROTATION -> {}
                     }
                 }
 
-                val itemColor = item.dominantHex?.let { parseColor(it) } 
-                    ?: item.colorHex?.let { parseColor(it) } 
+                val itemColor = item.dominantHex?.let { parseColor(it) }
+                    ?: item.colorHex?.let { parseColor(it) }
                     ?: Color.White
-                
+
                 Surface(
                     modifier = Modifier
                         .padding(16.dp)
@@ -470,14 +597,18 @@ fun RecentClothingCard(uiState: ClothingItem, modifier: Modifier = Modifier, onE
                     border = BorderStroke(1.dp, Color.White.copy(alpha = 0.5f))
                 ) {}
             } else {
-                val itemColor = item.dominantHex?.let { parseColor(it) } 
-                    ?: item.colorHex?.let { parseColor(it) } 
+                val itemColor = item.dominantHex?.let { parseColor(it) }
+                    ?: item.colorHex?.let { parseColor(it) }
                     ?: MaterialTheme.colorScheme.surfaceVariant
-                Box(modifier = Modifier.fillMaxSize().background(itemColor))
+                Box(modifier = Modifier
+                    .fillMaxSize()
+                    .background(itemColor))
             }
-            
+
             Surface(
-                modifier = Modifier.padding(16.dp).align(Alignment.TopStart),
+                modifier = Modifier
+                    .padding(16.dp)
+                    .align(Alignment.TopStart),
                 color = Color.White.copy(alpha = 0.9f),
                 shape = RoundedCornerShape(12.dp)
             ) {
@@ -489,12 +620,76 @@ fun RecentClothingCard(uiState: ClothingItem, modifier: Modifier = Modifier, onE
                 )
             }
 
-            Box(modifier = Modifier.fillMaxSize().background(Brush.verticalGradient(listOf(Color.Transparent, Color.Black.copy(alpha = 0.6f)), startY = 300f)))
-            
-            Column(modifier = Modifier.align(Alignment.BottomStart).padding(16.dp)) {
-                Text(text = item.name, style = MaterialTheme.typography.titleMedium, color = Color.White, fontWeight = FontWeight.Bold, maxLines = 1)
-                Text(text = item.brand ?: "", style = MaterialTheme.typography.labelSmall, color = Color.White.copy(alpha = 0.7f))
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(
+                                Color.Transparent,
+                                Color.Black.copy(alpha = 0.6f)
+                            ), startY = 300f
+                        )
+                    )
+            )
+
+            Column(modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(16.dp)) {
+                Text(
+                    text = item.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1
+                )
+                Text(
+                    text = item.brand ?: "",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.White.copy(alpha = 0.7f)
+                )
             }
         }
     }
+
 }
+
+@Composable
+private fun StatIcon(
+    icon: ImageVector,
+    value: String,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .clickable { onClick() }
+            .background(Color(0xFFF5F5F5))
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = Color(0xFF2C2420).copy(alpha = 0.6f)
+        )
+        Spacer(Modifier.width(12.dp))
+        Column {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+                color = Color.Black
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
+                color = Color.Gray,
+                letterSpacing = 0.5.sp
+            )
+        }
+    }
+}
+

--- a/applications/kocolor/features/inventory/src/main/res/values/strings.xml
+++ b/applications/kocolor/features/inventory/src/main/res/values/strings.xml
@@ -22,6 +22,12 @@
     <string name="applications_kocolor_features_inventory_style_efficiency">STYLE EFFICIENCY</string>
     <string name="applications_kocolor_features_inventory_efficiency_prompt">Log more wear events to calculate wardrobe efficiency.</string>
     <string name="applications_kocolor_features_inventory_per_wear">PER WEAR</string>
+    <string name="applications_kocolor_features_inventory_usage_distribution">USAGE DISTRIBUTION</string>
+    <string name="applications_kocolor_features_inventory_never_worn">Never</string>
+    <string name="applications_kocolor_features_inventory_rarely_worn">1-5</string>
+    <string name="applications_kocolor_features_inventory_occasionally_worn">6-10</string>
+    <string name="applications_kocolor_features_inventory_regularly_worn">11-20</string>
+    <string name="applications_kocolor_features_inventory_wardrobe_heroes">20+</string>
     <string name="applications_kocolor_features_inventory_brand_wears_format">%1$s · %2$d wears</string>
     <string name="applications_kocolor_features_inventory_archive">Archive</string>
 

--- a/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/KoColorRoute.kt
+++ b/applications/kocolor/model/src/main/java/com/zoewave/probase/kocolor/model/KoColorRoute.kt
@@ -77,6 +77,9 @@ sealed class KoColorRoute {
 
     @Serializable
     data object WardrobeAnalytics : KoColorRoute()
+
+    @Serializable
+    data object UsageDistribution : KoColorRoute()
     
     @Serializable
     data class WardrobeCategoryCover(val categoryName: String) : KoColorRoute()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ android-minSdk = "34"
 android-targetSdk = "37"
 
 # -- Build Tools --
-agp = "9.5.0-alpha01"
+agp = "9.5.0-alpha02"
 kotlin = "2.4.10"
 # KSP version must match Kotlin version exactly
 ksp = "2.3.9"


### PR DESCRIPTION
Summary of Changes
1.
New Screen: Created  UsageDistributionScreen.kt which focuses entirely on the usage metrics and the frequency distribution of your wardrobe.
2.
Navigation Wiring:
◦
Added UsageDistribution to the  KoColorRoute navigation model.
◦
Updated  WardrobeLandingScreen.kt to navigate to this new screen when the GLOW SCORE (Utility) icon is clicked.
◦
Registered the new screen in  KoColorNavEntryProvider.kt to ensure the navigation works correctly in the app.
3.
Cleanup: Removed the chart from the general  WardrobeAnalyticsScreen.kt to avoid redundancy and keep the "Style Intelligence" screen focused on investment and color palettes.
How to Verify
•
Build and run the app.
•
Go to the Style Archive (Wardrobe Landing).
•
Tap on the GLOW SCORE icon in the header.
•
You will be navigated to the new Usage Distribution screen showing the frequency histogram of your items.